### PR TITLE
Added CMake configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,8 @@ functions/lib/
 *.log
 
 
+# CMake
+build/
+
 # Developer Files
 config.yaml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,11 +119,11 @@ endif()
 # Top-level aggregate targets
 # ---------------------------------------------------------------------------
 
-# build — build all available components (proto-all runs first)
+# build — build all available components
 if(HAS_API)
-    add_custom_target(build DEPENDS proto-all api-build ui-build)
+    add_custom_target(build DEPENDS api-build ui-build)
 else()
-    add_custom_target(build DEPENDS proto-all ui-build)
+    add_custom_target(build DEPENDS ui-build)
 endif()
 
 # install-deps — install all dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,179 @@
+cmake_minimum_required(VERSION 3.20)
+project(opentrace NONE)
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+# Node / npm — required for UI
+find_program(NODE_EXECUTABLE node REQUIRED
+    DOC "Node.js runtime (https://nodejs.org)")
+find_program(NPM_EXECUTABLE npm REQUIRED
+    DOC "npm package manager (https://npmjs.com)")
+
+execute_process(
+    COMMAND ${NODE_EXECUTABLE} --version
+    OUTPUT_VARIABLE NODE_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "Found node: ${NODE_EXECUTABLE} (${NODE_VERSION})")
+
+execute_process(
+    COMMAND ${NPM_EXECUTABLE} --version
+    OUTPUT_VARIABLE NPM_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "Found npm: ${NPM_EXECUTABLE} (${NPM_VERSION})")
+
+# Go — required when api/ is present
+if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/api")
+    find_program(GO_EXECUTABLE go REQUIRED
+        DOC "Go toolchain (https://go.dev)")
+    execute_process(
+        COMMAND ${GO_EXECUTABLE} version
+        OUTPUT_VARIABLE GO_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Found go: ${GO_EXECUTABLE} (${GO_VERSION})")
+endif()
+
+# Python / uv — required when agent/ is present
+if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/agent")
+    find_program(UV_EXECUTABLE uv REQUIRED
+        DOC "uv Python package manager (https://github.com/astral-sh/uv)")
+    execute_process(
+        COMMAND ${UV_EXECUTABLE} --version
+        OUTPUT_VARIABLE UV_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Found uv: ${UV_EXECUTABLE} (${UV_VERSION})")
+endif()
+
+# grpc_tools — required for Python proto stub generation
+find_program(PYTHON3_EXECUTABLE python3 REQUIRED)
+execute_process(
+    COMMAND ${PYTHON3_EXECUTABLE} -c "import grpc_tools"
+    RESULT_VARIABLE GRPC_TOOLS_RESULT
+    ERROR_QUIET)
+if(GRPC_TOOLS_RESULT EQUAL 0)
+    set(GRPC_TOOLS_AVAILABLE TRUE)
+    message(STATUS "Found grpc_tools Python module")
+else()
+    set(GRPC_TOOLS_AVAILABLE FALSE)
+    message(WARNING
+        "grpc_tools Python module not found — proto-py target will fail if invoked.\n"
+        "Install with:  pip install grpcio-tools\n"
+        "or with uv:    uv pip install grpcio-tools")
+endif()
+
+# protoc — required for proto code generation
+find_program(PROTOC_EXECUTABLE protoc
+    DOC "Protocol Buffers compiler (https://protobuf.dev)")
+if(PROTOC_EXECUTABLE)
+    execute_process(
+        COMMAND ${PROTOC_EXECUTABLE} --version
+        OUTPUT_VARIABLE PROTOC_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Found protoc: ${PROTOC_EXECUTABLE} (${PROTOC_VERSION})")
+else()
+    message(WARNING
+        "protoc not found — proto code generation targets will be unavailable.\n"
+        "Install via your package manager, e.g.:\n"
+        "  openSUSE:  sudo zypper install protobuf-devel\n"
+        "  Debian:    sudo apt install protobuf-compiler\n"
+        "  macOS:     brew install protobuf")
+endif()
+
+# ---------------------------------------------------------------------------
+# Subdirectories
+# ---------------------------------------------------------------------------
+
+add_subdirectory(proto)
+add_subdirectory(ui)
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/api/CMakeLists.txt")
+    set(HAS_API TRUE)
+    add_subdirectory(api)
+endif()
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/agent/CMakeLists.txt")
+    set(HAS_AGENT TRUE)
+    add_subdirectory(agent)
+endif()
+
+# ---------------------------------------------------------------------------
+# Cross-component proto dependencies
+#
+# proto-ts needs ui-install first (protoc-gen-ts_proto lives in node_modules).
+# All build targets that compile generated sources depend on the relevant
+# proto target so that code generation runs automatically before compilation.
+# ---------------------------------------------------------------------------
+
+add_dependencies(proto-ts ui-install)
+add_dependencies(ui-build        proto-ts)
+add_dependencies(ui-build-static proto-ts)
+add_dependencies(ui-test         proto-ts)
+add_dependencies(ui-lint         proto-ts)
+
+if(HAS_API)
+    add_dependencies(api-build proto-go)
+endif()
+
+if(HAS_AGENT)
+    add_dependencies(agent-install proto-py)
+    add_dependencies(agent-test    proto-py)
+endif()
+
+# ---------------------------------------------------------------------------
+# Top-level aggregate targets
+# ---------------------------------------------------------------------------
+
+# build — build all available components (proto-all runs first)
+if(HAS_API)
+    add_custom_target(build DEPENDS proto-all api-build ui-build)
+else()
+    add_custom_target(build DEPENDS proto-all ui-build)
+endif()
+
+# install-deps — install all dependencies
+set(_install_deps ui-install)
+if(HAS_API)
+    list(APPEND _install_deps api-build)   # go build fetches modules
+endif()
+if(HAS_AGENT)
+    list(APPEND _install_deps agent-install)
+endif()
+add_custom_target(install-deps DEPENDS ${_install_deps})
+
+# test
+set(_test_targets ui-test)
+if(HAS_API)
+    list(APPEND _test_targets api-test)
+endif()
+if(HAS_AGENT)
+    list(APPEND _test_targets agent-test)
+endif()
+add_custom_target(test DEPENDS ${_test_targets})
+
+# fmt
+set(_fmt_targets ui-fmt)
+if(HAS_API)
+    list(APPEND _fmt_targets api-fmt)
+endif()
+if(HAS_AGENT)
+    list(APPEND _fmt_targets agent-fmt)
+endif()
+add_custom_target(fmt DEPENDS ${_fmt_targets})
+
+# lint
+set(_lint_targets ui-lint)
+if(HAS_API)
+    list(APPEND _lint_targets api-lint)
+endif()
+if(HAS_AGENT)
+    list(APPEND _lint_targets agent-lint)
+endif()
+add_custom_target(lint DEPENDS ${_lint_targets})
+
+# clean — remove all build artifacts (CMake clean + component artifacts)
+add_custom_target(clean-all
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target clean
+    COMMAND ${CMAKE_COMMAND} -E rm -rf
+        "${CMAKE_SOURCE_DIR}/ui/dist"
+        "${CMAKE_SOURCE_DIR}/ui/node_modules"
+    COMMENT "Removing all build artifacts"
+)
+
+# proto — generate protobuf code for all languages
+add_custom_target(proto DEPENDS proto-all)

--- a/README-cmake.md
+++ b/README-cmake.md
@@ -1,0 +1,156 @@
+# Building with CMake
+
+CMake handles prerequisite checking and Makefile generation for the OpenTrace platform.
+
+## Prerequisites
+
+| Tool | Required for | Install |
+|------|-------------|---------|
+| CMake ≥ 3.20 | All | [cmake.org](https://cmake.org/download/) |
+| Node.js + npm | UI | [nodejs.org](https://nodejs.org) |
+| Go | `api/` (when present) | [go.dev](https://go.dev) |
+| uv | `agent/` (when present) | [github.com/astral-sh/uv](https://github.com/astral-sh/uv) |
+| protoc | Proto code generation | see below |
+
+### Installing protoc
+
+```bash
+# openSUSE
+sudo zypper install protobuf-devel protoc-gen-go protoc-gen-go-grpc
+
+# Debian / Ubuntu
+sudo apt install protobuf-compiler
+
+# macOS
+brew install protobuf
+```
+
+For Go proto generation, also install the plugins:
+```bash
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+```
+
+## Configure
+
+Run CMake once from the repository root to check prerequisites and generate the Makefile:
+
+```bash
+cmake -B build .
+```
+
+CMake will report found tools and warn about anything missing. The generated Makefile is written to `build/`.
+
+To reconfigure (e.g. after installing a missing tool):
+```bash
+cmake -B build . --fresh
+```
+
+## Building
+
+```bash
+# Build all components
+cmake --build build
+
+# Build only the UI
+cmake --build build --target ui-build
+
+# Build a static UI for Firebase hosting (no API base URL)
+cmake --build build --target ui-build-static
+```
+
+## Installing dependencies
+
+```bash
+# Install all dependencies
+cmake --build build --target install-deps
+
+# UI only (re-runs only when package.json changes)
+cmake --build build --target ui-install
+```
+
+## Testing
+
+```bash
+# Run all tests
+cmake --build build --target test
+
+# UI tests only
+cmake --build build --target ui-test
+```
+
+## Formatting and linting
+
+```bash
+# Format all source files
+cmake --build build --target fmt
+
+# Lint all source files
+cmake --build build --target lint
+
+# Individual components
+cmake --build build --target ui-fmt
+cmake --build build --target ui-lint
+```
+
+## Proto code generation
+
+Requires `protoc` (see Prerequisites above).
+
+```bash
+# Generate for all languages (TypeScript, Python, Go)
+cmake --build build --target proto-all
+
+# Individual languages
+cmake --build build --target proto-ts
+cmake --build build --target proto-py
+cmake --build build --target proto-go
+```
+
+## Running development servers
+
+These targets are not part of the default build — invoke them directly:
+
+```bash
+cmake --build build --target ui-dev      # Vite dev server (port 5173)
+cmake --build build --target ui-preview  # Preview production build
+```
+
+## Cleaning
+
+```bash
+# Remove generated proto output
+cmake --build build --target proto-clean
+
+# Remove UI dist/ and node_modules/
+cmake --build build --target ui-clean
+
+# Remove everything including the build/ directory itself
+cmake --build build --target clean-all
+rm -rf build/
+```
+
+## Available targets
+
+| Target | Description |
+|--------|-------------|
+| `build` (default) | Build all components |
+| `install-deps` | Install all dependencies |
+| `test` | Run all tests |
+| `fmt` | Format all source files |
+| `lint` | Lint all source files |
+| `proto-all` | Generate proto code for TS, Python, and Go |
+| `proto-ts` | Generate TypeScript proto types |
+| `proto-py` | Generate Python proto stubs |
+| `proto-go` | Generate Go proto code |
+| `proto-clean` | Remove generated proto output |
+| `ui-install` | Install npm dependencies |
+| `ui-build` | Build the UI |
+| `ui-build-static` | Build static UI (browser-only, for Firebase) |
+| `ui-dev` | Start Vite development server |
+| `ui-preview` | Start Vite preview server |
+| `ui-test` | Run UI tests |
+| `ui-fmt` | Format UI source files |
+| `ui-lint` | Lint UI source files |
+| `ui-clean` | Remove UI dist/ and node_modules/ |
+| `clean-all` | Remove all build artifacts |

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -1,0 +1,133 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Use protoc found by the parent; support standalone invocation too.
+if(NOT PROTOC_EXECUTABLE)
+    find_program(PROTOC_EXECUTABLE protoc)
+endif()
+
+set(PROTO_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(PROTO_FILES
+    "${PROTO_DIR}/opentrace/v1/job_config.proto"
+    "${PROTO_DIR}/opentrace/v1/agent_service.proto"
+)
+
+set(TS_OUT  "${CMAKE_CURRENT_SOURCE_DIR}/../ui/src/gen")
+set(PY_OUT  "${CMAKE_CURRENT_SOURCE_DIR}/../agent/src/opentrace_agent/gen")
+set(GO_OUT  "${CMAKE_CURRENT_SOURCE_DIR}/../api")
+set(GO_MODULE "github.com/opentrace/opentrace/api")
+
+set(TS_PROTO_PLUGIN "${CMAKE_CURRENT_SOURCE_DIR}/../ui/node_modules/.bin/protoc-gen-ts_proto")
+
+# ---------------------------------------------------------------------------
+# proto-ts — generate TypeScript types
+# ---------------------------------------------------------------------------
+if(PROTOC_EXECUTABLE)
+    add_custom_target(proto-ts
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${TS_OUT}"
+        COMMAND ${PROTOC_EXECUTABLE}
+            --proto_path=${PROTO_DIR}
+            --plugin=protoc-gen-ts_proto=${TS_PROTO_PLUGIN}
+            --ts_proto_out=${TS_OUT}
+            --ts_proto_opt=onlyTypes=true
+            --ts_proto_opt=enumsAsLiterals=true
+            --ts_proto_opt=outputServices=false
+            --ts_proto_opt=esModuleInterop=true
+            ${PROTO_FILES}
+        WORKING_DIRECTORY "${PROTO_DIR}"
+        COMMENT "Generating TypeScript protobuf types"
+    )
+else()
+    add_custom_target(proto-ts
+        COMMAND ${CMAKE_COMMAND} -E echo "ERROR: protoc is required to generate TypeScript proto types."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "proto-ts unavailable: protoc not found"
+    )
+endif()
+
+# ---------------------------------------------------------------------------
+# proto-py — generate Python stubs
+# ---------------------------------------------------------------------------
+if(PROTOC_EXECUTABLE AND GRPC_TOOLS_AVAILABLE)
+    add_custom_target(proto-py
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${PY_OUT}"
+        COMMAND python3 -m grpc_tools.protoc
+            --proto_path=${PROTO_DIR}
+            --python_out=${PY_OUT}
+            --pyi_out=${PY_OUT}
+            --grpc_python_out=${PY_OUT}
+            ${PROTO_FILES}
+        # Fix cross-file imports: rewrite proto package path to package path used at runtime
+        COMMAND find ${PY_OUT} -name "*.py"  -exec
+            sed -i "s/from opentrace\\.v1 import/from opentrace_agent.gen.opentrace.v1 import/g" {} +
+        COMMAND find ${PY_OUT} -name "*.pyi" -exec
+            sed -i "s/from opentrace\\.v1 import/from opentrace_agent.gen.opentrace.v1 import/g" {} +
+        COMMAND ${CMAKE_COMMAND} -E touch "${PY_OUT}/opentrace/__init__.py"
+        COMMAND ${CMAKE_COMMAND} -E touch "${PY_OUT}/opentrace/v1/__init__.py"
+        WORKING_DIRECTORY "${PROTO_DIR}"
+        COMMENT "Generating Python protobuf stubs"
+    )
+else()
+    if(NOT PROTOC_EXECUTABLE)
+        set(_proto_py_reason "protoc not found")
+    elseif(NOT GRPC_TOOLS_AVAILABLE)
+        set(_proto_py_reason "grpc_tools Python module not found (pip install grpcio-tools)")
+    endif()
+    add_custom_target(proto-py
+        COMMAND ${CMAKE_COMMAND} -E echo "ERROR: proto-py unavailable: ${_proto_py_reason}"
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "proto-py unavailable: ${_proto_py_reason}"
+    )
+endif()
+
+# ---------------------------------------------------------------------------
+# proto-go — generate Go code
+# ---------------------------------------------------------------------------
+find_program(GO_EXECUTABLE go)
+find_program(PROTOC_GEN_GO      protoc-gen-go)
+find_program(PROTOC_GEN_GO_GRPC protoc-gen-go-grpc)
+
+if(PROTOC_EXECUTABLE AND GO_EXECUTABLE AND PROTOC_GEN_GO AND PROTOC_GEN_GO_GRPC)
+    add_custom_target(proto-go
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${GO_OUT}/pkg/gen/otv1"
+        COMMAND ${PROTOC_EXECUTABLE}
+            --proto_path=${PROTO_DIR}
+            --go_out=${GO_OUT}
+            --go_opt=module=${GO_MODULE}
+            --go-grpc_out=${GO_OUT}
+            --go-grpc_opt=module=${GO_MODULE}
+            ${PROTO_FILES}
+        WORKING_DIRECTORY "${PROTO_DIR}"
+        COMMENT "Generating Go protobuf code"
+    )
+else()
+    if(NOT PROTOC_EXECUTABLE)
+        message(STATUS "protoc not found — proto-go target will fail if invoked")
+    endif()
+    if(NOT PROTOC_GEN_GO)
+        message(STATUS "protoc-gen-go not found — proto-go target will fail if invoked")
+        message(STATUS "  Install: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest")
+    endif()
+    if(NOT PROTOC_GEN_GO_GRPC)
+        message(STATUS "protoc-gen-go-grpc not found — proto-go target will fail if invoked")
+        message(STATUS "  Install: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest")
+    endif()
+    add_custom_target(proto-go
+        COMMAND ${CMAKE_COMMAND} -E echo
+            "ERROR: proto-go requires protoc, protoc-gen-go, and protoc-gen-go-grpc."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "proto-go unavailable: missing protoc or Go plugins"
+    )
+endif()
+
+# ---------------------------------------------------------------------------
+# proto-all — generate for all languages
+# ---------------------------------------------------------------------------
+add_custom_target(proto-all DEPENDS proto-ts proto-py proto-go)
+
+# ---------------------------------------------------------------------------
+# proto-clean
+# ---------------------------------------------------------------------------
+add_custom_target(proto-clean
+    COMMAND ${CMAKE_COMMAND} -E rm -rf "${TS_OUT}" "${PY_OUT}"
+    COMMENT "Removing generated proto output"
+)

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,0 +1,95 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Use variables set by the parent; support standalone invocation too.
+if(NOT NPM_EXECUTABLE)
+    find_program(NPM_EXECUTABLE npm REQUIRED)
+endif()
+
+set(UI_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(UI_STAMP "${CMAKE_CURRENT_BINARY_DIR}/npm_install.stamp")
+
+# ---------------------------------------------------------------------------
+# ui-install — npm install (re-runs only when package.json changes)
+# ---------------------------------------------------------------------------
+add_custom_command(
+    OUTPUT  "${UI_STAMP}"
+    COMMAND ${NPM_EXECUTABLE} install
+    COMMAND ${CMAKE_COMMAND} -E touch "${UI_STAMP}"
+    WORKING_DIRECTORY "${UI_DIR}"
+    DEPENDS "${UI_DIR}/package.json"
+    COMMENT "Installing UI npm dependencies"
+)
+add_custom_target(ui-install DEPENDS "${UI_STAMP}")
+
+# ---------------------------------------------------------------------------
+# ui-build — tsc + vite build (depends on install)
+# ---------------------------------------------------------------------------
+add_custom_target(ui-build
+    COMMAND ${NPM_EXECUTABLE} run build
+    WORKING_DIRECTORY "${UI_DIR}"
+    DEPENDS "${UI_STAMP}"
+    COMMENT "Building UI (tsc + vite)"
+)
+
+# ---------------------------------------------------------------------------
+# ui-build-static — browser-only static build (used for Firebase hosting)
+# ---------------------------------------------------------------------------
+add_custom_target(ui-build-static
+    COMMAND ${CMAKE_COMMAND} -E env
+        VITE_API_BASE=""
+        VITE_BROWSER_ONLY=true
+        ${NPM_EXECUTABLE} run build
+    WORKING_DIRECTORY "${UI_DIR}"
+    DEPENDS "${UI_STAMP}"
+    COMMENT "Building static UI (browser-only, no API base URL)"
+)
+
+# ---------------------------------------------------------------------------
+# Development / preview
+# ---------------------------------------------------------------------------
+add_custom_target(ui-dev
+    COMMAND ${NPM_EXECUTABLE} run dev
+    WORKING_DIRECTORY "${UI_DIR}"
+    COMMENT "Starting UI development server"
+)
+
+add_custom_target(ui-preview
+    COMMAND ${NPM_EXECUTABLE} run preview
+    WORKING_DIRECTORY "${UI_DIR}"
+    COMMENT "Starting UI preview server"
+)
+
+# ---------------------------------------------------------------------------
+# Test / lint / fmt
+# ---------------------------------------------------------------------------
+add_custom_target(ui-test
+    COMMAND ${NPM_EXECUTABLE} test
+    WORKING_DIRECTORY "${UI_DIR}"
+    DEPENDS "${UI_STAMP}"
+    COMMENT "Running UI tests"
+)
+
+add_custom_target(ui-fmt
+    COMMAND ${NPM_EXECUTABLE} run fmt
+    WORKING_DIRECTORY "${UI_DIR}"
+    DEPENDS "${UI_STAMP}"
+    COMMENT "Formatting UI source files"
+)
+
+add_custom_target(ui-lint
+    COMMAND ${NPM_EXECUTABLE} run lint
+    WORKING_DIRECTORY "${UI_DIR}"
+    DEPENDS "${UI_STAMP}"
+    COMMENT "Linting UI source files"
+)
+
+# ---------------------------------------------------------------------------
+# Clean
+# ---------------------------------------------------------------------------
+add_custom_target(ui-clean
+    COMMAND ${CMAKE_COMMAND} -E rm -rf
+        "${UI_DIR}/dist"
+        "${UI_DIR}/node_modules"
+        "${UI_STAMP}"
+    COMMENT "Cleaning UI build artifacts and node_modules"
+)


### PR DESCRIPTION
Building and running now explicitly checks prerequisites, and fails when required components/programs are missing, thanks to CMake.
See `README-cmake.md` for details.