### PR TITLE
ci: only run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Run CI only on pull requests
🔧 **Chore**

Removes the `push` trigger from the CI workflow so it only runs on pull requests. This prevents duplicate CI runs when PRs are merged to main.

### Complexity
🟢 Trivial · `1 file changed, 2 deletions(-)`

Removes two lines from a workflow configuration file to change when CI runs. The change is mechanical and has no impact on code quality or correctness — it only affects when GitHub Actions executes.