### PR TITLE
feat(ui): add Star on GitHub button

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -767,6 +767,32 @@ header h1 {
   border-color: var(--primary);
 }
 
+/* GitHub Star Button */
+.github-star-btn {
+  pointer-events: auto;
+  background: color-mix(in oklch, var(--card) 80%, transparent);
+  border: 1px solid color-mix(in oklch, var(--border) 30%, transparent);
+  color: var(--muted-foreground);
+  height: 36px;
+  padding: 0 12px;
+  border-radius: calc(var(--radius) + 2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.github-star-btn:hover {
+  background: color-mix(in oklch, var(--primary) 10%, transparent);
+  color: var(--primary);
+  border-color: color-mix(in oklch, var(--primary) 30%, transparent);
+}
+
 /* Chat Panel */
 .chat-toggle-btn {
   pointer-events: auto;

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -1281,6 +1281,28 @@ const GraphViewer = memo(
               </svg>
             </button>
 
+            <a
+              className="github-star-btn"
+              href="https://github.com/opentrace/opentrace"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Star on GitHub"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+              </svg>
+              <span>Star</span>
+            </a>
+
             <button
               className={`settings-toggle-btn ${showSettings ? 'active' : ''}`}
               onClick={onToggleSettings}


### PR DESCRIPTION
## Add GitHub star button to header toolbar
🆕 **New Feature**

Adds a "Star on GitHub" button to the header toolbar linking to the opentrace repository. The button uses a star icon and matches the existing UI style with semi-transparent theming.

### Complexity
🟢 Trivial · `2 files changed, 48 insertions(+)`

Adds a single UI element to the header toolbar — reviewers can verify the link and styling in seconds.

---

<details>
<summary><strong>Additional details</strong></summary>

The button is positioned in the header toolbar between the chat toggle and settings button. It uses a semi-transparent background with subtle border styling that matches the existing button pattern in the UI, and the hover state applies the theme's primary color for visual feedback.

The CSS uses `color-mix()` with oklch color space to create consistent transparency effects that work across the app's theme system.

</details>
<!-- opentrace:jid=j-036b22fb-7f0e-4a5c-aacf-1460fea4983a|sha=3e2369da12aaf2bbabfcd37d2a57004f7b764ca1 -->