### PR TITLE
fix(ci): add contents:read permission and fix checkout action version

### DIFF
--- a/.github/workflows/ai-coauthor-check.yml
+++ b/.github/workflows/ai-coauthor-check.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -12,7 +13,7 @@ jobs:
     name: Check for AI co-authors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Added `contents: read` to the workflow permissions block — without it, the explicit `permissions` declaration revoked the default read access, causing "repository not found" on checkout
- Fixed `actions/checkout@v6` → `@v4` (v6 doesn't exist)

## Test plan
- [ ] Re-run the "Check for AI co-authors" workflow on an open PR and verify checkout succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)