### PR TITLE
fix: strip newlines in KuzuDB CSV escape

### DIFF
--- a/ui/src/store/kuzuStore.ts
+++ b/ui/src/store/kuzuStore.ts
@@ -70,7 +70,8 @@ const REL_PAIR_SET: ReadonlySet<string> = new Set(
 function csvEscape(value: string): string {
   // Always quote to avoid ambiguity — KuzuDB's CSV parser can misparse
   // fields containing JSON with nested commas + quotes.
-  return '"' + value.replace(/"/g, '""') + '"';
+  // Strip newlines — KuzuDB's parallel CSV reader rejects quoted newlines.
+  return '"' + value.replace(/"/g, '""').replace(/[\r\n]+/g, ' ') + '"';
 }
 
 /** Generate CSV for a typed node table (no type column — table name IS the type). */


### PR DESCRIPTION
## Strip newlines in KuzuDB CSV escape
🐛 **Bug Fix**

Fixes CSV import failures by stripping newlines from field values before writing to KuzuDB. KuzuDB's parallel CSV reader rejects quoted newlines, causing `COPY FROM` to fail when node properties contain newline characters (e.g., JSON with embedded newlines).

### Complexity
🟢 Low · `1 file changed, 2 insertions(+), 1 deletion(-)`

Single-line fix to a CSV escape helper that resolves a specific import failure mode. The change is localized to one function and the impact is straightforward — prevents COPY FROM failures without changing the data model or query logic.

### Tests
🧪 No tests included — fixes a data-dependent edge case in CSV import.

### Review focus
Pay particular attention to the following areas:

- **Data integrity** — verify newline replacement with spaces doesn't break JSON parsing or semantic meaning in property values