### PR TITLE
ui: clickable header logo with reset confirmation

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -921,9 +921,57 @@ header h1 {
   pointer-events: auto;
 }
 
+.header-logo--clickable {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: opacity 0.15s;
+}
+
+.header-logo--clickable:hover {
+  opacity: 0.7;
+}
+
 .header-logo img {
   height: 28px;
   width: auto;
+}
+
+/* ── Reset Confirm Modal ─────────────────────── */
+.reset-confirm {
+  text-align: center;
+  width: 340px;
+}
+
+.reset-confirm h2 {
+  margin: 0 0 8px;
+}
+
+.reset-confirm-text {
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+  margin: 0 0 20px;
+  line-height: 1.45;
+}
+
+.reset-confirm-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.reset-confirm-actions .btn-cta {
+  flex: 1;
+}
+
+.btn-cta--destructive {
+  background: var(--destructive);
+  color: white;
+}
+
+.btn-cta--destructive:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--destructive) 85%, black);
 }
 
 /* Theme selector */

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -32,6 +32,7 @@ import JobMinimizedBar from './JobMinimizedBar';
 import SidePanel from './SidePanel';
 import ThemeSelector from './ThemeSelector';
 import { OpenTraceLogo } from './OpenTraceLogo';
+import ResetConfirmModal from './ResetConfirmModal';
 import GraphEvents from './sigma/GraphEvents';
 import LayoutController from './sigma/LayoutController';
 import { zoomToNodes, zoomToFit } from './sigma/zoomToNodes';
@@ -211,6 +212,7 @@ const GraphViewer = memo(
         null,
       );
       const [searchQuery, setSearchQuery] = useState('');
+      const [showResetConfirm, setShowResetConfirm] = useState(false);
       const [hops, setHops] = useState(2);
       const [highlightNodes, setHighlightNodes] = useState(new Set<string>());
       const [highlightLinks, setHighlightLinks] = useState(new Set<string>());
@@ -886,10 +888,14 @@ const GraphViewer = memo(
             hopMap={hopMap}
           />
           <header>
-            <div className="header-logo">
+            <button
+              type="button"
+              className="header-logo header-logo--clickable"
+              onClick={() => setShowResetConfirm(true)}
+            >
               <img src="/opentrace-logo.svg" alt="OpenTrace" />
               <h1>OpenTrace</h1>
-            </div>
+            </button>
             <div className="search-container">
               <input
                 type="text"
@@ -1041,6 +1047,13 @@ const GraphViewer = memo(
               </svg>
             </button>
           </header>
+
+          {showResetConfirm && (
+            <ResetConfirmModal
+              onConfirm={() => window.location.reload()}
+              onCancel={() => setShowResetConfirm(false)}
+            />
+          )}
 
           {showAddRepo && jobState.status === 'idle' && (
             <AddRepoModal onClose={onAddRepoClose} onSubmit={onJobSubmit} />

--- a/ui/src/components/ResetConfirmModal.tsx
+++ b/ui/src/components/ResetConfirmModal.tsx
@@ -1,0 +1,42 @@
+interface Props {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ResetConfirmModal({ onConfirm, onCancel }: Props) {
+  return (
+    <div
+      className="modal-backdrop"
+      onClick={onCancel}
+      data-testid="reset-backdrop"
+    >
+      <div
+        className="modal-card reset-confirm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2>Reset OpenTrace?</h2>
+        <p className="reset-confirm-text">
+          This will reload the page and clear the current session.
+        </p>
+        <div className="reset-confirm-actions">
+          <button
+            type="button"
+            className="btn-cta btn-cta--secondary"
+            onClick={onCancel}
+            data-testid="reset-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-cta btn-cta--destructive"
+            onClick={onConfirm}
+            data-testid="reset-confirm"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/__tests__/ResetConfirmModal.test.tsx
+++ b/ui/src/components/__tests__/ResetConfirmModal.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import React from 'react';
+import ResetConfirmModal from '../ResetConfirmModal';
+
+afterEach(cleanup);
+
+const defaultProps = {
+  onConfirm: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('ResetConfirmModal', () => {
+  it('renders the confirmation text', () => {
+    const { getByText } = render(
+      React.createElement(ResetConfirmModal, defaultProps),
+    );
+    expect(getByText('Reset OpenTrace?')).toBeDefined();
+    expect(
+      getByText('This will reload the page and clear the current session.'),
+    ).toBeDefined();
+  });
+
+  it('calls onConfirm when Reset is clicked', () => {
+    const onConfirm = vi.fn();
+    const { getByTestId } = render(
+      React.createElement(ResetConfirmModal, { ...defaultProps, onConfirm }),
+    );
+    fireEvent.click(getByTestId('reset-confirm'));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when Cancel is clicked', () => {
+    const onCancel = vi.fn();
+    const { getByTestId } = render(
+      React.createElement(ResetConfirmModal, { ...defaultProps, onCancel }),
+    );
+    fireEvent.click(getByTestId('reset-cancel'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when backdrop is clicked', () => {
+    const onCancel = vi.fn();
+    const { getByTestId } = render(
+      React.createElement(ResetConfirmModal, { ...defaultProps, onCancel }),
+    );
+    fireEvent.click(getByTestId('reset-backdrop'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onCancel when modal card is clicked', () => {
+    const onCancel = vi.fn();
+    const { getByText } = render(
+      React.createElement(ResetConfirmModal, { ...defaultProps, onCancel }),
+    );
+    // Click inside the modal card (on the heading)
+    fireEvent.click(getByText('Reset OpenTrace?'));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Add logo click to reset session with confirmation
🆕 **New Feature** · 🧪 **Tests**

Adds a clickable reset feature to the header logo that prompts for confirmation before reloading the page. Users can now click the OpenTrace logo to clear their session state.

### Complexity
🟢 Low · `4 files changed, 166 insertions(+), 2 deletions(-)`

This is a self-contained feature addition that touches only the header UI and introduces a new modal component. The change is narrow in scope (single user flow) and the consequence is low — the reset action is explicit and user-confirmed, so a missed issue would only affect this specific interaction.

### Tests
🧪 Includes unit tests for the modal component covering all interaction paths (confirm, cancel, backdrop click, event propagation).

---

<details>
<summary><strong>Additional details</strong></summary>

### Implementation approach

The logo button replaces the existing `<div>` wrapper with a `<button>` element that preserves the same visual structure while adding click handling. The modal follows the existing modal pattern in the codebase (modal-backdrop, modal-card) and uses a confirmation flow before executing the page reload.

### Styling notes

The clickable logo uses a transparent background and border-radius to show a subtle hover effect (opacity transition) without disrupting the header layout. The destructive button styling uses CSS color-mix to derive the hover state from the base `--destructive` variable.

</details>