### PR TITLE
ui: add drag handles to resize side panels

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -754,13 +754,40 @@ header h1 {
 }
 
 .chat-panel {
-  width: 480px;
   flex-shrink: 0;
   background: var(--background);
   border-left: 1px solid color-mix(in oklch, var(--border) 40%, transparent);
   display: flex;
   flex-direction: column;
   z-index: 10;
+  position: relative;
+}
+
+/* Drag handle on the left edge */
+.chat-panel-drag-handle {
+  position: absolute;
+  top: 0;
+  left: -3px;
+  bottom: 0;
+  width: 6px;
+  cursor: col-resize;
+  z-index: 20;
+}
+
+.chat-panel-drag-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 2px;
+  bottom: 0;
+  width: 2px;
+  background: transparent;
+  transition: background 0.15s;
+}
+
+.chat-panel-drag-handle:hover::after,
+.chat-panel-drag-handle:active::after {
+  background: var(--primary);
 }
 
 @keyframes slideInRight {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -27,6 +27,7 @@ function App() {
   const [chatGraphData, setChatGraphData] = useState(EMPTY_GRAPH);
 
   const [showChat, setShowChat] = useState(false);
+  const [chatWidth, setChatWidth] = useState(480);
   const [showSettings, setShowSettings] = useState(false);
   const [showAddRepo, setShowAddRepo] = useState(false);
   const [activeRepoUrl, setActiveRepoUrl] = useState('');
@@ -72,6 +73,7 @@ function App() {
   const handleAddRepoOpen = useCallback(() => setShowAddRepo(true), []);
   const handleAddRepoClose = useCallback(() => setShowAddRepo(false), []);
   const handleToggleChat = useCallback(() => setShowChat((v) => !v), []);
+  const handleChatWidthChange = useCallback((w: number) => setChatWidth(w), []);
   const handleToggleSettings = useCallback(
     () => setShowSettings((v) => !v),
     [],
@@ -96,6 +98,7 @@ function App() {
           onAddRepoClose={handleAddRepoClose}
           onJobSubmit={handleJobSubmit}
           showChat={showChat}
+          chatWidth={chatWidth}
           onToggleChat={handleToggleChat}
           showSettings={showSettings}
           onToggleSettings={handleToggleSettings}
@@ -120,6 +123,7 @@ function App() {
               }
             }}
             repoUrl={activeRepoUrl}
+            onWidthChange={handleChatWidthChange}
           />
         )}
       </div>

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -23,6 +23,7 @@ import { HumanMessage, AIMessage } from '@langchain/core/messages';
 import type { AIMessageChunk } from '@langchain/core/messages';
 import { useStore } from '../store';
 import { PRClient, parseRepoUrl } from '../pr/client';
+import { useResizablePanel } from '../hooks/useResizablePanel';
 import PRListPanel from './PRListPanel';
 import '../chat/markdown.css';
 import '../chat/parts.css';
@@ -36,6 +37,7 @@ interface Props {
   onNodeSelect?: (nodeId: string) => void;
   onGraphChange?: (focusNodeId?: string) => Promise<void>;
   repoUrl?: string;
+  onWidthChange?: (width: number) => void;
 }
 
 export default function ChatPanel({
@@ -44,8 +46,22 @@ export default function ChatPanel({
   onNodeSelect,
   onGraphChange,
   repoUrl,
+  onWidthChange,
 }: Props) {
   const { store } = useStore();
+
+  const { width: panelWidth, handleMouseDown } = useResizablePanel({
+    storageKey: 'ot_chat_panel_width',
+    defaultWidth: 480,
+    minWidth: 320,
+    maxWidth: 800,
+    side: 'left',
+  });
+
+  // Notify parent of width changes so graph canvas can adjust
+  useEffect(() => {
+    onWidthChange?.(panelWidth);
+  }, [panelWidth, onWidthChange]);
 
   const [providerId, setProviderId] = useState(loadProviderChoice);
   const [modelId, setModelId] = useState(() => {
@@ -406,7 +422,8 @@ export default function ChatPanel({
   const hasPRTab = !!prClient;
 
   return (
-    <div className="chat-panel">
+    <div className="chat-panel" style={{ width: panelWidth }}>
+      <div className="chat-panel-drag-handle" onMouseDown={handleMouseDown} />
       <div className="panel-header">
         <div className="panel-header-title">
           <h3>AI Assistant</h3>

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -101,6 +101,7 @@ export interface GraphViewerProps {
   onJobSubmit: (message: JobMessage) => void;
   // Toolbar toggles
   showChat: boolean;
+  chatWidth: number;
   onToggleChat: () => void;
   showSettings: boolean;
   onToggleSettings: () => void;
@@ -129,6 +130,7 @@ const GraphViewer = memo(
         onAddRepoClose,
         onJobSubmit,
         showChat,
+        chatWidth,
         onToggleChat,
         showSettings,
         onToggleSettings,
@@ -647,7 +649,6 @@ const GraphViewer = memo(
         ((jobState.status === 'enriching' || jobState.status === 'done') &&
           jobExpanded);
 
-      const chatWidth = 480;
       const graphWidth = showChat ? width - chatWidth : width;
 
       const isEmpty = graphData.nodes.length === 0;

--- a/ui/src/components/SidePanel.css
+++ b/ui/src/components/SidePanel.css
@@ -14,11 +14,33 @@
   padding-top: 64px;
   display: flex;
   flex-direction: column;
-  transition: width 0.3s ease;
 }
 
-.side-panel--expanded {
-  width: 480px;
+/* Drag handle on the right edge */
+.side-panel-drag-handle {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  bottom: 0;
+  width: 6px;
+  cursor: col-resize;
+  z-index: 10;
+}
+
+.side-panel-drag-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 2px;
+  bottom: 0;
+  width: 2px;
+  background: transparent;
+  transition: background 0.15s;
+}
+
+.side-panel-drag-handle:hover::after,
+.side-panel-drag-handle:active::after {
+  background: var(--primary);
 }
 
 /* Tab bar — only rendered when a node is selected */

--- a/ui/src/components/SidePanel.tsx
+++ b/ui/src/components/SidePanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { NodeObject, LinkObject } from 'react-force-graph-2d';
 import type { GraphNode, GraphLink } from '../types/graph';
 import type { NodeSourceResponse } from '../store/types';
+import { useResizablePanel } from '../hooks/useResizablePanel';
 import FilterPanel from './FilterPanel';
 import DiscoverPanel from './DiscoverPanel';
 import NodeDetailsPanel from './NodeDetailsPanel';
@@ -86,6 +87,17 @@ export default function SidePanel({
   const activeTabRef = useRef(activeTab);
   activeTabRef.current = activeTab;
 
+  const hasSelection = selectedNode !== null || selectedLink !== null;
+  const expanded = hasSelection || activeTab === 'discover';
+
+  const { width: panelWidth, handleMouseDown } = useResizablePanel({
+    storageKey: expanded ? 'ot_side_panel_expanded_width' : 'ot_side_panel_width',
+    defaultWidth: expanded ? 480 : 220,
+    minWidth: 180,
+    maxWidth: 700,
+    side: 'right',
+  });
+
   // Auto-switch to details when node or edge is selected
   useEffect(() => {
     if (selectedNode || selectedLink) {
@@ -100,16 +112,13 @@ export default function SidePanel({
     }
   }, [selectedNode, selectedLink]);
 
-  const hasSelection = selectedNode !== null || selectedLink !== null;
-  const expanded = hasSelection || activeTab === 'discover';
-
   const handleCloseDetails = () => {
     onCloseDetails();
     setActiveTab(previousTab.current);
   };
 
   return (
-    <div className={`side-panel ${expanded ? 'side-panel--expanded' : ''}`}>
+    <div className="side-panel" style={{ width: panelWidth }}>
       <div className="side-panel-tabs">
         <button
           className={`side-panel-tab ${activeTab === 'filters' ? 'side-panel-tab--active' : ''}`}
@@ -179,6 +188,7 @@ export default function SidePanel({
           ) : null}
         </div>
       )}
+      <div className="side-panel-drag-handle" onMouseDown={handleMouseDown} />
     </div>
   );
 }

--- a/ui/src/hooks/useResizablePanel.ts
+++ b/ui/src/hooks/useResizablePanel.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseResizablePanelOptions {
+  /** localStorage key for persisting width */
+  storageKey: string;
+  /** Default width when nothing is stored */
+  defaultWidth: number;
+  /** Minimum allowed width */
+  minWidth: number;
+  /** Maximum allowed width */
+  maxWidth: number;
+  /** Which side of the panel the handle is on — determines drag direction */
+  side: 'left' | 'right';
+}
+
+export function useResizablePanel({
+  storageKey,
+  defaultWidth,
+  minWidth,
+  maxWidth,
+  side,
+}: UseResizablePanelOptions) {
+  const [width, setWidth] = useState(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!isNaN(parsed) && parsed >= minWidth && parsed <= maxWidth)
+        return parsed;
+    }
+    return defaultWidth;
+  });
+
+  const isDragging = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(0);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      isDragging.current = true;
+      startX.current = e.clientX;
+      startWidth.current = width;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    },
+    [width],
+  );
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      const delta = e.clientX - startX.current;
+      // For a right-side handle, dragging right = wider; for left-side, dragging left = wider
+      const newWidth =
+        side === 'right'
+          ? startWidth.current + delta
+          : startWidth.current - delta;
+      const clamped = Math.max(minWidth, Math.min(maxWidth, newWidth));
+      setWidth(clamped);
+    };
+
+    const handleMouseUp = () => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [minWidth, maxWidth, side]);
+
+  // Persist to localStorage on change (debounced via the mouseup ending the drag)
+  useEffect(() => {
+    localStorage.setItem(storageKey, String(width));
+  }, [storageKey, width]);
+
+  return { width, handleMouseDown };
+}


### PR DESCRIPTION
## Add resizable drag handles to side panels
🆕 **New Feature** · ✨ **Improvement**

Adds drag-to-resize functionality to both the side panel and chat panel. Users can now customize panel widths by dragging handles at panel edges, with widths persisted to localStorage.

### Complexity
🟡 Moderate · `7 files changed, 173 insertions(+), 9 deletions(-)`

This PR introduces a new interaction pattern with panel resizing that affects two critical UI components. The custom hook manages stateful drag interactions with global mouse event handlers that must be carefully cleaned up. The side panel has conditional storage keys based on expansion state, which creates a state-dependent persistence model that needs verification. The changes integrate into existing state management (width flows up to parent components to adjust graph canvas), requiring coordination across multiple components. While the scope is limited to panel resizing, the consequence is moderate — bugs in event handling could cause memory leaks or broken interactions, and incorrect width persistence could confuse users.

### Tests
🧪 No tests included — adds UI interaction logic without test coverage.

### Review focus
Pay particular attention to the following areas:

- **localStorage key collision** — side panel uses different keys for collapsed vs expanded state, verify this doesn't cause unexpected behavior when toggling between states
- **Mouse event cleanup** — the useEffect must properly remove event listeners to prevent memory leaks or stale handlers

---

<details>
<summary><strong>Additional details</strong></summary>

### How it works

The new `useResizablePanel` hook encapsulates the resize logic:
- Drag state is tracked with refs to avoid re-renders during active drags
- Mouse move handlers calculate new width based on drag direction (left vs right handle)
- Width is clamped to min/max bounds and persisted to localStorage on every change

Panel integration differs slightly:
- **Chat panel**: uses a fixed storage key, notifies parent component of width changes via callback so the graph canvas can adjust its available space
- **Side panel**: switches between two storage keys depending on whether it's expanded (detail view) or collapsed (filter-only), allowing different default widths for each state

</details>