### PR TITLE
ui: add Discover tab with directory tree browser

### DIFF
--- a/ui/src/components/DiscoverPanel.css
+++ b/ui/src/components/DiscoverPanel.css
@@ -1,0 +1,209 @@
+/* Discover Panel — directory tree view */
+
+.discover-panel {
+  padding: 8px 0 120px;
+}
+
+/* Filter bar */
+.discover-filter-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 10px 8px;
+  gap: 4px;
+  position: relative;
+}
+
+.discover-filter-input {
+  flex: 1;
+  background: color-mix(in oklch, var(--accent) 40%, transparent);
+  border: 1px solid color-mix(in oklch, var(--border) 30%, transparent);
+  border-radius: var(--radius);
+  padding: 5px 28px 5px 10px;
+  font-size: 0.78rem;
+  color: var(--foreground);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.discover-filter-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.discover-filter-input:focus {
+  border-color: var(--primary);
+}
+
+.discover-filter-clear {
+  position: absolute;
+  right: 14px;
+  background: none;
+  border: none;
+  color: var(--muted-foreground);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  border-radius: var(--radius);
+}
+
+.discover-filter-clear:hover {
+  color: var(--foreground);
+}
+
+.discover-panel-empty {
+  padding: 24px 16px;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  text-align: center;
+}
+
+.discover-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  padding-right: 8px;
+  min-height: 28px;
+}
+
+.discover-tree-row:hover {
+  background: color-mix(in oklch, var(--accent) 30%, transparent);
+}
+
+.discover-tree-row--selected {
+  background: color-mix(in oklch, var(--primary) 15%, transparent);
+}
+
+.discover-tree-row--selected .discover-tree-name {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+/* Hop-distance highlight — intensity set via --hop-intensity CSS variable */
+.discover-tree-row--hop {
+  background: color-mix(
+    in oklch,
+    var(--primary) calc(var(--hop-intensity) * 18%),
+    transparent
+  );
+}
+
+.discover-tree-row--hop .discover-tree-name {
+  color: color-mix(
+    in oklch,
+    var(--primary) calc(var(--hop-intensity) * 100%),
+    var(--foreground)
+  );
+}
+
+.discover-tree-row--faded {
+  opacity: 0.35;
+}
+
+.discover-tree-row--faded:hover {
+  opacity: 0.7;
+}
+
+/* Graph-only toggle */
+.discover-graph-toggle {
+  padding: 0 10px 8px;
+}
+
+.discover-graph-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.72rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s;
+}
+
+.discover-graph-toggle-label:hover {
+  color: var(--foreground);
+}
+
+/* Hide native checkbox */
+.discover-graph-toggle-label input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Pill track */
+.discover-toggle-track {
+  position: relative;
+  width: 28px;
+  height: 16px;
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  border: 1px solid color-mix(in oklch, var(--border) 30%, transparent);
+  flex-shrink: 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+/* Pill thumb */
+.discover-toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+  transition: transform 0.2s, background 0.2s;
+}
+
+/* Checked state */
+.discover-graph-toggle-label input:checked + .discover-toggle-track {
+  background: color-mix(in oklch, var(--primary) 25%, transparent);
+  border-color: color-mix(in oklch, var(--primary) 40%, transparent);
+}
+
+.discover-graph-toggle-label input:checked + .discover-toggle-track::after {
+  transform: translateX(12px);
+  background: var(--primary);
+}
+
+/* Active label text when checked */
+.discover-graph-toggle-label:has(input:checked) {
+  color: var(--foreground);
+}
+
+.discover-tree-name {
+  background: none;
+  border: none;
+  color: var(--foreground);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.discover-tree-name:hover {
+  color: var(--primary);
+}
+
+.discover-tree-type {
+  font-size: 0.65rem;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.discover-tree-placeholder {
+  font-size: 0.78rem;
+  color: var(--muted-foreground);
+  padding-top: 3px;
+  padding-bottom: 3px;
+  font-style: italic;
+}

--- a/ui/src/components/DiscoverPanel.tsx
+++ b/ui/src/components/DiscoverPanel.tsx
@@ -1,0 +1,615 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useStore } from '../store/context';
+import { getNodeColor } from '../chat/results/nodeColors';
+import type { NodeResult } from '../store/types';
+import './DiscoverPanel.css';
+
+const EXPANDABLE_TYPES = new Set([
+  'Repo',
+  'Repository',
+  'Directory',
+  'File',
+  'Class',
+  'Module',
+  'PullRequest',
+]);
+
+const REPO_TYPES = new Set(['Repo', 'Repository']);
+
+/** Sort priority: directories → files → PRs → symbols, then alphabetical */
+function sortRank(type: string): number {
+  if (type === 'Repo' || type === 'Repository' || type === 'Directory')
+    return 0;
+  if (type === 'File') return 1;
+  if (type === 'PullRequest') return 2;
+  return 3;
+}
+
+function displayName(name: string): string {
+  const segments = name.split('/');
+  return segments[segments.length - 1] || name;
+}
+
+function sortChildren(nodes: NodeResult[]): NodeResult[] {
+  return [...nodes].sort((a, b) => {
+    const ra = sortRank(a.type);
+    const rb = sortRank(b.type);
+    if (ra !== rb) return ra - rb;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/** Check if a node or any of its cached descendants are in the graph */
+function isInGraph(
+  node: NodeResult,
+  graphIds: Set<string>,
+  childrenMap: Map<string, NodeResult[]>,
+): boolean {
+  if (graphIds.has(node.id)) return true;
+  const children = childrenMap.get(node.id);
+  if (children) {
+    return children.some((c) => isInGraph(c, graphIds, childrenMap));
+  }
+  return false;
+}
+
+/** Check if a node or any of its cached descendants match the filter */
+function matchesFilter(
+  node: NodeResult,
+  filter: string,
+  childrenMap: Map<string, NodeResult[]>,
+): boolean {
+  if (displayName(node.name).toLowerCase().includes(filter)) return true;
+  const children = childrenMap.get(node.id);
+  if (children) {
+    return children.some((c) => matchesFilter(c, filter, childrenMap));
+  }
+  return false;
+}
+
+interface TreeItemProps {
+  node: NodeResult;
+  depth: number;
+  expanded: Set<string>;
+  childrenMap: Map<string, NodeResult[]>;
+  loadingSet: Set<string>;
+  filter: string;
+  selectedNodeId?: string;
+  graphNodeIdSet?: Set<string>;
+  hideOffGraph: boolean;
+  hopMap?: Map<string, number>;
+  maxHops: number;
+  scrollTrigger: number;
+  onToggle: (nodeId: string) => void;
+  onSelect: (nodeId: string) => void;
+}
+
+function TreeItem({
+  node,
+  depth,
+  expanded,
+  childrenMap,
+  loadingSet,
+  filter,
+  selectedNodeId,
+  graphNodeIdSet,
+  hideOffGraph,
+  hopMap,
+  maxHops,
+  scrollTrigger,
+  onToggle,
+  onSelect,
+}: TreeItemProps) {
+  const isExpanded = expanded.has(node.id);
+  const isLoading = loadingSet.has(node.id);
+  const children = childrenMap.get(node.id);
+
+  // A node is expandable if it could have children and we either
+  // haven't loaded yet, or it actually has children
+  const couldExpand = EXPANDABLE_TYPES.has(node.type);
+  const knownEmpty = children !== undefined && children.length === 0;
+  const expandable = couldExpand && !knownEmpty;
+
+  // Is this node (or a descendant) present in the current graph view?
+  const offGraph = graphNodeIdSet
+    ? !isInGraph(node, graphNodeIdSet, childrenMap)
+    : false;
+
+  // Hop distance from selected node (undefined = not in neighborhood)
+  const hopDist = hopMap?.get(node.id);
+  const isSelected = node.id === selectedNodeId;
+
+  // Compute highlight intensity: 1.0 at hop 0, fading to ~0.15 at maxHops
+  const hopHighlight = hopDist !== undefined && maxHops > 0
+    ? Math.max(0.15, 1 - (hopDist / maxHops) * 0.85)
+    : undefined;
+
+  // Filter children if a filter is active
+  const visibleChildren = useMemo(() => {
+    if (!children || !filter) return children;
+    return children.filter((c) => matchesFilter(c, filter, childrenMap));
+  }, [children, filter, childrenMap]);
+
+  // Scroll selected node to upper-third of the panel when selection changes or tab activates
+  const rowRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (isSelected && rowRef.current) {
+      const scrollParent = rowRef.current.closest('.side-panel-content') as HTMLElement | null;
+      // Skip if panel is hidden (display:none) — offsetParent is null in that case
+      if (scrollParent && scrollParent.offsetParent !== null) {
+        const rowRect = rowRef.current.getBoundingClientRect();
+        const parentRect = scrollParent.getBoundingClientRect();
+        const offset = rowRect.top - parentRect.top + scrollParent.scrollTop;
+        scrollParent.scrollTo({
+          top: offset - parentRect.height * 0.33,
+          behavior: 'smooth',
+        });
+      }
+    }
+  }, [isSelected, scrollTrigger]);
+
+  if (hideOffGraph && offGraph) return null;
+
+  const rowClasses = [
+    'discover-tree-row',
+    isSelected ? 'discover-tree-row--selected' : '',
+    !isSelected && hopHighlight !== undefined ? 'discover-tree-row--hop' : '',
+    offGraph && hopHighlight === undefined ? 'discover-tree-row--faded' : '',
+  ].filter(Boolean).join(' ');
+
+  const rowStyle: React.CSSProperties = {
+    paddingLeft: `${12 + depth * 16}px`,
+    ...(!isSelected && hopHighlight !== undefined
+      ? { '--hop-intensity': hopHighlight } as React.CSSProperties
+      : {}),
+  };
+
+  return (
+    <div className="discover-tree-group">
+      <div
+        className={rowClasses}
+        style={rowStyle}
+        ref={isSelected ? rowRef : undefined}
+      >
+        {expandable ? (
+          <button
+            className="filter-expand-btn"
+            onClick={() => onToggle(node.id)}
+            title={isExpanded ? 'Collapse' : 'Expand'}
+          >
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 10 10"
+              className={`filter-expand-icon ${isExpanded ? 'filter-expand-icon--open' : ''}`}
+            >
+              <path
+                d="M3 2 L7 5 L3 8"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+            </svg>
+          </button>
+        ) : (
+          <span className="filter-expand-spacer" />
+        )}
+        <span
+          className="filter-dot"
+          style={{ backgroundColor: getNodeColor(node.type) }}
+        />
+        <button
+          className="discover-tree-name"
+          onClick={() => onSelect(node.id)}
+          title={node.name}
+        >
+          {displayName(node.name)}
+        </button>
+        <span className="discover-tree-type">{node.type}</span>
+      </div>
+
+      {isExpanded && (
+        <div className="discover-tree-children">
+          {isLoading ? (
+            <div
+              className="discover-tree-placeholder"
+              style={{ paddingLeft: `${12 + (depth + 1) * 16}px` }}
+            >
+              Loading...
+            </div>
+          ) : (
+            visibleChildren?.map((child) => (
+              <TreeItem
+                key={child.id}
+                node={child}
+                depth={depth + 1}
+                expanded={expanded}
+                childrenMap={childrenMap}
+                loadingSet={loadingSet}
+                filter={filter}
+                selectedNodeId={selectedNodeId}
+                graphNodeIdSet={graphNodeIdSet}
+                hideOffGraph={hideOffGraph}
+                hopMap={hopMap}
+                maxHops={maxHops}
+                scrollTrigger={scrollTrigger}
+                onToggle={onToggle}
+                onSelect={onSelect}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface DiscoverPanelProps {
+  onSelectNode: (nodeId: string) => void;
+  graphVersion?: number;
+  selectedNodeId?: string;
+  /** Node IDs currently visible in the graph view */
+  graphNodeIds?: string[];
+  /** Map of node ID → hop distance from selected node */
+  hopMap?: Map<string, number>;
+  /** Whether this tab is currently visible */
+  isActive?: boolean;
+}
+
+export default function DiscoverPanel({ onSelectNode, graphVersion, selectedNodeId, graphNodeIds, hopMap, isActive }: DiscoverPanelProps) {
+  const { store } = useStore();
+  const [roots, setRoots] = useState<NodeResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [childrenMap, setChildrenMap] = useState<Map<string, NodeResult[]>>(
+    new Map(),
+  );
+  const [loadingSet, setLoadingSet] = useState<Set<string>>(new Set());
+  const [filter, setFilter] = useState('');
+  const [hideOffGraph, setHideOffGraph] = useState(false);
+  const [scrollTrigger, setScrollTrigger] = useState(0);
+
+  // Refs for latest values — used by async effects to avoid stale closures
+  const rootsRef = useRef(roots);
+  rootsRef.current = roots;
+  const childrenMapRef = useRef(childrenMap);
+  childrenMapRef.current = childrenMap;
+
+  // Trigger scroll-into-view when the tab becomes active
+  useEffect(() => {
+    if (isActive && selectedNodeId) {
+      setScrollTrigger((v) => v + 1);
+    }
+  }, [isActive, selectedNodeId]);
+
+  // Build a Set for O(1) lookups; undefined means "no filtering" (all nodes in graph)
+  const graphNodeIdSet = useMemo(
+    () => (graphNodeIds ? new Set(graphNodeIds) : undefined),
+    [graphNodeIds],
+  );
+
+  /** Fetch children for a node without writing to state — pure data fetch. */
+  const fetchChildren = useCallback(
+    async (nodeId: string, nodeType: string): Promise<NodeResult[]> => {
+      const queries: Promise<NodeResult[]>[] = [];
+
+      if (nodeType === 'PullRequest') {
+        queries.push(
+          store
+            .traverse(nodeId, 'outgoing', 1, 'CHANGES')
+            .then((r) => r.filter((x) => x.node.id !== nodeId).map((x) => x.node)),
+        );
+      } else {
+        queries.push(
+          store
+            .traverse(nodeId, 'incoming', 1, 'DEFINED_IN')
+            .then((r) => r.filter((x) => x.node.id !== nodeId).map((x) => x.node)),
+        );
+        if (REPO_TYPES.has(nodeType)) {
+          queries.push(
+            store
+              .traverse(nodeId, 'incoming', 1, 'TARGETS_REPO')
+              .then((r) => r.filter((x) => x.node.id !== nodeId).map((x) => x.node)),
+          );
+        }
+      }
+
+      const results = await Promise.all(queries);
+      const seen = new Set<string>();
+      const merged: NodeResult[] = [];
+      for (const nodes of results) {
+        for (const node of nodes) {
+          if (!seen.has(node.id)) {
+            seen.add(node.id);
+            merged.push(node);
+          }
+        }
+      }
+      return sortChildren(merged);
+    },
+    [store],
+  );
+
+  /** Fetch children and write them to state (used for interactive expand). */
+  const loadChildren = useCallback(
+    async (nodeId: string, nodeType: string): Promise<NodeResult[]> => {
+      const children = await fetchChildren(nodeId, nodeType);
+      setChildrenMap((prev) => {
+        const next = new Map(prev);
+        next.set(nodeId, children);
+        return next;
+      });
+      return children;
+    },
+    [fetchChildren],
+  );
+
+  // Load repo roots on mount (and re-load when graphVersion changes), then auto-expand 3 levels
+  useEffect(() => {
+    let cancelled = false;
+    async function init() {
+      // Clear stale cache so re-expanding fetches fresh data
+      setChildrenMap(new Map());
+      try {
+        const [repos, repositories] = await Promise.all([
+          store.listNodes('Repo', 100),
+          store.listNodes('Repository', 100),
+        ]);
+        if (cancelled) return;
+        const seen = new Set<string>();
+        const merged: NodeResult[] = [];
+        for (const node of [...repos, ...repositories]) {
+          if (!seen.has(node.id)) {
+            seen.add(node.id);
+            merged.push(node);
+          }
+        }
+        const sorted = sortChildren(merged);
+        setRoots(sorted);
+
+        // Auto-expand 3 levels (root → children → grandchildren)
+        const newExpandedIds = new Set<string>();
+        const newChildrenMap = new Map<string, NodeResult[]>();
+
+        async function expandLevel(
+          nodes: NodeResult[],
+          depth: number,
+        ): Promise<void> {
+          if (depth >= 3 || cancelled) return;
+          const expandable = nodes.filter((n) => EXPANDABLE_TYPES.has(n.type));
+          const childResults = await Promise.all(
+            expandable.map(async (n) => {
+              const children = await fetchChildren(n.id, n.type);
+              return { parentId: n.id, children };
+            }),
+          );
+          if (cancelled) return;
+          for (const { parentId, children } of childResults) {
+            newChildrenMap.set(parentId, children);
+            if (children.length > 0) newExpandedIds.add(parentId);
+          }
+          const allChildren = childResults.flatMap((r) => r.children);
+          await expandLevel(allChildren, depth + 1);
+        }
+
+        await expandLevel(sorted, 0);
+        if (!cancelled) {
+          setChildrenMap((prev) => {
+            const next = new Map(prev);
+            for (const [k, v] of newChildrenMap) next.set(k, v);
+            return next;
+          });
+          setExpanded((prev) => {
+            const next = new Set(prev);
+            for (const id of newExpandedIds) next.add(id);
+            return next;
+          });
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, [store, graphVersion, fetchChildren]);
+
+  /** Find a node's type from roots or childrenMap */
+  const findNodeType = useCallback(
+    (nodeId: string): string => {
+      for (const r of roots) {
+        if (r.id === nodeId) return r.type;
+      }
+      for (const children of childrenMap.values()) {
+        for (const c of children) {
+          if (c.id === nodeId) return c.type;
+        }
+      }
+      return '';
+    },
+    [roots, childrenMap],
+  );
+
+  const handleToggle = useCallback(
+    async (nodeId: string) => {
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(nodeId)) {
+          next.delete(nodeId);
+          return next;
+        }
+        next.add(nodeId);
+        return next;
+      });
+
+      // Lazy-load children if not cached or already loading
+      if (childrenMap.has(nodeId) || loadingSet.has(nodeId)) return;
+
+      setLoadingSet((prev) => new Set(prev).add(nodeId));
+      try {
+        await loadChildren(nodeId, findNodeType(nodeId));
+      } finally {
+        setLoadingSet((prev) => {
+          const next = new Set(prev);
+          next.delete(nodeId);
+          return next;
+        });
+      }
+    },
+    [loadChildren, childrenMap, findNodeType],
+  );
+
+  // Compute max hops for gradient scaling
+  const maxHops = useMemo(() => {
+    if (!hopMap || hopMap.size === 0) return 1;
+    let max = 0;
+    for (const d of hopMap.values()) {
+      if (d > max) max = d;
+    }
+    return max || 1;
+  }, [hopMap]);
+
+  // Auto-expand tree path to the selected node
+  useEffect(() => {
+    if (!selectedNodeId) return;
+
+    // Use refs for latest values to avoid stale closures
+    const currentRoots = rootsRef.current;
+    const currentChildrenMap = childrenMapRef.current;
+
+    // Check if the node is already visible in the tree
+    const isVisible = (nodeId: string): boolean => {
+      for (const r of currentRoots) {
+        if (r.id === nodeId) return true;
+      }
+      for (const [parentId, children] of currentChildrenMap.entries()) {
+        if (children.some((c) => c.id === nodeId) && expanded.has(parentId)) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (isVisible(selectedNodeId)) return;
+
+    // Walk up DEFINED_IN to find ancestor path, then expand it
+    let cancelled = false;
+    (async () => {
+      const ancestors: string[] = [];
+      let currentId = selectedNodeId;
+      // Walk up the tree (max 20 levels to avoid infinite loops)
+      for (let i = 0; i < 20; i++) {
+        const results = await store.traverse(currentId, 'outgoing', 1, 'DEFINED_IN');
+        if (cancelled) return;
+        const parent = results.find((r) => r.node.id !== currentId);
+        if (!parent) break;
+        ancestors.push(parent.node.id);
+        // If we've reached a root, stop
+        if (rootsRef.current.some((r) => r.id === parent.node.id)) break;
+        currentId = parent.node.id;
+      }
+      if (cancelled || ancestors.length === 0) return;
+
+      // Load children for each ancestor (top-down) and expand
+      ancestors.reverse(); // root → ... → parent
+      for (const ancestorId of ancestors) {
+        if (cancelled) return;
+        if (!childrenMapRef.current.has(ancestorId)) {
+          await loadChildren(ancestorId, findNodeType(ancestorId) || 'Directory');
+        }
+      }
+      if (cancelled) return;
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        for (const id of ancestors) next.add(id);
+        return next;
+      });
+    })();
+    return () => { cancelled = true; };
+  }, [selectedNodeId, store, loadChildren, findNodeType, expanded]);
+
+  const normalizedFilter = filter.toLowerCase().trim();
+
+  const visibleRoots = useMemo(() => {
+    if (!normalizedFilter) return roots;
+    return roots.filter((r) => matchesFilter(r, normalizedFilter, childrenMap));
+  }, [roots, normalizedFilter, childrenMap]);
+
+  if (loading) {
+    return (
+      <div className="discover-panel">
+        <div className="discover-panel-empty">Loading repositories...</div>
+      </div>
+    );
+  }
+
+  if (roots.length === 0) {
+    return (
+      <div className="discover-panel">
+        <div className="discover-panel-empty">
+          No repositories indexed yet.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="discover-panel">
+      <div className="discover-filter-bar">
+        <input
+          className="discover-filter-input"
+          type="text"
+          placeholder="Filter..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        {filter && (
+          <button
+            className="discover-filter-clear"
+            onClick={() => setFilter('')}
+            title="Clear filter"
+          >
+            &times;
+          </button>
+        )}
+      </div>
+      {graphNodeIdSet && (
+        <div className="discover-graph-toggle">
+          <label className="discover-graph-toggle-label">
+            <input
+              type="checkbox"
+              checked={hideOffGraph}
+              onChange={(e) => setHideOffGraph(e.target.checked)}
+            />
+            <span className="discover-toggle-track" />
+            <span>In graph only</span>
+          </label>
+        </div>
+      )}
+      {visibleRoots.length === 0 ? (
+        <div className="discover-panel-empty">No matches</div>
+      ) : (
+        visibleRoots.map((root) => (
+          <TreeItem
+            key={root.id}
+            node={root}
+            depth={0}
+            expanded={expanded}
+            childrenMap={childrenMap}
+            loadingSet={loadingSet}
+            filter={normalizedFilter}
+            selectedNodeId={selectedNodeId}
+            graphNodeIdSet={graphNodeIdSet}
+            hideOffGraph={hideOffGraph}
+            hopMap={hopMap}
+            maxHops={maxHops}
+            scrollTrigger={scrollTrigger}
+            onToggle={handleToggle}
+            onSelect={onSelectNode}
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -148,6 +148,7 @@ const GraphViewer = memo(
         error,
         stats,
         lastSearchQuery,
+        graphVersion,
         loadGraph,
         setError,
       } = useGraphData(onGraphLoaded);
@@ -168,6 +169,7 @@ const GraphViewer = memo(
       const [highlightNodes, setHighlightNodes] = useState(new Set<string>());
       const [highlightLinks, setHighlightLinks] = useState(new Set<string>());
       const [labelNodes, setLabelNodes] = useState(new Set<string>());
+      const [hopMap, setHopMap] = useState(new Map<string, number>());
       const [hiddenNodeTypes, setHiddenNodeTypes] = useState(new Set<string>());
       const [hiddenLinkTypes, setHiddenLinkTypes] = useState(
         new Set<string>(['DEPENDS_ON']),
@@ -460,10 +462,12 @@ const GraphViewer = memo(
 
         // BFS from selected node up to `hops` depth for highlights,
         // but only up to 2 hops for labels
+        const hm = new Map<string, number>();
         if (selectedNode) {
           const labelDepth = Math.min(2, hops);
           nodes.add(selectedNode.id);
           labels.add(selectedNode.id);
+          hm.set(selectedNode.id, 0);
           let frontier = new Set<string>([selectedNode.id]);
           for (let depth = 0; depth < hops && frontier.size > 0; depth++) {
             const nextFrontier = new Set<string>();
@@ -474,6 +478,7 @@ const GraphViewer = memo(
                 links.add(linkKey);
                 if (!nodes.has(neighbor)) {
                   nextFrontier.add(neighbor);
+                  hm.set(neighbor, depth + 1);
                 }
                 nodes.add(neighbor);
                 if (depth < labelDepth) {
@@ -488,6 +493,7 @@ const GraphViewer = memo(
         setHighlightNodes(nodes);
         setHighlightLinks(links);
         setLabelNodes(labels);
+        setHopMap(hm);
       }, [
         searchQuery,
         selectedNode,
@@ -498,6 +504,11 @@ const GraphViewer = memo(
       ]);
 
       // Compute degree (connection count) per node for size scaling
+      const graphNodeIds = useMemo(
+        () => graphData.nodes.map((n) => n.id as string),
+        [graphData.nodes],
+      );
+
       const degreeMap = useMemo(() => {
         const map = new Map<string, number>();
         filteredGraphData.links.forEach((l) => {
@@ -541,6 +552,25 @@ const GraphViewer = memo(
             ctx.shadowBlur = 15;
           }
 
+          // Selection halo
+          if (selectedNode && node.id === selectedNode.id) {
+            const haloRadius = size + 4;
+            ctx.beginPath();
+            ctx.arc(node.x!, node.y!, haloRadius, 0, 2 * Math.PI);
+            ctx.strokeStyle = nodeColor(node);
+            ctx.lineWidth = 2;
+            ctx.globalAlpha = 0.6;
+            ctx.stroke();
+            // Outer glow ring
+            ctx.beginPath();
+            ctx.arc(node.x!, node.y!, haloRadius + 3, 0, 2 * Math.PI);
+            ctx.strokeStyle = nodeColor(node);
+            ctx.lineWidth = 1;
+            ctx.globalAlpha = 0.25;
+            ctx.stroke();
+            ctx.globalAlpha = isHighlighted ? 1 : 0.15;
+          }
+
           // Circle
           ctx.beginPath();
           ctx.arc(node.x!, node.y!, size, 0, 2 * Math.PI);
@@ -566,7 +596,7 @@ const GraphViewer = memo(
           }
           ctx.globalAlpha = 1;
         },
-        [nodeColor, nodeSize, highlightNodes, labelNodes],
+        [nodeColor, nodeSize, highlightNodes, labelNodes, selectedNode],
       );
 
       const nodePointerArea = useCallback(
@@ -855,6 +885,9 @@ const GraphViewer = memo(
               setSelectedNode(null);
               setSelectedLink(null);
             }}
+            graphVersion={graphVersion}
+            graphNodeIds={graphNodeIds}
+            hopMap={hopMap}
           />
           <header>
             <div className="header-logo">

--- a/ui/src/components/SidePanel.tsx
+++ b/ui/src/components/SidePanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { NodeObject, LinkObject } from 'react-force-graph-2d';
 import type { GraphNode, GraphLink } from '../types/graph';
 import type { NodeSourceResponse } from '../store/types';
 import FilterPanel from './FilterPanel';
+import DiscoverPanel from './DiscoverPanel';
 import NodeDetailsPanel from './NodeDetailsPanel';
 import EdgeDetailsPanel from './EdgeDetailsPanel';
 import './SidePanel.css';
@@ -46,6 +47,13 @@ interface SidePanelProps {
   /* Edge details props */
   selectedLink: Link | null;
   onSelectNode?: (nodeId: string) => void;
+
+  /** Bumps when the graph store changes (new indexing, PR import, etc.) */
+  graphVersion?: number;
+  /** IDs of nodes currently in the graph view */
+  graphNodeIds?: string[];
+  /** Map of node ID → hop distance from selected node (0 = selected) */
+  hopMap?: Map<string, number>;
 }
 
 export default function SidePanel({
@@ -69,70 +77,108 @@ export default function SidePanel({
   onCloseDetails,
   selectedLink,
   onSelectNode,
+  graphVersion,
+  graphNodeIds,
+  hopMap,
 }: SidePanelProps) {
-  const [activeTab, setActiveTab] = useState<'filters' | 'details'>('filters');
+  const [activeTab, setActiveTab] = useState<'filters' | 'discover' | 'details'>('filters');
+  const previousTab = useRef<'filters' | 'discover'>('filters');
+  const activeTabRef = useRef(activeTab);
+  activeTabRef.current = activeTab;
 
-  // Auto-switch tabs when node or edge selection changes
+  // Auto-switch to details when node or edge is selected
   useEffect(() => {
     if (selectedNode || selectedLink) {
+      // Remember where we were before switching to details
+      if (activeTabRef.current !== 'details') {
+        previousTab.current = activeTabRef.current as 'filters' | 'discover';
+      }
       setActiveTab('details');
-    } else {
-      setActiveTab('filters');
+    } else if (activeTabRef.current === 'details') {
+      // Restore previous tab when details close
+      setActiveTab(previousTab.current);
     }
   }, [selectedNode, selectedLink]);
 
-  const expanded = selectedNode !== null || selectedLink !== null;
+  const hasSelection = selectedNode !== null || selectedLink !== null;
+  const expanded = hasSelection || activeTab === 'discover';
+
+  const handleCloseDetails = () => {
+    onCloseDetails();
+    setActiveTab(previousTab.current);
+  };
 
   return (
     <div className={`side-panel ${expanded ? 'side-panel--expanded' : ''}`}>
-      {expanded && (
-        <div className="side-panel-tabs">
-          <button
-            className={`side-panel-tab ${activeTab === 'filters' ? 'side-panel-tab--active' : ''}`}
-            onClick={() => setActiveTab('filters')}
-          >
-            Filters
-          </button>
-          <button
-            className={`side-panel-tab ${activeTab === 'details' ? 'side-panel-tab--active' : ''}`}
-            onClick={() => setActiveTab('details')}
-          >
-            Details
-          </button>
-          <button className="side-panel-close" onClick={onCloseDetails}>
-            &times;
-          </button>
+      <div className="side-panel-tabs">
+        <button
+          className={`side-panel-tab ${activeTab === 'filters' ? 'side-panel-tab--active' : ''}`}
+          onClick={() => setActiveTab('filters')}
+        >
+          Filters
+        </button>
+        <button
+          className={`side-panel-tab ${activeTab === 'discover' ? 'side-panel-tab--active' : ''}`}
+          onClick={() => setActiveTab('discover')}
+        >
+          Discover
+        </button>
+        {hasSelection && (
+          <>
+            <button
+              className={`side-panel-tab ${activeTab === 'details' ? 'side-panel-tab--active' : ''}`}
+              onClick={() => setActiveTab('details')}
+            >
+              Details
+            </button>
+            <button className="side-panel-close" onClick={handleCloseDetails}>
+              &times;
+            </button>
+          </>
+        )}
+      </div>
+
+      <div className="side-panel-content" style={{ display: activeTab === 'filters' ? undefined : 'none' }}>
+        <FilterPanel
+          nodeTypes={nodeTypes}
+          linkTypes={linkTypes}
+          hiddenNodeTypes={hiddenNodeTypes}
+          hiddenLinkTypes={hiddenLinkTypes}
+          subTypesByNodeType={subTypesByNodeType}
+          hiddenSubTypes={hiddenSubTypes}
+          onToggleNodeType={onToggleNodeType}
+          onToggleLinkType={onToggleLinkType}
+          onToggleSubType={onToggleSubType}
+          onShowAllNodes={onShowAllNodes}
+          onHideAllNodes={onHideAllNodes}
+          onShowAllLinks={onShowAllLinks}
+          onHideAllLinks={onHideAllLinks}
+        />
+      </div>
+      <div className="side-panel-content" style={{ display: activeTab === 'discover' ? undefined : 'none' }}>
+        <DiscoverPanel
+          onSelectNode={onSelectNode ?? (() => {})}
+          graphVersion={graphVersion}
+          selectedNodeId={selectedNode?.id as string | undefined}
+          graphNodeIds={graphNodeIds}
+          hopMap={hopMap}
+          isActive={activeTab === 'discover'}
+        />
+      </div>
+      {activeTab === 'details' && (
+        <div className="side-panel-content">
+          {selectedNode ? (
+            <NodeDetailsPanel
+              node={selectedNode}
+              nodeSource={nodeSource}
+              sourceLoading={sourceLoading}
+              sourceError={sourceError}
+            />
+          ) : selectedLink ? (
+            <EdgeDetailsPanel link={selectedLink} onSelectNode={onSelectNode} />
+          ) : null}
         </div>
       )}
-
-      <div className="side-panel-content">
-        {activeTab === 'filters' ? (
-          <FilterPanel
-            nodeTypes={nodeTypes}
-            linkTypes={linkTypes}
-            hiddenNodeTypes={hiddenNodeTypes}
-            hiddenLinkTypes={hiddenLinkTypes}
-            subTypesByNodeType={subTypesByNodeType}
-            hiddenSubTypes={hiddenSubTypes}
-            onToggleNodeType={onToggleNodeType}
-            onToggleLinkType={onToggleLinkType}
-            onToggleSubType={onToggleSubType}
-            onShowAllNodes={onShowAllNodes}
-            onHideAllNodes={onHideAllNodes}
-            onShowAllLinks={onShowAllLinks}
-            onHideAllLinks={onHideAllLinks}
-          />
-        ) : selectedNode ? (
-          <NodeDetailsPanel
-            node={selectedNode}
-            nodeSource={nodeSource}
-            sourceLoading={sourceLoading}
-            sourceError={sourceError}
-          />
-        ) : selectedLink ? (
-          <EdgeDetailsPanel link={selectedLink} onSelectNode={onSelectNode} />
-        ) : null}
-      </div>
     </div>
   );
 }

--- a/ui/src/hooks/useGraphData.ts
+++ b/ui/src/hooks/useGraphData.ts
@@ -8,6 +8,8 @@ export interface GraphDataState {
   error: string | null;
   stats: GraphStats | null;
   lastSearchQuery: string;
+  /** Monotonically increasing counter — bumps after each successful loadGraph */
+  graphVersion: number;
   loadGraph: (query?: string, hops?: number) => Promise<void>;
   setError: (error: string | null) => void;
 }
@@ -22,6 +24,7 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
   const [error, setError] = useState<string | null>(null);
   const [stats, setStats] = useState<GraphStats | null>(null);
   const [lastSearchQuery, setLastApiQuery] = useState('');
+  const [graphVersion, setGraphVersion] = useState(0);
 
   // Use a ref so loadGraph's identity doesn't depend on the callback
   const onGraphLoadedRef = useRef(onGraphLoaded);
@@ -37,6 +40,7 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
           setGraphData(data);
           setLoading(false);
           setLastApiQuery(query ?? '');
+          setGraphVersion((v) => v + 1);
           onGraphLoadedRef.current?.();
           store
             .fetchStats()
@@ -61,6 +65,7 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
     error,
     stats,
     lastSearchQuery,
+    graphVersion,
     loadGraph,
     setError,
   };


### PR DESCRIPTION
## Add Discover tab with directory tree navigation
🆕 **New Feature** · ✨ **Improvement**

Adds a new "Discover" tab to the side panel with a hierarchical directory tree view of the indexed codebase. Nodes are displayed in a filterable tree structure that automatically expands to show the currently selected node, with visual indicators showing hop distance from the selection and whether nodes are present in the current graph view.

Also adds a selection halo to the graph canvas to make the selected node more visible.

### Complexity
🟡 Moderate · `5 files changed, 961 insertions(+), 53 deletions(-)`

This PR introduces a complete new feature with several non-trivial pieces that need careful review, but the changes are well-contained to the UI layer and don't affect core graph logic or API contracts. The tree component implements recursive filtering, lazy-loading with state management, auto-expansion path finding, and coordinated scroll behavior. The SidePanel refactor changes tab visibility logic and selection state handling. While these are moderately complex interactions, reviewers familiar with React patterns and the existing codebase structure will find the changes straightforward to verify.

### Tests
🧪 No tests included — adds new UI feature without corresponding test coverage.

### Review focus
Pay particular attention to the following areas:

- **Auto-expand path traversal** — verify the DEFINED_IN edge walk doesn't infinite-loop on circular graphs or malformed data
- **Lazy-loading race conditions** — check that concurrent expand/collapse operations don't corrupt the children cache
- **Filter performance** — ensure recursive filtering doesn't degrade with deep trees or broad repositories
- **Hop-distance gradient** — confirm the CSS variable interpolation works across all supported browsers

---

<details>
<summary><strong>Additional details</strong></summary>

### Tree expansion strategy

The component uses three-level auto-expansion on mount (repository → directories → files), caching children in a Map for instant re-expansion. Interactive expand triggers lazy-load only if not already cached. When a node is selected externally (from graph click), the component walks up DEFINED_IN edges to find ancestors, then expands that path top-down.

### Graph-aware highlighting

The tree receives `hopMap` (node ID → distance from selection) and `graphNodeIds` (nodes visible in current graph) from the parent. Rows apply gradient background intensity based on hop distance (1.0 at selection, fading to 0.15 at max hops). Nodes not in the graph are dimmed unless the "In graph only" toggle is active, which hides them entirely.

### Filter behavior

Filtering is recursive: a node is visible if it or any descendant matches the filter string. This keeps parent directories visible when deep children match. The filter applies post-load, so it doesn't trigger additional traversal queries.

### Selection state flow

SidePanel now maintains `previousTab` ref to remember the last non-details tab (Filters or Discover). When a node/edge is selected, it auto-switches to Details; when deselected, it returns to the previous tab. The panel stays expanded when Discover is active, even without a selection.

</details>