### PR TITLE
feat(ui): community-aware graph layout, filtering, and legend

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -237,7 +237,7 @@ header h1 {
 /* Filter Panel — content-only (positioning handled by SidePanel) */
 .filter-panel {
   overflow-y: auto;
-  padding: 0 0 16px;
+  padding: 0 0 80px;
 }
 
 .filter-section {
@@ -506,13 +506,14 @@ header h1 {
   left: 24px;
   z-index: 10;
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 16px;
   background: color-mix(in oklch, var(--background) 85%, transparent);
   backdrop-filter: blur(8px);
   padding: 10px 16px;
   border-radius: calc(var(--radius) + 2px);
   border: 1px solid color-mix(in oklch, var(--border) 25%, transparent);
-  pointer-events: none;
 }
 
 .legend-item {
@@ -549,6 +550,41 @@ header h1 {
   height: 3px;
   border-radius: 1.5px;
   flex-shrink: 0;
+}
+
+.legend-more-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  cursor: pointer;
+  pointer-events: auto;
+  white-space: nowrap;
+}
+
+.legend-more-btn:hover {
+  color: var(--foreground);
+  border-color: var(--foreground);
+}
+
+.legend-popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 16px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) + 2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  max-height: 320px;
+  overflow-y: auto;
+  pointer-events: auto;
 }
 
 /* Loading state */

--- a/ui/src/chat/results/communityColors.ts
+++ b/ui/src/chat/results/communityColors.ts
@@ -49,6 +49,206 @@ export function buildCommunityColorMap(
   return colorMap;
 }
 
+// Node types that represent structural containers (ordered by priority — most specific first)
+const CONTAINER_TYPES = ['Package', 'Directory', 'Repository'];
+
+interface NameableNode {
+  id: string;
+  name: string;
+  type: string;
+}
+
+/**
+ * Derive a human-readable name for each community based on its member nodes.
+ *
+ * Strategy (in priority order):
+ * 1. Highest-priority container node (Module > Package > Directory > ...)
+ * 2. Longest common path prefix of node names (e.g., "src/components")
+ * 3. Hub node — the node whose name appears most often as a prefix/substring
+ *    in other members' names, or failing that, the shortest-named node
+ *    (often the defining class/file of the cluster)
+ * 4. Dominant node type + hub qualifier (e.g., "Functions · handleRequest")
+ *
+ * A final dedup pass appends the hub node name to any colliding labels.
+ */
+export function buildCommunityNames(
+  assignments: Record<string, number>,
+  nodes: NameableNode[],
+): Map<number, string> {
+  // Group nodes by community
+  const groups = new Map<number, NameableNode[]>();
+  for (const node of nodes) {
+    const cid = assignments[node.id];
+    if (cid === undefined) continue;
+    let list = groups.get(cid);
+    if (!list) {
+      list = [];
+      groups.set(cid, list);
+    }
+    list.push(node);
+  }
+
+  const names = new Map<number, string>();
+  // Track hub node per community for dedup
+  const hubs = new Map<number, string>();
+
+  for (const [cid, members] of groups) {
+    const hub = findHubNode(members);
+    if (hub) hubs.set(cid, hub);
+
+    // Strategy 1: Find the highest-priority container node
+    let containerName: string | null = null;
+    let bestPriority = CONTAINER_TYPES.length;
+    for (const node of members) {
+      const priority = CONTAINER_TYPES.indexOf(node.type);
+      if (priority !== -1 && priority < bestPriority) {
+        bestPriority = priority;
+        containerName = node.name;
+      }
+    }
+    if (containerName) {
+      names.set(cid, containerName);
+      continue;
+    }
+
+    // Strategy 2: Longest common path prefix
+    const nodeNames = members.map((n) => n.name);
+    const prefix = longestCommonPrefix(nodeNames);
+    if (prefix.length > 0) {
+      // Trim to last path separator for a clean directory-like name
+      const trimmed = prefix.includes('/')
+        ? prefix.slice(0, prefix.lastIndexOf('/') + 1)
+        : prefix.includes('.')
+          ? prefix.slice(0, prefix.lastIndexOf('.') + 1)
+          : prefix;
+      if (trimmed.length > 1) {
+        names.set(cid, trimmed.replace(/\/$/, ''));
+        continue;
+      }
+    }
+
+    // Strategy 3: Hub node name directly (if it's distinctive enough)
+    if (hub) {
+      names.set(cid, hub);
+      continue;
+    }
+
+    // Strategy 4: Dominant node type (last resort)
+    const typeCounts = new Map<string, number>();
+    for (const node of members) {
+      typeCounts.set(node.type, (typeCounts.get(node.type) || 0) + 1);
+    }
+    let dominantType = 'Nodes';
+    let maxCount = 0;
+    for (const [type, count] of typeCounts) {
+      if (count > maxCount) {
+        maxCount = count;
+        dominantType = type;
+      }
+    }
+    names.set(cid, pluralize(dominantType));
+  }
+
+  // Dedup: guarantee every community name is unique.
+  // Pass 1: append hub qualifier to collisions.
+  // Pass 2: if still colliding, append numeric suffix.
+  dedup(names, hubs);
+
+  return names;
+}
+
+/**
+ * Find the most representative node in a community.
+ * Picks the node whose name is a prefix/substring of the most other members,
+ * breaking ties by shortest name (classes/files tend to be shorter than methods).
+ */
+function findHubNode(members: NameableNode[]): string | null {
+  if (members.length === 0) return null;
+  if (members.length === 1) return members[0].name;
+
+  // Score each node by how many other members' names contain it as substring
+  const scores: { name: string; score: number; len: number }[] = [];
+  for (const node of members) {
+    const lowerName = node.name.toLowerCase();
+    // Skip very short names (single char, empty) — they'd match everything
+    if (lowerName.length <= 1) continue;
+    let score = 0;
+    for (const other of members) {
+      if (other === node) continue;
+      if (other.name.toLowerCase().includes(lowerName)) score++;
+    }
+    scores.push({ name: node.name, score, len: node.name.length });
+  }
+
+  if (scores.length === 0) {
+    // All names are very short — pick the shortest
+    return members.reduce((a, b) => (a.name.length <= b.name.length ? a : b))
+      .name;
+  }
+
+  // Sort by: highest score, then shortest name
+  scores.sort((a, b) => b.score - a.score || a.len - b.len);
+
+  return scores[0].name;
+}
+
+/** Mutates `names` until every value is unique. */
+function dedup(names: Map<number, string>, hubs: Map<number, string>): void {
+  // Collect collisions
+  const byCid = () => {
+    const map = new Map<string, number[]>();
+    for (const [cid, name] of names) {
+      let list = map.get(name);
+      if (!list) {
+        list = [];
+        map.set(name, list);
+      }
+      list.push(cid);
+    }
+    return map;
+  };
+
+  // Pass 1: append hub qualifier
+  for (const [, cids] of byCid()) {
+    if (cids.length <= 1) continue;
+    for (const cid of cids) {
+      const hub = hubs.get(cid);
+      const current = names.get(cid)!;
+      if (hub && hub !== current && !current.includes(hub)) {
+        names.set(cid, `${current} · ${hub}`);
+      }
+    }
+  }
+
+  // Pass 2: if still colliding, append numeric suffix
+  for (const [, cids] of byCid()) {
+    if (cids.length <= 1) continue;
+    for (let i = 0; i < cids.length; i++) {
+      const cid = cids[i];
+      names.set(cid, `${names.get(cid)!} (${i + 1})`);
+    }
+  }
+}
+
+function longestCommonPrefix(strings: string[]): string {
+  if (strings.length === 0) return '';
+  if (strings.length === 1) return strings[0];
+  let prefix = strings[0];
+  for (let i = 1; i < strings.length; i++) {
+    while (!strings[i].startsWith(prefix)) {
+      prefix = prefix.slice(0, -1);
+      if (prefix.length === 0) return '';
+    }
+  }
+  return prefix;
+}
+
+function pluralize(type: string): string {
+  if (type.endsWith('s')) return type;
+  if (type.endsWith('y')) return type.slice(0, -1) + 'ies';
+  return type + 's';
+}
+
 /**
  * Look up the community color for a given node.
  */

--- a/ui/src/components/FilterPanel.tsx
+++ b/ui/src/components/FilterPanel.tsx
@@ -12,6 +12,13 @@ interface SubTypeEntry {
   count: number;
 }
 
+interface CommunityEntry {
+  communityId: number;
+  label: string;
+  count: number;
+  color: string;
+}
+
 interface FilterPanelProps {
   nodeTypes: TypeEntry[];
   linkTypes: TypeEntry[];
@@ -26,6 +33,12 @@ interface FilterPanelProps {
   onHideAllNodes: () => void;
   onShowAllLinks: () => void;
   onHideAllLinks: () => void;
+  colorMode?: 'type' | 'community';
+  communities?: CommunityEntry[];
+  hiddenCommunities?: Set<number>;
+  onToggleCommunity?: (cid: number) => void;
+  onShowAllCommunities?: () => void;
+  onHideAllCommunities?: () => void;
 }
 
 export default function FilterPanel({
@@ -42,6 +55,12 @@ export default function FilterPanel({
   onHideAllNodes,
   onShowAllLinks,
   onHideAllLinks,
+  colorMode,
+  communities,
+  hiddenCommunities,
+  onToggleCommunity,
+  onShowAllCommunities,
+  onHideAllCommunities,
 }: FilterPanelProps) {
   const allLinksHidden = hiddenLinkTypes.size === linkTypes.length;
   const [expandedTypes, setExpandedTypes] = useState<Set<string>>(new Set());
@@ -76,8 +95,63 @@ export default function FilterPanel({
     return hiddenNodeTypes.has(type);
   });
 
+  const showCommunities =
+    colorMode === 'community' &&
+    communities &&
+    communities.length > 0 &&
+    hiddenCommunities &&
+    onToggleCommunity;
+
+  const allCommunitiesHidden =
+    showCommunities &&
+    communities!.every((c) => hiddenCommunities!.has(c.communityId));
+
   return (
     <div className="filter-panel">
+      {showCommunities && (
+        <div className="filter-section">
+          <div className="filter-section-header">
+            <span className="filter-section-title">Communities</span>
+            <button
+              className="filter-toggle-all"
+              onClick={
+                allCommunitiesHidden
+                  ? onShowAllCommunities
+                  : onHideAllCommunities
+              }
+            >
+              {allCommunitiesHidden ? 'Show all' : 'Hide all'}
+            </button>
+          </div>
+          <div className="filter-list">
+            {communities!.map(({ communityId, label, count, color }) => {
+              const hidden = hiddenCommunities!.has(communityId);
+              return (
+                <label
+                  key={communityId}
+                  className={`filter-item ${hidden ? 'hidden' : ''}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!hidden}
+                    onChange={() => onToggleCommunity!(communityId)}
+                  />
+                  <span className="filter-expand-spacer" />
+                  <span
+                    className="filter-dot"
+                    style={{
+                      backgroundColor: hidden ? 'var(--muted)' : color,
+                    }}
+                  />
+                  <span className="filter-type-name">{label}</span>
+                  <span className="filter-count">{count}</span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       <div className="filter-section">
         <div className="filter-section-header">
           <span className="filter-section-title">Node Types</span>

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -23,7 +23,7 @@ import { useStore } from '../store';
 import { getNodeColor } from '../chat/results/nodeColors';
 import { getLinkColor } from '../chat/results/linkColors';
 import { useGraphData } from '../hooks/useGraphData';
-import { useSigmaGraph } from '../hooks/useSigmaGraph';
+import { useSigmaGraph, useLouvainCommunities } from '../hooks/useSigmaGraph';
 import type { JobState } from '../job';
 import type { JobMessage } from '../job';
 import { detectProvider } from './AddRepoModal';
@@ -79,6 +79,131 @@ function getSubType(node: GraphNode): string | null {
 function linkId(endpoint: string | number | GraphNode | undefined): string {
   if (typeof endpoint === 'object' && endpoint !== null) return endpoint.id;
   return String(endpoint);
+}
+
+// ─── Graph Legend with overflow popover ─────────────────────────────
+
+const LEGEND_MAX_NODES = 5;
+
+type LegendEntry = {
+  key: string;
+  label: string;
+  count: number;
+  color: string;
+  shape: 'dot' | 'line';
+};
+
+function GraphLegend({
+  colorMode,
+  legendItems,
+  communityLegendItems,
+  legendLinkItems,
+}: {
+  colorMode: 'type' | 'community';
+  legendItems: { type: string; count: number; color: string }[];
+  communityLegendItems: { label: string; count: number; color: string }[];
+  legendLinkItems: { type: string; count: number; color: string }[];
+}) {
+  const [showOverflow, setShowOverflow] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Close popover on outside click
+  useEffect(() => {
+    if (!showOverflow) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node)
+      ) {
+        setShowOverflow(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showOverflow]);
+
+  // Build node/community items (truncatable) and link items (always shown)
+  const nodeItems: LegendEntry[] = [];
+  if (colorMode === 'community') {
+    for (const { label, count, color } of communityLegendItems) {
+      nodeItems.push({ key: `c:${label}`, label, count, color, shape: 'dot' });
+    }
+  } else {
+    for (const { type, count, color } of legendItems) {
+      nodeItems.push({
+        key: `n:${type}`,
+        label: type,
+        count,
+        color,
+        shape: 'dot',
+      });
+    }
+  }
+
+  const linkItems: LegendEntry[] = [];
+  for (const { type, count, color } of legendLinkItems) {
+    linkItems.push({
+      key: `l:${type}`,
+      label: type,
+      count,
+      color,
+      shape: 'line',
+    });
+  }
+
+  const visibleNodes = nodeItems.slice(0, LEGEND_MAX_NODES);
+  const overflowNodes = nodeItems.slice(LEGEND_MAX_NODES);
+
+  return (
+    <div className="legend" ref={popoverRef}>
+      {visibleNodes.map(({ key, label, count, color }) => (
+        <span key={key} className="legend-item" title={label}>
+          <span className="legend-dot" style={{ backgroundColor: color }} />
+          <span className="legend-count">{count}</span>
+          {label.length > 10 ? label.slice(0, 10) + '…' : label}
+        </span>
+      ))}
+      {overflowNodes.length > 0 && (
+        <>
+          <button
+            className="legend-more-btn"
+            onClick={() => setShowOverflow((v) => !v)}
+          >
+            +{overflowNodes.length} more
+          </button>
+          {showOverflow && (
+            <div className="legend-popover">
+              {nodeItems.map(({ key, label, count, color }) => (
+                <span key={key} className="legend-item">
+                  <span
+                    className="legend-dot"
+                    style={{ backgroundColor: color }}
+                  />
+                  <span className="legend-count">{count}</span>
+                  {label}
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+      {linkItems.length > 0 && (
+        <>
+          <span className="legend-divider" />
+          {linkItems.map(({ key, label, count, color }) => (
+            <span key={key} className="legend-item">
+              <span
+                className="legend-line"
+                style={{ backgroundColor: color }}
+              />
+              <span className="legend-count">{count}</span>
+              {label}
+            </span>
+          ))}
+        </>
+      )}
+    </div>
+  );
 }
 
 export interface GraphViewerHandle {
@@ -240,6 +365,9 @@ const GraphViewer = memo(
         new Set<string>(['DEPENDS_ON']),
       );
       const [hiddenSubTypes, setHiddenSubTypes] = useState(new Set<string>());
+      const [hiddenCommunities, setHiddenCommunities] = useState(
+        new Set<number>(),
+      );
       // Track whether we've applied the default Package hiding
       const defaultsApplied = useRef(false);
       const [nodeSource, setNodeSource] = useState<NodeSourceResponse | null>(
@@ -279,6 +407,15 @@ const GraphViewer = memo(
           loadGraph();
         }
       };
+
+      // Compute Louvain communities on the full graph (before filtering, so
+      // community assignments are available for the community filter).
+      const {
+        communityAssignments,
+        communityColorMap,
+        communityNames,
+        communityCount,
+      } = useLouvainCommunities(graphData.nodes, graphData.links);
 
       // Derive available types from raw graph data (for filter panel)
       const availableNodeTypes = useMemo(() => {
@@ -338,9 +475,14 @@ const GraphViewer = memo(
         }
       }, [availableSubTypes]);
 
-      // Apply type + sub-type filters to produce the rendered graph.
+      // Apply type + sub-type + community filters to produce the rendered graph.
       const filteredGraphData = useMemo(() => {
         const nodes = graphData.nodes.filter((n) => {
+          // Community filter (when any communities are hidden)
+          if (hiddenCommunities.size > 0) {
+            const cid = communityAssignments[n.id];
+            if (cid !== undefined && hiddenCommunities.has(cid)) return false;
+          }
           const hasSubTypeFilters = availableSubTypes.has(n.type);
           if (hasSubTypeFilters) {
             const sub = getSubType(n);
@@ -372,6 +514,8 @@ const GraphViewer = memo(
         hiddenNodeTypes,
         hiddenLinkTypes,
         hiddenSubTypes,
+        hiddenCommunities,
+        communityAssignments,
         availableSubTypes,
       ]);
 
@@ -584,13 +728,7 @@ const GraphViewer = memo(
       const [colorMode, setColorMode] = useState<'type' | 'community'>('type');
 
       // Build graphology Graph from filtered data (layout uses full dataset)
-      const {
-        graph,
-        layoutReady,
-        communityCount,
-        communityAssignments,
-        communityColorMap,
-      } = useSigmaGraph({
+      const { graph, layoutReady } = useSigmaGraph({
         allNodes: graphData.nodes,
         allLinks: graphData.links,
         nodes: filteredGraphData.nodes,
@@ -602,6 +740,8 @@ const GraphViewer = memo(
         selectedNodeId: selectedNode?.id ?? null,
         isLargeGraph,
         colorMode,
+        communityAssignments,
+        communityColorMap,
       });
 
       const legendItems = useMemo(() => {
@@ -618,6 +758,30 @@ const GraphViewer = memo(
           .sort((a, b) => b.count - a.count);
       }, [filteredGraphData.nodes]);
 
+      // Derive available communities from raw graph data (for filter panel)
+      const availableCommunities = useMemo(() => {
+        const counts = new Map<number, number>();
+        for (const n of graphData.nodes) {
+          const cid = communityAssignments[n.id];
+          if (cid !== undefined) {
+            counts.set(cid, (counts.get(cid) || 0) + 1);
+          }
+        }
+        return [...counts.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .map(([cid, count]) => ({
+            communityId: cid,
+            label: communityNames.get(cid) ?? `Community ${cid}`,
+            count,
+            color: communityColorMap.get(cid) ?? '#64748b',
+          }));
+      }, [
+        graphData.nodes,
+        communityAssignments,
+        communityNames,
+        communityColorMap,
+      ]);
+
       const communityLegendItems = useMemo(() => {
         if (colorMode !== 'community') return [];
         // Group filtered nodes by community
@@ -631,7 +795,7 @@ const GraphViewer = memo(
         return [...counts.entries()]
           .sort((a, b) => b[1] - a[1])
           .map(([cid, count]) => ({
-            label: `Community ${cid}`,
+            label: communityNames.get(cid) ?? `Community ${cid}`,
             count,
             color: communityColorMap.get(cid) ?? '#64748b',
           }));
@@ -640,6 +804,7 @@ const GraphViewer = memo(
         filteredGraphData.nodes,
         communityAssignments,
         communityColorMap,
+        communityNames,
       ]);
 
       const legendLinkItems = useMemo(() => {
@@ -858,6 +1023,18 @@ const GraphViewer = memo(
 
       // --- Main graph viewport ---
 
+      const selectedCommunityId = selectedNode
+        ? communityAssignments[selectedNode.id]
+        : undefined;
+      const selectedCommunityName =
+        selectedCommunityId !== undefined
+          ? communityNames.get(selectedCommunityId)
+          : undefined;
+      const selectedCommunityColor =
+        selectedCommunityId !== undefined
+          ? communityColorMap.get(selectedCommunityId)
+          : undefined;
+
       return (
         <div className="graph-viewport">
           <SidePanel
@@ -930,6 +1107,8 @@ const GraphViewer = memo(
             nodeSource={nodeSource}
             sourceLoading={sourceLoading}
             sourceError={sourceError}
+            communityName={selectedCommunityName}
+            communityColor={selectedCommunityColor}
             selectedLink={selectedLink}
             onSelectNode={(nodeId) => {
               const node = graphDataRef.current.nodes.find(
@@ -944,6 +1123,23 @@ const GraphViewer = memo(
             graphVersion={graphVersion}
             graphNodeIds={graphNodeIds}
             hopMap={hopMap}
+            colorMode={colorMode}
+            communities={availableCommunities}
+            hiddenCommunities={hiddenCommunities}
+            onToggleCommunity={(cid) =>
+              setHiddenCommunities((prev) => {
+                const next = new Set(prev);
+                if (next.has(cid)) next.delete(cid);
+                else next.add(cid);
+                return next;
+              })
+            }
+            onShowAllCommunities={() => setHiddenCommunities(new Set())}
+            onHideAllCommunities={() =>
+              setHiddenCommunities(
+                new Set(availableCommunities.map((c) => c.communityId)),
+              )
+            }
           />
           <header>
             <button
@@ -1142,44 +1338,12 @@ const GraphViewer = memo(
             />
           )}
 
-          <div className="legend">
-            {colorMode === 'community'
-              ? communityLegendItems.map(({ label, count, color }) => (
-                  <span key={label} className="legend-item">
-                    <span
-                      className="legend-dot"
-                      style={{ backgroundColor: color }}
-                    />
-                    <span className="legend-count">{count}</span>
-                    {label}
-                  </span>
-                ))
-              : legendItems.map(({ type, count, color }) => (
-                  <span key={type} className="legend-item">
-                    <span
-                      className="legend-dot"
-                      style={{ backgroundColor: color }}
-                    />
-                    <span className="legend-count">{count}</span>
-                    {type}
-                  </span>
-                ))}
-            {colorMode === 'type' && legendLinkItems.length > 0 && (
-              <>
-                <span className="legend-divider" />
-                {legendLinkItems.map(({ type, count, color }) => (
-                  <span key={type} className="legend-item">
-                    <span
-                      className="legend-line"
-                      style={{ backgroundColor: color }}
-                    />
-                    <span className="legend-count">{count}</span>
-                    {type}
-                  </span>
-                ))}
-              </>
-            )}
-          </div>
+          <GraphLegend
+            colorMode={colorMode}
+            legendItems={legendItems}
+            communityLegendItems={communityLegendItems}
+            legendLinkItems={legendLinkItems}
+          />
 
           {!layoutReady && !isEmpty && (
             <div

--- a/ui/src/components/NodeDetailsPanel.css
+++ b/ui/src/components/NodeDetailsPanel.css
@@ -34,6 +34,11 @@
   flex-shrink: 0;
 }
 
+.community-badge {
+  background: none !important;
+  padding: 1px 8px;
+}
+
 /* ── Generic detail row (used in properties) ── */
 .detail-row {
   display: flex;

--- a/ui/src/components/NodeDetailsPanel.tsx
+++ b/ui/src/components/NodeDetailsPanel.tsx
@@ -169,6 +169,8 @@ interface NodeDetailsPanelProps {
   nodeSource: NodeSourceResponse | null;
   sourceLoading: boolean;
   sourceError: string | null;
+  communityName?: string;
+  communityColor?: string;
 }
 
 type PreviewTab = 'rendered' | 'raw';
@@ -188,6 +190,8 @@ export default function NodeDetailsPanel({
   nodeSource,
   sourceLoading,
   sourceError,
+  communityName,
+  communityColor,
 }: NodeDetailsPanelProps) {
   const [previewTab, setPreviewTab] = useState<PreviewTab>('rendered');
   const color = getNodeColor(node.type);
@@ -210,6 +214,17 @@ export default function NodeDetailsPanel({
         <span className="type-badge" style={{ backgroundColor: color }}>
           {node.type}
         </span>
+        {communityName && (
+          <span
+            className="type-badge community-badge"
+            style={{
+              color: communityColor ?? '#64748b',
+              border: `1.5px solid ${communityColor ?? '#64748b'}`,
+            }}
+          >
+            {communityName}
+          </span>
+        )}
         <span className="detail-name">{node.name || 'N/A'}</span>
         {sourceUri && (
           <a

--- a/ui/src/components/SidePanel.tsx
+++ b/ui/src/components/SidePanel.tsx
@@ -18,6 +18,13 @@ interface SubTypeEntry {
   count: number;
 }
 
+interface CommunityEntry {
+  communityId: number;
+  label: string;
+  count: number;
+  color: string;
+}
+
 interface SidePanelProps {
   /* Filter props — forwarded to FilterPanel */
   nodeTypes: TypeEntry[];
@@ -34,12 +41,24 @@ interface SidePanelProps {
   onShowAllLinks: () => void;
   onHideAllLinks: () => void;
 
+  /* Community filter props */
+  colorMode?: 'type' | 'community';
+  communities?: CommunityEntry[];
+  hiddenCommunities?: Set<number>;
+  onToggleCommunity?: (cid: number) => void;
+  onShowAllCommunities?: () => void;
+  onHideAllCommunities?: () => void;
+
   /* Node details props */
   selectedNode: SelectedNode | null;
   nodeSource: NodeSourceResponse | null;
   sourceLoading: boolean;
   sourceError: string | null;
   onCloseDetails: () => void;
+  /** Community name for the selected node */
+  communityName?: string;
+  /** Community color for the selected node */
+  communityColor?: string;
 
   /* Edge details props */
   selectedLink: SelectedEdge | null;
@@ -67,8 +86,16 @@ export default function SidePanel({
   onHideAllNodes,
   onShowAllLinks,
   onHideAllLinks,
+  colorMode,
+  communities,
+  hiddenCommunities,
+  onToggleCommunity,
+  onShowAllCommunities,
+  onHideAllCommunities,
   selectedNode,
   nodeSource,
+  communityName,
+  communityColor,
   sourceLoading,
   sourceError,
   onCloseDetails,
@@ -168,6 +195,12 @@ export default function SidePanel({
           onHideAllNodes={onHideAllNodes}
           onShowAllLinks={onShowAllLinks}
           onHideAllLinks={onHideAllLinks}
+          colorMode={colorMode}
+          communities={communities}
+          hiddenCommunities={hiddenCommunities}
+          onToggleCommunity={onToggleCommunity}
+          onShowAllCommunities={onShowAllCommunities}
+          onHideAllCommunities={onHideAllCommunities}
         />
       </div>
       <div
@@ -190,6 +223,8 @@ export default function SidePanel({
               node={selectedNode}
               nodeSource={nodeSource}
               sourceLoading={sourceLoading}
+              communityName={communityName}
+              communityColor={communityColor}
               sourceError={sourceError}
             />
           ) : selectedLink ? (

--- a/ui/src/config/graphLayout.ts
+++ b/ui/src/config/graphLayout.ts
@@ -53,6 +53,8 @@ export const ZOOM_SIZE_EXPONENT = 0.9;
 export const FORCE_LINK_DISTANCE = 200; // target distance between linked nodes
 export const FORCE_CHARGE_STRENGTH = -200; // repulsion between all nodes (negative = repel)
 export const FORCE_SIMULATION_TICKS = 80; // total simulation iterations (enough to seed FA2)
+export const FORCE_CLUSTER_STRENGTH = 0.3; // how strongly nodes pull toward community centroid (0-1)
+export const FORCE_CLUSTER_TICKS = 40; // additional ticks for clustering phase
 
 // ─── ForceAtlas2 Live Physics ───────────────────────────────────────────
 // Runs after d3-force initial positioning to refine the layout.

--- a/ui/src/hooks/d3LayoutWorker.ts
+++ b/ui/src/hooks/d3LayoutWorker.ts
@@ -9,6 +9,8 @@ import {
   forceLink,
   forceManyBody,
   forceCenter,
+  forceX,
+  forceY,
 } from 'd3-force';
 
 interface SimNode {
@@ -25,10 +27,13 @@ interface SimLink {
 export interface LayoutRequest {
   nodeIds: string[];
   links: SimLink[];
+  communities?: Record<string, number>;
   config: {
     linkDistance: number;
     chargeStrength: number;
     ticks: number;
+    clusterStrength?: number;
+    clusterTicks?: number;
   };
 }
 
@@ -37,10 +42,11 @@ export interface LayoutResponse {
 }
 
 self.onmessage = (e: MessageEvent<LayoutRequest>) => {
-  const { nodeIds, links, config } = e.data;
+  const { nodeIds, links, communities, config } = e.data;
 
   const simNodes: SimNode[] = nodeIds.map((id) => ({ id }));
 
+  // Phase 1: Standard force layout
   const simulation = forceSimulation(simNodes)
     .force(
       'link',
@@ -54,6 +60,64 @@ self.onmessage = (e: MessageEvent<LayoutRequest>) => {
 
   for (let i = 0; i < config.ticks; i++) {
     simulation.tick();
+  }
+
+  // Phase 2: Community clustering
+  if (communities && config.clusterStrength) {
+    // Compute centroid of each community from Phase 1 positions
+    const centroidSums = new Map<
+      number,
+      { x: number; y: number; count: number }
+    >();
+    for (const node of simNodes) {
+      const cid = communities[node.id];
+      if (cid === undefined) continue;
+      const entry = centroidSums.get(cid) || { x: 0, y: 0, count: 0 };
+      entry.x += node.x ?? 0;
+      entry.y += node.y ?? 0;
+      entry.count += 1;
+      centroidSums.set(cid, entry);
+    }
+    const centroids = new Map<number, { x: number; y: number }>();
+    for (const [cid, { x, y, count }] of centroidSums) {
+      centroids.set(cid, { x: x / count, y: y / count });
+    }
+
+    // Build lookup: nodeId → centroid
+    const nodeCentroid = new Map<string, { x: number; y: number }>();
+    for (const node of simNodes) {
+      const cid = communities[node.id];
+      if (cid !== undefined && centroids.has(cid)) {
+        nodeCentroid.set(node.id, centroids.get(cid)!);
+      }
+    }
+
+    // Phase 2 simulation: keep link forces + add clustering pull with softer repulsion
+    const sim2 = forceSimulation(simNodes)
+      .force(
+        'link',
+        forceLink<SimNode, SimLink>(links)
+          .id((d) => d.id)
+          .distance(config.linkDistance),
+      )
+      .force('charge', forceManyBody().strength(config.chargeStrength * 0.5))
+      .force(
+        'clusterX',
+        forceX<SimNode>((d) => nodeCentroid.get(d.id)?.x ?? 0).strength(
+          config.clusterStrength,
+        ),
+      )
+      .force(
+        'clusterY',
+        forceY<SimNode>((d) => nodeCentroid.get(d.id)?.y ?? 0).strength(
+          config.clusterStrength,
+        ),
+      )
+      .stop();
+
+    for (let i = 0; i < (config.clusterTicks ?? 40); i++) {
+      sim2.tick();
+    }
   }
 
   const positions: [string, number, number][] = simNodes.map((n) => [

--- a/ui/src/hooks/useSigmaGraph.ts
+++ b/ui/src/hooks/useSigmaGraph.ts
@@ -6,6 +6,7 @@ import { getNodeColor } from '../chat/results/nodeColors';
 import { getLinkColor } from '../chat/results/linkColors';
 import {
   buildCommunityColorMap,
+  buildCommunityNames,
   getCommunityColor,
 } from '../chat/results/communityColors';
 import type { LayoutRequest, LayoutResponse } from './d3LayoutWorker';
@@ -24,19 +25,98 @@ import {
   FORCE_LINK_DISTANCE,
   FORCE_CHARGE_STRENGTH,
   FORCE_SIMULATION_TICKS,
+  FORCE_CLUSTER_STRENGTH,
+  FORCE_CLUSTER_TICKS,
   LOUVAIN_RESOLUTION,
 } from '../config/graphLayout';
+
+// ─── Community Detection Hook ────────────────────────────────────────
+
+export interface LouvainResult {
+  communityAssignments: Record<string, number>;
+  communityColorMap: Map<number, string>;
+  communityNames: Map<number, string>;
+  communityCount: number;
+}
+
+/**
+ * Compute Louvain communities on the full (unfiltered) graph.
+ * Extracted so callers can use community data before filtering.
+ */
+export function useLouvainCommunities(
+  allNodes: GraphNode[],
+  allLinks: GraphLink[],
+): LouvainResult {
+  return useMemo(() => {
+    if (allNodes.length === 0) {
+      return {
+        communityAssignments: {} as Record<string, number>,
+        communityColorMap: new Map<number, string>(),
+        communityNames: new Map<number, string>(),
+        communityCount: 0,
+      };
+    }
+
+    const tempGraph = new UndirectedGraph();
+    const nodeIdSet = new Set<string>();
+
+    for (const node of allNodes) {
+      if (!nodeIdSet.has(node.id)) {
+        tempGraph.addNode(node.id);
+        nodeIdSet.add(node.id);
+      }
+    }
+
+    for (const link of allLinks) {
+      const source =
+        typeof link.source === 'string'
+          ? link.source
+          : (link.source as GraphNode).id;
+      const target =
+        typeof link.target === 'string'
+          ? link.target
+          : (link.target as GraphNode).id;
+      if (source === target) continue;
+      if (!nodeIdSet.has(source) || !nodeIdSet.has(target)) continue;
+
+      if (tempGraph.hasEdge(source, target)) {
+        const w =
+          (tempGraph.getEdgeAttribute(source, target, 'weight') as number) ?? 1;
+        tempGraph.setEdgeAttribute(source, target, 'weight', w + 1);
+      } else {
+        tempGraph.addEdge(source, target, { weight: 1 });
+      }
+    }
+
+    const assignments = louvain(tempGraph, {
+      resolution: LOUVAIN_RESOLUTION,
+      getEdgeWeight: 'weight',
+    });
+    const colorMap = buildCommunityColorMap(assignments);
+    const nameMap = buildCommunityNames(assignments, allNodes);
+    const count = new Set(Object.values(assignments)).size;
+
+    if (process.env.NODE_ENV === 'development') {
+      console.log(
+        `[graph] Louvain: ${count} communities from ${allNodes.length} nodes`,
+      );
+    }
+
+    return {
+      communityAssignments: assignments,
+      communityColorMap: colorMap,
+      communityNames: nameMap,
+      communityCount: count,
+    };
+  }, [allNodes, allLinks]);
+}
+
+// ─── Graph Layout Hook ──────────────────────────────────────────────
 
 export interface UseSigmaGraphResult {
   graph: Graph;
   /** True once d3-force layout has been applied and graph is built */
   layoutReady: boolean;
-  /** Number of detected Louvain communities */
-  communityCount: number;
-  /** Node ID → community ID assignments */
-  communityAssignments: Record<string, number>;
-  /** Community ID → color */
-  communityColorMap: Map<number, string>;
 }
 
 interface UseSigmaGraphOptions {
@@ -55,6 +135,9 @@ interface UseSigmaGraphOptions {
   isLargeGraph: boolean;
   /** Color nodes by type or community */
   colorMode: 'type' | 'community';
+  /** Pre-computed community data (from useLouvainCommunities) */
+  communityAssignments: Record<string, number>;
+  communityColorMap: Map<number, string>;
 }
 
 const STRUCTURAL_TYPES = new Set(['Repository', 'Directory', 'Package']);
@@ -119,6 +202,8 @@ export function useSigmaGraph({
   selectedNodeId,
   isLargeGraph,
   colorMode,
+  communityAssignments,
+  communityColorMap,
 }: UseSigmaGraphOptions): UseSigmaGraphResult {
   // Stable graph instance — created once, never replaced.
   const graph = useMemo(() => new Graph({ multi: true, type: 'directed' }), []);
@@ -138,73 +223,6 @@ export function useSigmaGraph({
   // True once d3-force positions are available
   const layoutReady = positions !== null && positions.size > 0;
 
-  // Compute Louvain communities on the full (unfiltered) graph.
-  // Built on an undirected copy — Louvain expects undirected edges.
-  // Includes ALL edge types for full coupling signal.
-  const { communityAssignments, communityColorMap, communityCount } =
-    useMemo(() => {
-      if (allNodes.length === 0) {
-        return {
-          communityAssignments: {} as Record<string, number>,
-          communityColorMap: new Map<number, string>(),
-          communityCount: 0,
-        };
-      }
-
-      const tempGraph = new UndirectedGraph();
-      const nodeIdSet = new Set<string>();
-
-      for (const node of allNodes) {
-        if (!nodeIdSet.has(node.id)) {
-          tempGraph.addNode(node.id);
-          nodeIdSet.add(node.id);
-        }
-      }
-
-      for (const link of allLinks) {
-        const source =
-          typeof link.source === 'string'
-            ? link.source
-            : (link.source as GraphNode).id;
-        const target =
-          typeof link.target === 'string'
-            ? link.target
-            : (link.target as GraphNode).id;
-        // Skip self-loops and missing nodes
-        if (source === target) continue;
-        if (!nodeIdSet.has(source) || !nodeIdSet.has(target)) continue;
-
-        // Merge parallel edges as weight
-        if (tempGraph.hasEdge(source, target)) {
-          const w =
-            (tempGraph.getEdgeAttribute(source, target, 'weight') as number) ??
-            1;
-          tempGraph.setEdgeAttribute(source, target, 'weight', w + 1);
-        } else {
-          tempGraph.addEdge(source, target, { weight: 1 });
-        }
-      }
-
-      const assignments = louvain(tempGraph, {
-        resolution: LOUVAIN_RESOLUTION,
-        getEdgeWeight: 'weight',
-      });
-      const colorMap = buildCommunityColorMap(assignments);
-      const count = new Set(Object.values(assignments)).size;
-
-      if (process.env.NODE_ENV === 'development') {
-        console.log(
-          `[graph] Louvain: ${count} communities from ${allNodes.length} nodes`,
-        );
-      }
-
-      return {
-        communityAssignments: assignments,
-        communityColorMap: colorMap,
-        communityCount: count,
-      };
-    }, [allNodes, allLinks]);
-
   // Launch worker computation when allNodes/allLinks change.
   useEffect(() => {
     if (allNodes.length === 0) {
@@ -213,7 +231,7 @@ export function useSigmaGraph({
     }
 
     // Reset — new data arriving, layout not ready yet
-    setPositions(null); // eslint-disable-line react-hooks/set-state-in-effect -- reset so layoutReady gates graph build
+    setPositions(null);
 
     // Prepare DEFINED_IN links for the worker
     const nodeIds = allNodes.map((n) => n.id);
@@ -278,10 +296,13 @@ export function useSigmaGraph({
     worker.postMessage({
       nodeIds,
       links: simLinks,
+      communities: communityAssignments,
       config: {
         linkDistance: FORCE_LINK_DISTANCE,
         chargeStrength: FORCE_CHARGE_STRENGTH,
         ticks: FORCE_SIMULATION_TICKS,
+        clusterStrength: FORCE_CLUSTER_STRENGTH,
+        clusterTicks: FORCE_CLUSTER_TICKS,
       },
     } satisfies LayoutRequest);
 
@@ -291,7 +312,7 @@ export function useSigmaGraph({
         workerRef.current = null;
       }
     };
-  }, [allNodes, allLinks]);
+  }, [allNodes, allLinks, communityAssignments]);
 
   // Build graph only once positions are ready, and when filtered data changes.
   // Uses graph.import() for bulk construction.
@@ -443,8 +464,5 @@ export function useSigmaGraph({
   return {
     graph,
     layoutReady,
-    communityCount,
-    communityAssignments,
-    communityColorMap,
   };
 }


### PR DESCRIPTION
## Add Louvain community detection and visualization
🆕 **New Feature** · ✨ **Improvement**

Adds Louvain algorithm-based community detection to the graph viewer with visualization, filtering, and clustering layout enhancements. Nodes can now be colored by community membership, with communities auto-labeled and filterable in the side panel.

### Complexity
🟠 High · `12 files changed, 962 insertions(+), 39 deletions(-)`

This PR introduces a multi-layered feature spanning algorithmic processing (Louvain), layout physics (two-phase force simulation), state management (community filtering, color mode toggle), and UI changes (legend overflow, filter panel, node details badge). The community detection runs on the full graph and must be synchronized with the filtering pipeline — community assignments are computed before filtering but must be correctly referenced during filtering, legend rendering, and node coloring. The two-phase layout worker modification changes how all graphs are positioned and adds complexity to the force simulation logic. The legend overflow UI adds interaction state (popover toggle) that must coordinate with click-outside dismissal. While each piece is moderately sized, they interact across data flow (community computation → layout → filtering → rendering) in ways that require understanding the full pipeline to review safely. Missing tests increase risk.

### Tests
🧪 No tests included — adds untested community detection, layout, and UI filtering logic.

### Note
⚠️ This PR builds on several prior commits in the branch (`684b111`, `ab694ca`, `2136e3f`) that incrementally added Louvain detection. Review the full branch history to understand the evolution.

### Review focus
Pay particular attention to the following areas:

- **Community-filter sequencing** — verify community assignments are available before filtering applies community hiding, and that hidden communities correctly hide nodes without breaking layout or legend
- **Two-phase layout determinism** — confirm the clustering phase doesn't destabilize previously computed positions or create layout jank when toggling color modes
- **Legend popover dismissal** — check the click-outside handler correctly cleans up and doesn't interfere with legend item clicks or graph interactions
- **Color mode toggle state sync** — ensure switching modes correctly updates node colors, legend items, and filter panel without stale references to old color maps

---

<details>
<summary><strong>Additional details</strong></summary>

### Community detection pipeline

The `useLouvainCommunities` hook runs **once** on the raw unfiltered graph (`allNodes`, `allLinks`) and produces `communityAssignments` (node ID → community ID), `communityColorMap` (community ID → hex color), and `communityNames` (community ID → label). These are computed in `GraphViewer` before filtering and passed down to:
- `useSigmaGraph` — uses assignments to enable community-aware layout clustering
- `FilterPanel` — builds `availableCommunities` list with counts and colors
- Node filtering logic — checks `hiddenCommunities` set to exclude nodes

### Layout clustering mechanics

The d3 layout worker now has two phases:
1. **Standard force-directed** — link distance, charge repulsion, center gravity
2. **Community clustering** (new) — `forceX`/`forceY` pull nodes toward their community's centroid with strength `FORCE_CLUSTER_STRENGTH` (0.3), running for `FORCE_CLUSTER_TICKS` (40) iterations. Centroids are computed from Phase 1 final positions, ensuring clustering doesn't fight initial layout

Phase 2 runs **only when** `communities` and `config.clusterStrength` are provided, preserving backward compatibility.

### Naming strategy priority

`buildCommunityNames` tries these heuristics in order:
1. **Container nodes** — Module > Package > Directory > Namespace (highest priority structural type wins)
2. **Path prefix** — longest common prefix trimmed to last `/` or `.` separator
3. **Hub node** — node name appearing as substring in most other members (e.g., class name for its methods)
4. **Dominant type** — pluralized type name (e.g., "Functions") as fallback

A dedup pass appends hub names or numeric suffixes to resolve collisions.

### Color mode toggle interaction

Switching `colorMode` triggers a full graph rebuild (see `useSigmaGraph` deps) because node `color` attributes must be recomputed. The graph stores both `_typeColor` and `_communityColor` on every node so the highlight effect logic can access the correct base color without re-querying maps. The legend and filter panel reactively update via `useMemo` on `colorMode`.

</details>