### PR TITLE
perf(ui): optimize graph rendering for large graphs

### DIFF
--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { SigmaContainer, useSigma } from '@react-sigma/core';
 import { EdgeCurvedArrowProgram } from '@sigma/edge-curve';
+import { EdgeLineProgram } from 'sigma/rendering';
 import '@react-sigma/core/lib/style.css';
 import type {
   GraphNode,
@@ -37,6 +38,7 @@ import LayoutController from './sigma/LayoutController';
 import { zoomToNodes, zoomToFit } from './sigma/zoomToNodes';
 import {
   ZOOM_SIZE_EXPONENT,
+  EDGE_PROGRAM_THRESHOLD,
   LABEL_RENDERED_SIZE_THRESHOLD,
   LABEL_SIZE,
   LABEL_FONT,
@@ -558,8 +560,12 @@ const GraphViewer = memo(
         return map;
       }, [filteredGraphData.links]);
 
+      // Adapts edge program and sizes based on graph size.
+      // Uses unfiltered count so filter toggles don't flip the edge program mid-layout.
+      const isLargeGraph = graphData.links.length > EDGE_PROGRAM_THRESHOLD;
+
       // Build graphology Graph from filtered data (layout uses full dataset)
-      const graph = useSigmaGraph({
+      const { graph, layoutReady } = useSigmaGraph({
         allNodes: graphData.nodes,
         allLinks: graphData.links,
         nodes: filteredGraphData.nodes,
@@ -569,6 +575,7 @@ const GraphViewer = memo(
         highlightLinks,
         labelNodes,
         selectedNodeId: selectedNode?.id ?? null,
+        isLargeGraph,
       });
 
       const legendItems = useMemo(() => {
@@ -625,16 +632,18 @@ const GraphViewer = memo(
         }
       }, [isEmpty, isSearchEmpty, loading, jobState.status, onAddRepoOpen]);
 
-      // Sigma settings — stable reference to avoid re-creating the sigma instance
       const sigmaSettings = useMemo(
         () => ({
           defaultNodeType: 'circle',
-          defaultEdgeType: 'curvedArrow',
+          defaultEdgeType: isLargeGraph ? 'line' : 'curvedArrow',
           edgeProgramClasses: {
-            curvedArrow: EdgeCurvedArrowProgram,
+            ...(isLargeGraph
+              ? { line: EdgeLineProgram }
+              : { curvedArrow: EdgeCurvedArrowProgram }),
           },
           renderEdgeLabels: false,
-          enableEdgeEvents: true,
+          // Edge hit-testing is O(edges) per mouse move — disable for large graphs
+          enableEdgeEvents: !isLargeGraph,
           labelRenderedSizeThreshold: LABEL_RENDERED_SIZE_THRESHOLD,
           labelFont: LABEL_FONT,
           labelColor: { color: LABEL_COLOR },
@@ -643,7 +652,7 @@ const GraphViewer = memo(
           zoomToSizeRatioFunction: (ratio: number) =>
             Math.pow(ratio, ZOOM_SIZE_EXPONENT),
         }),
-        [],
+        [isLargeGraph],
       );
 
       const handleSigmaReady = useCallback(
@@ -1095,6 +1104,19 @@ const GraphViewer = memo(
             )}
           </div>
 
+          {!layoutReady && !isEmpty && (
+            <div
+              className="loading"
+              style={{ position: 'absolute', inset: 0, zIndex: 1 }}
+            >
+              <OpenTraceLogo size={48} />
+              <span>
+                Computing layout (
+                {filteredGraphData.nodes.length.toLocaleString()} nodes)...
+              </span>
+            </div>
+          )}
+
           <SigmaContainer
             graph={graph}
             style={{
@@ -1111,7 +1133,10 @@ const GraphViewer = memo(
               onEdgeClick={onLinkClick}
               onStageClick={handleStageClick}
             />
-            <LayoutController nodeCount={filteredGraphData.nodes.length} />
+            <LayoutController
+              nodeCount={filteredGraphData.nodes.length}
+              layoutReady={layoutReady}
+            />
             <SigmaZoomControls onReady={handleSigmaReady} />
           </SigmaContainer>
 

--- a/ui/src/components/SettingsDrawer.tsx
+++ b/ui/src/components/SettingsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   loadSummarizerStrategy,
   saveSummarizerStrategy,
@@ -91,17 +91,16 @@ export default function SettingsDrawer({
     }
   };
 
-  const limitsTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const debouncedLimitsChanged = useCallback(() => {
-    clearTimeout(limitsTimer.current);
-    limitsTimer.current = setTimeout(() => onLimitsChanged?.(), 400);
-  }, [onLimitsChanged]);
+  // Track whether limits have been edited but not yet applied
+  const savedNodes = loadLimit(LS_KEY_NODES, DEFAULT_MAX_NODES);
+  const savedEdges = loadLimit(LS_KEY_EDGES, DEFAULT_MAX_EDGES);
+  const limitsChanged = maxNodes !== savedNodes || maxEdges !== savedEdges;
 
-  const applyLimits = async (nodes: number, edges: number) => {
-    localStorage.setItem(LS_KEY_NODES, String(nodes));
-    localStorage.setItem(LS_KEY_EDGES, String(edges));
-    await store.setLimits?.(nodes, edges);
-    debouncedLimitsChanged();
+  const applyLimits = async () => {
+    localStorage.setItem(LS_KEY_NODES, String(maxNodes));
+    localStorage.setItem(LS_KEY_EDGES, String(maxEdges));
+    await store.setLimits?.(maxNodes, maxEdges);
+    onLimitsChanged?.();
   };
 
   return (
@@ -277,7 +276,6 @@ export default function SettingsDrawer({
                     Number(e.target.value) || DEFAULT_MAX_NODES,
                   );
                   setMaxNodes(v);
-                  applyLimits(v, maxEdges);
                 }}
               />
             </div>
@@ -299,10 +297,17 @@ export default function SettingsDrawer({
                     Number(e.target.value) || DEFAULT_MAX_EDGES,
                   );
                   setMaxEdges(v);
-                  applyLimits(maxNodes, v);
                 }}
               />
             </div>
+            <button
+              className="settings-back-btn"
+              onClick={applyLimits}
+              disabled={!limitsChanged}
+              style={{ marginTop: 8, alignSelf: 'flex-start' }}
+            >
+              Redraw Graph
+            </button>
             <p className="setting-hint">
               Defaults: {DEFAULT_MAX_NODES.toLocaleString()} nodes /{' '}
               {DEFAULT_MAX_EDGES.toLocaleString()} edges.

--- a/ui/src/components/sigma/LayoutController.tsx
+++ b/ui/src/components/sigma/LayoutController.tsx
@@ -23,9 +23,14 @@ import {
 
 interface LayoutControllerProps {
   nodeCount: number;
+  /** When true, d3-force positions are applied and FA2 can start */
+  layoutReady: boolean;
 }
 
-export default function LayoutController({ nodeCount }: LayoutControllerProps) {
+export default function LayoutController({
+  nodeCount,
+  layoutReady,
+}: LayoutControllerProps) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const runningRef = useRef(false);
   const sigma = useSigma();
@@ -45,6 +50,9 @@ export default function LayoutController({ nodeCount }: LayoutControllerProps) {
   });
 
   useEffect(() => {
+    // Don't start FA2 until d3-force worker has delivered positions
+    if (!layoutReady) return;
+
     const sigmaInstance = sigma as unknown as import('sigma').Sigma;
     const graph = sigma.getGraph();
 
@@ -56,10 +64,18 @@ export default function LayoutController({ nodeCount }: LayoutControllerProps) {
         stop();
         runningRef.current = false;
 
-        // Noverlap cleanup after FA2 stops
+        // Noverlap cleanup — scale iterations down for large graphs to avoid freeze
         if (graph.order > 0) {
+          const maxIter =
+            graph.order > 5000
+              ? Math.max(
+                  5,
+                  Math.round(NOVERLAP_MAX_ITERATIONS * (5000 / graph.order)),
+                )
+              : NOVERLAP_MAX_ITERATIONS;
+
           noverlap.assign(graph, {
-            maxIterations: NOVERLAP_MAX_ITERATIONS,
+            maxIterations: maxIter,
             settings: {
               ratio: NOVERLAP_RATIO,
               margin: NOVERLAP_MARGIN,
@@ -76,8 +92,16 @@ export default function LayoutController({ nodeCount }: LayoutControllerProps) {
     } else {
       // No FA2 — just noverlap + zoom
       if (graph.order > 0) {
+        const maxIter =
+          graph.order > 5000
+            ? Math.max(
+                5,
+                Math.round(NOVERLAP_MAX_ITERATIONS * (5000 / graph.order)),
+              )
+            : NOVERLAP_MAX_ITERATIONS;
+
         noverlap.assign(graph, {
-          maxIterations: NOVERLAP_MAX_ITERATIONS,
+          maxIterations: maxIter,
           settings: {
             ratio: NOVERLAP_RATIO,
             margin: NOVERLAP_MARGIN,
@@ -95,7 +119,7 @@ export default function LayoutController({ nodeCount }: LayoutControllerProps) {
       stop();
       runningRef.current = false;
     };
-  }, [nodeCount, start, stop, sigma]);
+  }, [layoutReady, nodeCount, start, stop, sigma]);
 
   return null;
 }

--- a/ui/src/config/graphLayout.ts
+++ b/ui/src/config/graphLayout.ts
@@ -28,7 +28,8 @@ export const NODE_SIZE_MULTIPLIERS: Record<string, number> = {
 
 // ─── Edge Sizes (screen pixels) ─────────────────────────────────────────
 
-export const EDGE_SIZE_DEFAULT = 1; // normal state
+export const EDGE_SIZE_DEFAULT = 1; // normal state (curved arrows)
+export const EDGE_SIZE_DEFAULT_LINE = 2; // normal state (straight lines, for large graphs)
 export const EDGE_SIZE_HIGHLIGHTED = 2.5; // when part of a selected neighborhood
 export const EDGE_SIZE_DIMMED = 0.5; // when another node is selected
 
@@ -54,9 +55,7 @@ export const ZOOM_SIZE_EXPONENT = 0.9;
 
 export const FORCE_LINK_DISTANCE = 200; // target distance between linked nodes
 export const FORCE_CHARGE_STRENGTH = -200; // repulsion between all nodes (negative = repel)
-export const FORCE_COLLIDE_PADDING = 40; // extra px padding around each node for collision
-export const FORCE_COLLIDE_ITERATIONS = 3; // collision resolution passes per tick
-export const FORCE_SIMULATION_TICKS = 300; // total simulation iterations
+export const FORCE_SIMULATION_TICKS = 80; // total simulation iterations (enough to seed FA2)
 
 // ─── ForceAtlas2 Live Physics ───────────────────────────────────────────
 // Runs after d3-force initial positioning to refine the layout.
@@ -72,7 +71,7 @@ export const FA2_STRONG_GRAVITY = false;
 export const FA2_LIN_LOG_MODE = true;
 export const FA2_OUTBOUND_ATTRACTION = true;
 export const FA2_ADJUST_SIZES = true;
-export const FA2_DURATION = 8000; // ms to run before auto-stop
+export const FA2_DURATION = 3000; // ms to run before auto-stop
 
 // ─── Noverlap Post-Processing ───────────────────────────────────────────
 // Runs after FA2 stops (or after d3-force if FA2 disabled) to push apart remaining overlaps.
@@ -83,6 +82,9 @@ export const NOVERLAP_MARGIN = 10;
 export const NOVERLAP_EXPANSION = 1.5;
 
 // ─── Sigma Renderer ─────────────────────────────────────────────────────
+
+// Above this edge count, use simple line edges instead of curved arrows
+export const EDGE_PROGRAM_THRESHOLD = 10000;
 
 export const LABEL_RENDERED_SIZE_THRESHOLD = 8;
 export const LABEL_SIZE = 12;

--- a/ui/src/hooks/d3LayoutWorker.ts
+++ b/ui/src/hooks/d3LayoutWorker.ts
@@ -1,0 +1,68 @@
+/**
+ * Web Worker that runs d3-force layout off the main thread.
+ *
+ * Receives: { nodeIds: string[], links: { source, target }[], config }
+ * Returns:  { positions: [id, x, y][] }
+ */
+import {
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+} from 'd3-force';
+
+interface SimNode {
+  id: string;
+  x?: number;
+  y?: number;
+}
+
+interface SimLink {
+  source: string;
+  target: string;
+}
+
+export interface LayoutRequest {
+  nodeIds: string[];
+  links: SimLink[];
+  config: {
+    linkDistance: number;
+    chargeStrength: number;
+    ticks: number;
+  };
+}
+
+export interface LayoutResponse {
+  positions: [string, number, number][];
+}
+
+self.onmessage = (e: MessageEvent<LayoutRequest>) => {
+  const { nodeIds, links, config } = e.data;
+
+  const simNodes: SimNode[] = nodeIds.map((id) => ({ id }));
+
+  const simulation = forceSimulation(simNodes)
+    .force(
+      'link',
+      forceLink<SimNode, SimLink>(links)
+        .id((d) => d.id)
+        .distance(config.linkDistance),
+    )
+    .force('charge', forceManyBody().strength(config.chargeStrength))
+    .force('center', forceCenter(0, 0))
+    .stop();
+
+  for (let i = 0; i < config.ticks; i++) {
+    simulation.tick();
+  }
+
+  const positions: [string, number, number][] = simNodes.map((n) => [
+    n.id,
+    n.x ?? 0,
+    n.y ?? 0,
+  ]);
+
+  (self as unknown as Worker).postMessage({
+    positions,
+  } satisfies LayoutResponse);
+};

--- a/ui/src/hooks/useSigmaGraph.ts
+++ b/ui/src/hooks/useSigmaGraph.ts
@@ -1,21 +1,16 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Graph from 'graphology';
-import {
-  forceSimulation,
-  forceLink,
-  forceManyBody,
-  forceCenter,
-  forceCollide,
-} from 'd3-force';
 import type { GraphNode, GraphLink } from '../types/graph';
 import { getNodeColor } from '../chat/results/nodeColors';
 import { getLinkColor } from '../chat/results/linkColors';
+import type { LayoutRequest, LayoutResponse } from './d3LayoutWorker';
 import {
   NODE_SIZE_MIN,
   NODE_SIZE_MAX,
   NODE_SIZE_DEGREE_SCALE,
   NODE_SIZE_MULTIPLIERS,
   EDGE_SIZE_DEFAULT,
+  EDGE_SIZE_DEFAULT_LINE,
   EDGE_SIZE_HIGHLIGHTED,
   EDGE_SIZE_DIMMED,
   EDGE_OPACITY_DEFAULT,
@@ -23,10 +18,14 @@ import {
   NODE_OPACITY_DIMMED,
   FORCE_LINK_DISTANCE,
   FORCE_CHARGE_STRENGTH,
-  FORCE_COLLIDE_PADDING,
-  FORCE_COLLIDE_ITERATIONS,
   FORCE_SIMULATION_TICKS,
 } from '../config/graphLayout';
+
+export interface UseSigmaGraphResult {
+  graph: Graph;
+  /** True once d3-force layout has been applied and graph is built */
+  layoutReady: boolean;
+}
 
 interface UseSigmaGraphOptions {
   /** Full unfiltered graph data — used for layout computation (cached) */
@@ -40,6 +39,8 @@ interface UseSigmaGraphOptions {
   highlightLinks: Set<string>;
   labelNodes: Set<string>;
   selectedNodeId: string | null;
+  /** When true, use thicker line-edge sizes (matches EdgeLineProgram in GraphViewer) */
+  isLargeGraph: boolean;
 }
 
 const STRUCTURAL_TYPES = new Set([
@@ -75,78 +76,6 @@ function endpointId(endpoint: string | number | GraphNode | undefined): string {
   if (typeof endpoint === 'object' && endpoint !== null)
     return (endpoint as GraphNode).id;
   return String(endpoint);
-}
-
-// ─── d3-force layout using only DEFINED_IN edges ────────────────────────
-
-interface SimNode {
-  id: string;
-  x?: number;
-  y?: number;
-  radius: number;
-}
-
-interface SimLink {
-  source: string;
-  target: string;
-}
-
-function computeD3Layout(
-  nodes: GraphNode[],
-  links: GraphLink[],
-): Map<string, { x: number; y: number }> {
-  // Compute degree locally so layout doesn't depend on external degreeMap
-  const localDegree = new Map<string, number>();
-  for (const link of links) {
-    const s = endpointId(link.source);
-    const t = endpointId(link.target);
-    localDegree.set(s, (localDegree.get(s) || 0) + 1);
-    localDegree.set(t, (localDegree.get(t) || 0) + 1);
-  }
-
-  const simNodes: SimNode[] = nodes.map((n) => {
-    const degree = localDegree.get(n.id) || 0;
-    return { id: n.id, radius: nodeSize(degree, n.type) };
-  });
-
-  const simLinks: SimLink[] = [];
-  const nodeIdSet = new Set(nodes.map((n) => n.id));
-  for (const link of links) {
-    if (link.label !== 'DEFINED_IN') continue;
-    const source = endpointId(link.source);
-    const target = endpointId(link.target);
-    if (nodeIdSet.has(source) && nodeIdSet.has(target)) {
-      simLinks.push({ source, target });
-    }
-  }
-
-  const simulation = forceSimulation(simNodes)
-    .force(
-      'link',
-      forceLink<SimNode, SimLink>(simLinks)
-        .id((d) => d.id)
-        .distance(FORCE_LINK_DISTANCE),
-    )
-    .force('charge', forceManyBody().strength(FORCE_CHARGE_STRENGTH))
-    .force('center', forceCenter(0, 0))
-    .force(
-      'collide',
-      forceCollide<SimNode>()
-        .radius((d) => d.radius + FORCE_COLLIDE_PADDING)
-        .iterations(FORCE_COLLIDE_ITERATIONS),
-    )
-    .stop();
-
-  for (let i = 0; i < FORCE_SIMULATION_TICKS; i++) {
-    simulation.tick();
-  }
-
-  const positions = new Map<string, { x: number; y: number }>();
-  for (const node of simNodes) {
-    positions.set(node.id, { x: node.x ?? 0, y: node.y ?? 0 });
-  }
-
-  return positions;
 }
 
 // ─── Pre-computed color cache ───────────────────────────────────────────
@@ -185,69 +114,180 @@ export function useSigmaGraph({
   highlightLinks,
   labelNodes,
   selectedNodeId,
-}: UseSigmaGraphOptions): Graph {
-  // Stable graph instance — created once, never replaced. Both useEffects
-  // below mutate this same instance sequentially (React guarantees effect
-  // ordering within a component), so rebuild always completes before
-  // highlight updates run.
+  isLargeGraph,
+}: UseSigmaGraphOptions): UseSigmaGraphResult {
+  // Stable graph instance — created once, never replaced.
   const graph = useMemo(() => new Graph({ multi: true, type: 'directed' }), []);
 
-  // Compute layout from full dataset (not filtered) so filter toggles are instant.
-  // useMemo ensures this only reruns when allNodes/allLinks change (new data fetch).
-  const positions = useMemo(() => {
-    if (allNodes.length === 0)
-      return new Map<string, { x: number; y: number }>();
-    if (process.env.NODE_ENV === 'development') {
-      console.time('[graph] d3-force layout');
+  // Worker ref — persists across renders, terminated on unmount
+  const workerRef = useRef<Worker | null>(null);
+
+  // Latest positions — set once when worker completes
+  const [positions, setPositions] = useState<Map<
+    string,
+    { x: number; y: number }
+  > | null>(null);
+
+  // Track which dataset the worker is computing for (to discard stale results)
+  const requestIdRef = useRef(0);
+
+  // True once d3-force positions are available
+  const layoutReady = positions !== null && positions.size > 0;
+
+  // Launch worker computation when allNodes/allLinks change.
+  useEffect(() => {
+    if (allNodes.length === 0) {
+      setPositions(null); // eslint-disable-line react-hooks/set-state-in-effect -- reset when data clears
+      return;
     }
-    const pos = computeD3Layout(allNodes, allLinks);
-    if (process.env.NODE_ENV === 'development') {
-      console.timeEnd('[graph] d3-force layout');
-      console.log(`[graph] layout computed for ${allNodes.length} nodes`);
+
+    // Reset — new data arriving, layout not ready yet
+    setPositions(null); // eslint-disable-line react-hooks/set-state-in-effect -- reset so layoutReady gates graph build
+
+    // Prepare DEFINED_IN links for the worker
+    const nodeIds = allNodes.map((n) => n.id);
+    const nodeIdSet = new Set(nodeIds);
+    const simLinks: { source: string; target: string }[] = [];
+    for (const link of allLinks) {
+      if (link.label !== 'DEFINED_IN') continue;
+      const source = endpointId(link.source);
+      const target = endpointId(link.target);
+      if (nodeIdSet.has(source) && nodeIdSet.has(target)) {
+        simLinks.push({ source, target });
+      }
     }
-    return pos;
+
+    // Terminate any previous worker
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+
+    const reqId = ++requestIdRef.current;
+
+    const worker = new Worker(new URL('./d3LayoutWorker.ts', import.meta.url), {
+      type: 'module',
+    });
+    workerRef.current = worker;
+
+    if (process.env.NODE_ENV === 'development') {
+      console.time('[graph] d3-force worker layout');
+    }
+
+    worker.onerror = (err) => {
+      if (reqId !== requestIdRef.current) return;
+      console.error('[graph] d3-force worker failed:', err);
+      // Fall back to zero positions so the graph still renders
+      const fallback = new Map<string, { x: number; y: number }>();
+      for (const id of nodeIds) fallback.set(id, { x: 0, y: 0 });
+      setPositions(fallback);
+      if (workerRef.current === worker) workerRef.current = null;
+    };
+
+    worker.onmessage = (e: MessageEvent<LayoutResponse>) => {
+      // Discard if a newer request was issued
+      if (reqId !== requestIdRef.current) return;
+
+      const pos = new Map<string, { x: number; y: number }>();
+      for (const [id, x, y] of e.data.positions) {
+        pos.set(id, { x, y });
+      }
+
+      if (process.env.NODE_ENV === 'development') {
+        console.timeEnd('[graph] d3-force worker layout');
+        console.log(`[graph] layout computed for ${pos.size} nodes`);
+      }
+
+      setPositions(pos);
+
+      worker.terminate();
+      if (workerRef.current === worker) workerRef.current = null;
+    };
+
+    worker.postMessage({
+      nodeIds,
+      links: simLinks,
+      config: {
+        linkDistance: FORCE_LINK_DISTANCE,
+        chargeStrength: FORCE_CHARGE_STRENGTH,
+        ticks: FORCE_SIMULATION_TICKS,
+      },
+    } satisfies LayoutRequest);
+
+    return () => {
+      if (workerRef.current === worker) {
+        worker.terminate();
+        workerRef.current = null;
+      }
+    };
   }, [allNodes, allLinks]);
 
-  // Rebuild graph structure when filtered data or positions change
+  // Build graph only once positions are ready, and when filtered data changes.
+  // Uses graph.import() for bulk construction.
   useEffect(() => {
     graph.clear();
-    if (nodes.length === 0) return;
+    if (!positions || nodes.length === 0) return;
 
-    for (const node of nodes) {
+    // Build serialized arrays in plain JS (no graphology events fired)
+    const nodeSet = new Set<string>();
+    const serializedNodes = nodes.map((node) => {
       const degree = degreeMap.get(node.id) || 0;
       const size = nodeSize(degree, node.type);
       const pos = positions.get(node.id) || { x: 0, y: 0 };
-      graph.addNode(node.id, {
-        label: node.name || node.id,
-        x: pos.x,
-        y: pos.y,
-        size,
-        color: getNodeColor(node.type),
-        nodeType: node.type,
-        _graphNode: node,
-      });
-    }
+      nodeSet.add(node.id);
+      return {
+        key: node.id,
+        attributes: {
+          label: node.name || node.id,
+          x: pos.x,
+          y: pos.y,
+          size,
+          color: getNodeColor(node.type),
+          nodeType: node.type,
+          _graphNode: node,
+        },
+      };
+    });
 
-    // Use stable edge keys based on source/target to avoid identity issues
-    // when filters change the set of visible edges.
+    const seenEdges = new Set<string>();
+    const serializedEdges: {
+      key: string;
+      source: string;
+      target: string;
+      attributes: Record<string, unknown>;
+    }[] = [];
+
+    const edgeSize = isLargeGraph ? EDGE_SIZE_DEFAULT_LINE : EDGE_SIZE_DEFAULT;
+
     for (const link of links) {
       const source = endpointId(link.source);
       const target = endpointId(link.target);
-      if (!graph.hasNode(source) || !graph.hasNode(target)) continue;
+      if (!nodeSet.has(source) || !nodeSet.has(target)) continue;
       const edgeKey = `${source}-${link.label}-${target}`;
-      // Deduplicate: skip if this exact edge already exists
-      if (graph.hasEdge(edgeKey)) continue;
-      graph.addEdgeWithKey(edgeKey, source, target, {
-        label: link.label,
-        color: getLinkColor(link.label),
-        size: EDGE_SIZE_DEFAULT,
-        _graphLink: link,
+      if (seenEdges.has(edgeKey)) continue;
+      seenEdges.add(edgeKey);
+      serializedEdges.push({
+        key: edgeKey,
+        source,
+        target,
+        attributes: {
+          label: link.label,
+          color: getLinkColor(link.label),
+          size: edgeSize,
+          _graphLink: link,
+        },
       });
     }
-  }, [graph, nodes, links, degreeMap, positions]);
+
+    // Single bulk import — graphology processes all nodes/edges internally
+    // then fires a single set of events for sigma to pick up.
+    graph.import({
+      nodes: serializedNodes,
+      edges: serializedEdges,
+    });
+  }, [graph, nodes, links, degreeMap, positions, isLargeGraph]);
 
   // Update visual attributes when highlight state changes.
-  // Runs after the rebuild effect above (React guarantees effect order).
   useEffect(() => {
     if (graph.order === 0) return;
     const hasHighlight = highlightNodes.size > 0;
@@ -267,6 +307,10 @@ export function useSigmaGraph({
       return attrs;
     });
 
+    const defaultEdgeSize = isLargeGraph
+      ? EDGE_SIZE_DEFAULT_LINE
+      : EDGE_SIZE_DEFAULT;
+
     graph.forEachEdge((id, attrs, source, target) => {
       const linkKey = `${source}-${target}`;
       const isHighlighted = highlightLinks.has(linkKey);
@@ -282,11 +326,25 @@ export function useSigmaGraph({
       } else {
         graph.mergeEdgeAttributes(id, {
           color: dimColor(baseColor, EDGE_OPACITY_DEFAULT),
-          size: EDGE_SIZE_DEFAULT,
+          size: defaultEdgeSize,
         });
       }
     });
-  }, [graph, highlightNodes, highlightLinks, labelNodes, selectedNodeId]);
+  }, [
+    graph,
+    highlightNodes,
+    highlightLinks,
+    labelNodes,
+    selectedNodeId,
+    isLargeGraph,
+  ]);
 
-  return graph;
+  // Cleanup worker on unmount
+  useEffect(() => {
+    return () => {
+      workerRef.current?.terminate();
+    };
+  }, []);
+
+  return { graph, layoutReady };
 }


### PR DESCRIPTION
## Optimize graph rendering for large graphs
⚡ **Performance** · ✨ **Improvement**

Improves graph rendering performance for large graphs (10k+ edges) by moving d3-force layout to a Web Worker, switching to simple line edges above a threshold, and scaling noverlap iterations.

Graph construction now happens in a single bulk import to avoid cascading re-renders, and edge hit-testing is disabled for large graphs to eliminate per-pixel O(edges) overhead on every mouse move.

### Complexity
🟠 High · `6 files changed, 303 insertions(+), 156 deletions(-)`

This PR touches the core graph rendering pipeline across multiple related areas: layout computation (migrated to a Web Worker with async coordination), sigma configuration (edge programs, hit-testing, sizes), and the LayoutController (added noverlap scaling and ready-state gating). The worker lifecycle introduces asynchronous coordination that must handle races, stale results, and cleanup correctly. Edge program and size logic is now conditional on graph size, which affects rendering, interactivity, and layout output in non-obvious ways. A mistake in worker termination or request gating could cause stale positions to overwrite fresh ones; missing the layoutReady check in LayoutController would cause FA2 to run on uninitialized positions, producing broken layouts. The noverlap scaling logic prevents UI freezes on very large graphs — incorrect scaling could either freeze the browser or leave overlapping nodes. The graph construction switch from incremental add to bulk import is subtle but critical for performance, and the isLargeGraph threshold must use unfiltered counts to avoid flip-flopping between rendering modes when filters change. The changes are tightly coupled: worker positions feed graph construction, which feeds LayoutController, which depends on layoutReady, which depends on worker completion. Testing this requires reasoning about timing, edge cases (empty graphs, worker errors), and multi-step state transitions.

### Tests
🧪 No tests included — changes graph rendering and layout computation, not covered by existing test suite.

### Review focus
Pay particular attention to the following areas:

- **Worker lifecycle** — verify the worker is terminated correctly when component unmounts or new layout starts, especially in the useEffect cleanup and request ID gating logic
- **Threshold consistency** — confirm isLargeGraph is computed from unfiltered edge count so filter toggles don't flip rendering modes mid-session
- **Layout ready gating** — ensure FA2 never starts before d3-force positions arrive, otherwise sigma will animate from (0,0) positions

---

<details>
<summary><strong>Additional details</strong></summary>

### Worker coordination

The d3-force layout runs off the main thread. `useSigmaGraph` launches the worker when `allNodes`/`allLinks` change, assigns a request ID, and sets `layoutReady` to false. When the worker completes, the callback checks the request ID to discard stale results (guards against slow worker finishing after a new one started). If the request ID matches, positions are set and `layoutReady` flips to true, triggering graph construction. Worker errors fall back to zero positions so rendering still happens.

### Graph construction

Previously, nodes and edges were added one-by-one with `graph.addNode()` and `graph.addEdgeWithKey()`, causing sigma to react to each mutation. Now uses `graph.import()` to bulk-load serialized nodes/edges in one pass — graphology processes the full structure internally, then fires events once. This eliminates cascading re-renders for large graphs.

### Conditional rendering modes

`isLargeGraph` is computed from `graphData.links.length` (unfiltered) so filter toggles don't flip the edge program. Above `EDGE_PROGRAM_THRESHOLD` (10k edges):
- Edges render as straight lines (`EdgeLineProgram`) instead of curved arrows
- Default edge size increases from 1px to 2px for visibility
- Edge hit-testing (`enableEdgeEvents`) is disabled — prevents O(edges) traversal on every mouse move

The edge program and settings are memoized in `sigmaSettings` with `isLargeGraph` as a dependency.

### FA2 gating and noverlap scaling

`LayoutController` receives `layoutReady` and waits for it before starting ForceAtlas2. Without this gate, FA2 would run on nodes at (0,0), wasting cycles and producing unusable output.

Noverlap iterations now scale down for graphs over 5000 nodes: `max(5, NOVERLAP_MAX_ITERATIONS * 5000 / nodeCount)`. This prevents multi-second freezes on very large graphs while still resolving most overlaps.

### Settings UI polish

The node/edge limit inputs no longer auto-apply on every keystroke. A "Redraw Graph" button appears when limits differ from saved values, and the user explicitly triggers the redraw. This avoids triggering expensive re-layouts mid-edit.

</details>