### PR TITLE
ui: auto-detect dev server port in 5173–5180 range for worktree support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ make build
 # Run individual components
 make api       # Start Go API server (port 8080)
 make agent     # Run Python agent
-make ui        # Start React dev server (port 5173)
+make ui        # Start React dev server (port 5173–5180, auto-detected)
 
 # Run all tests
 make test
@@ -54,6 +54,13 @@ cd ui
 npm install
 npm run dev
 ```
+
+#### Worktree & port handling
+
+`ui/vite.config.ts` has two worktree-aware helpers:
+
+- **`resolveEnvDir()`** — `.env` is gitignored so it only exists in the main working tree. When running from a worktree, falls back to the main tree's `.env` via `git worktree list --porcelain`.
+- **`resolvePort()`** — scans ports 5173–5180 and picks the first free one, so multiple worktrees can run `npm run dev` simultaneously. Uses `strictPort: true` so Vite errors instead of silently picking a random port outside the range.
 
 ## MCP Tools
 
@@ -93,7 +100,7 @@ server:
   port: 8080
   env: dev
   cors_hosts:
-    - http://localhost:5173
+    - http://localhost:5173   # UI auto-selects 5173–5180; add more if needed
 graph:
   db_path: ./data/graph.kuzu
 ```

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -44,9 +44,40 @@ function resolveEnvDir(): string {
 }
 
 /**
+ * Check whether a port is available by attempting a synchronous bind.
+ * Uses execSync to run a tiny Node one-liner so the check is blocking.
+ */
+function isPortFree(port: number): boolean {
+  try {
+    execSync(
+      `node -e "const s=require('net').createServer();s.on('error',()=>process.exit(1));s.on('listening',()=>{s.close();process.exit(0)});s.listen(${port},'0.0.0.0')"`,
+      { stdio: 'ignore', timeout: 2000 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find the first available port in the range 5173–5180. Returns
+ * undefined when no port is free (Vite will then fall back to its
+ * own default behaviour).
+ */
+function resolvePort(): number | undefined {
+  for (let port = 5173; port <= 5180; port++) {
+    if (isPortFree(port)) return port;
+  }
+  return undefined;
+}
+
+/**
  * Inline Vite plugin that sets Cross-Origin-Opener-Policy and
  * Cross-Origin-Embedder-Policy headers so SharedArrayBuffer is
  * available (required by kuzu-wasm).
+ *
+ * Also sets the correct MIME type for .wasm files so WebAssembly
+ * streaming compilation works (requires application/wasm).
  *
  * Uses "credentialless" instead of "require-corp" so cross-origin
  * fetches (e.g. api.github.com) still work without CORS attributes.
@@ -55,16 +86,22 @@ function crossOriginIsolation(): Plugin {
   return {
     name: 'cross-origin-isolation',
     configureServer(server) {
-      server.middlewares.use((_req, res, next) => {
+      server.middlewares.use((req, res, next) => {
         res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
         res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+        if (req.url?.endsWith('.wasm')) {
+          res.setHeader('Content-Type', 'application/wasm');
+        }
         next();
       });
     },
     configurePreviewServer(server) {
-      server.middlewares.use((_req, res, next) => {
+      server.middlewares.use((req, res, next) => {
         res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
         res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+        if (req.url?.endsWith('.wasm')) {
+          res.setHeader('Content-Type', 'application/wasm');
+        }
         next();
       });
     },
@@ -80,6 +117,8 @@ export default defineConfig({
   },
   plugins: [react(), crossOriginIsolation()],
   server: {
+    port: resolvePort(),
+    strictPort: true,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',
@@ -92,7 +131,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ['web-tree-sitter', '@kuzu/kuzu-wasm'],
+    exclude: ['web-tree-sitter', 'kuzu-wasm'],
   },
   worker: {
     format: 'es',


### PR DESCRIPTION
When multiple worktrees run `npm run dev`, they'd collide on port 5173. resolvePort() scans the range and picks the first free port, with strictPort: true to keep Vite from silently picking outside the range.