### PR TITLE
ui: add example repo chips and worktree .env resolution

### DIFF
--- a/ui/src/components/AddRepoModal.css
+++ b/ui/src/components/AddRepoModal.css
@@ -163,6 +163,41 @@
   background: color-mix(in oklch, var(--foreground) 6%, transparent);
 }
 
+/* ── Example Repos ──────────────────────────── */
+.example-repos {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.example-repos-label {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  opacity: 0.7;
+}
+
+.example-repo-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  background: color-mix(in oklch, var(--foreground) 5%, transparent);
+  border: 1px solid color-mix(in oklch, var(--border) 25%, transparent);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.example-repo-chip:hover {
+  color: var(--primary);
+  border-color: color-mix(in oklch, var(--primary) 40%, transparent);
+  background: color-mix(in oklch, var(--primary) 8%, transparent);
+}
+
 /* ── CTA Button ──────────────────────────────── */
 .btn-cta {
   display: flex;

--- a/ui/src/components/AddRepoModal.tsx
+++ b/ui/src/components/AddRepoModal.tsx
@@ -117,6 +117,26 @@ function FolderIcon() {
   );
 }
 
+// --- Example Repositories ---
+
+const EXAMPLE_REPOS = [
+  {
+    name: 'OpenTelemetry Demo',
+    url: 'https://github.com/open-telemetry/opentelemetry-demo',
+    description: 'Microservices demo with OTel instrumentation',
+  },
+  {
+    name: 'Podinfo',
+    url: 'https://github.com/stefanprodan/podinfo',
+    description: 'Go microservice template for Kubernetes',
+  },
+  {
+    name: 'Express.js',
+    url: 'https://github.com/expressjs/express',
+    description: 'Fast, minimalist web framework for Node.js',
+  },
+];
+
 // --- Main Component ---
 
 export default function AddRepoModal({
@@ -283,6 +303,23 @@ export default function AddRepoModal({
                   data-lpignore="true"
                   data-testid="repo-url-input"
                 />
+
+                {!provider && (
+                  <div className="example-repos">
+                    <span className="example-repos-label">Examples:</span>
+                    {EXAMPLE_REPOS.map((repo) => (
+                      <button
+                        key={repo.url}
+                        type="button"
+                        className="example-repo-chip"
+                        onClick={() => setRepoUrl(repo.url)}
+                        title={repo.description}
+                      >
+                        {repo.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
 
                 <div className="form-info">
                   <svg

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
+import { resolve } from 'path';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
@@ -10,6 +11,36 @@ try {
   gitSha = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 } catch {
   // not in a git repo
+}
+
+/**
+ * Resolve the env directory — normally `..` (repo root), but when running
+ * inside a git worktree the .env file lives in the main working tree since
+ * it's gitignored. Fall back to the main tree root when the local one has
+ * no .env file.
+ */
+function resolveEnvDir(): string {
+  const localRoot = resolve(__dirname, '..');
+  if (existsSync(resolve(localRoot, '.env'))) return localRoot;
+
+  try {
+    // `git worktree list --porcelain` lists the main working tree first.
+    const output = execSync('git worktree list --porcelain', {
+      encoding: 'utf-8',
+      cwd: __dirname,
+    });
+    const firstWorktree = output
+      .split('\n')
+      .find((line) => line.startsWith('worktree '));
+    if (firstWorktree) {
+      const mainRoot = firstWorktree.replace('worktree ', '');
+      if (existsSync(resolve(mainRoot, '.env'))) return mainRoot;
+    }
+  } catch {
+    // not in a git repo or git not available
+  }
+
+  return localRoot;
 }
 
 /**
@@ -42,7 +73,7 @@ function crossOriginIsolation(): Plugin {
 
 // https://vite.dev/config/
 export default defineConfig({
-  envDir: '..',
+  envDir: resolveEnvDir(),
   define: {
     __APP_VERSION__: JSON.stringify(`${pkg.version}+${gitSha}`),
     __BUILD_TIME__: JSON.stringify(new Date().toISOString()),


### PR DESCRIPTION
## Add example repo chips and fix worktree .env loading
✨ **Improvement** · 🆕 **New Feature**

Adds quick-fill example repository chips to the Git provider modal and fixes `.env` file loading for developers using git worktrees.

The example chips (OpenTelemetry Demo, Podinfo, Express.js) appear below the URL input and fill the field on click. The worktree fix updates Vite config to locate `.env` in the main working tree when running from a worktree checkout.

### Complexity
🟢 Low · `3 files changed, 105 insertions(+), 2 deletions(-)`

Two independent improvements, both narrow in scope. The example chips are purely additive UI — no logic changes, no data flow. The worktree fix is a small Vite config change that only affects local dev setups using git worktrees, with a sensible fallback to existing behavior.

### Tests
🧪 No tests included — adds UI element and Vite config logic without corresponding test coverage.

---

<details>
<summary><strong>Additional details</strong></summary>

### Example repo chips

The chips appear below the URL input, only when using the Git provider (not GitHub/GitLab). Clicking a chip fills the input field with that repo's URL — no navigation or fetch, just a UX convenience.

### Worktree .env resolution

Vite's `envDir` is now set dynamically. The resolver checks the local parent directory first (normal case), then queries `git worktree list` to find the main working tree if the local .env doesn't exist. This ensures environment variables load correctly whether you're in the main tree or a worktree checkout.

</details>