### PR TITLE
docs: add open-source README, CONTRIBUTING, and SECURITY guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to OpenTrace
+
+Thanks for your interest in contributing to OpenTrace! This guide will help you get started.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/opentrace.git
+   cd opentrace
+   ```
+3. Install dependencies:
+   ```bash
+   make install
+   ```
+4. Create a branch for your work:
+   ```bash
+   git checkout -b my-feature
+   ```
+
+## Development Workflow
+
+### Running Locally
+
+```bash
+make ui    # Start dev server at http://localhost:5173
+```
+
+### Testing
+
+```bash
+make test  # Run all tests
+make lint  # Run linter + format check
+```
+
+All pull requests must pass CI checks (tests, lint, formatting, license headers).
+
+### Code Style
+
+- **TypeScript** — Prettier for formatting, ESLint for linting
+- Run `make fmt` before committing to auto-format
+- License headers are required on all source files — run `make license-fix` to add them automatically
+
+### Commit Messages
+
+Use concise, descriptive commit messages:
+
+- `fix: resolve duplicate node emission in pipeline`
+- `feat: add summarization stage to indexing pipeline`
+- `chore: update dependencies`
+- `docs: add contributing guide`
+
+## Pull Requests
+
+1. Keep PRs focused — one feature or fix per PR
+2. Include tests for new functionality
+3. Update documentation if behavior changes
+4. Ensure CI passes before requesting review
+5. Link related issues in the PR description
+
+## Project Structure
+
+```
+ui/                   — React/TypeScript frontend
+  src/pipeline/       — Indexing pipeline (scanning → processing → resolving)
+  src/runner/         — Browser-based parser workers
+  src/store/          — Graph store implementations (KuzuDB WASM, in-memory)
+  src/components/     — React components
+  src/chat/           — Chat agent and graph tools
+proto/                — Protobuf definitions
+claude-code-plugin/   — Claude Code plugin configuration
+```
+
+See `ui/src/pipeline/CLAUDE.md` for detailed pipeline architecture documentation.
+
+## Reporting Issues
+
+- Use [GitHub Issues](https://github.com/opentrace/opentrace/issues) for bug reports and feature requests
+- Include steps to reproduce for bugs
+- Check existing issues before creating a new one
+
+## Code of Conduct
+
+Be respectful, constructive, and inclusive. We're all here to build something useful together.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # OpenTrace
 
+[![CI](https://github.com/opentrace/opentrace/actions/workflows/ci.yml/badge.svg)](https://github.com/opentrace/opentrace/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
 A knowledge graph that maps your codebase structure, service architecture, and system relationships — then exposes it all through MCP so AI tools can understand your systems.
+
+## Quick Start
+
+```bash
+git clone https://github.com/opentrace/opentrace.git
+cd opentrace
+make install
+make ui
+```
+
+Open [http://localhost:5173](http://localhost:5173), add a GitHub repo, and explore the graph.
+
+## What It Does
+
+OpenTrace indexes source code directly in your browser — no server required. Point it at a GitHub or GitLab repo and it will:
+
+1. **Parse** every file using tree-sitter WASM grammars (12 languages)
+2. **Extract** classes, functions, imports, and call relationships
+3. **Build** a knowledge graph stored in KuzuDB WASM (embedded graph database)
+4. **Summarize** every node using template-based identifier analysis
+5. **Expose** the graph to an in-app chat agent via MCP tools
 
 ## Architecture
 
@@ -20,23 +44,27 @@ A knowledge graph that maps your codebase structure, service architecture, and s
 └──────────────────────────────────────────────────────┘
 ```
 
-> **Planned:** A Go API server (MCP endpoint, persistent graph store) and a
-> Python agent (LangGraph pipeline, data loaders) are under development but not
-> yet included in the open-source repo.
+> **Planned:** A Go API server (MCP endpoint, persistent graph store) and a Python agent (LangGraph pipeline, data loaders) are under development but not yet included in the open-source repo.
 
-## Quick Start
+## Supported Languages
 
-```bash
-# Clone and install
-git clone https://github.com/opentrace/opentrace.git
-cd opentrace
-make install   # installs npm dependencies
+| Full Extraction (symbols + calls + imports) | Structural Extraction (symbols only) |
+|---|---|
+| Python, TypeScript/JavaScript, Go | Rust, Java, Kotlin, C#, C/C++, Ruby, Swift |
 
-# Start the UI
-make ui
-```
+Config and data files (JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash) are indexed as file nodes.
 
-Open [http://localhost:5173](http://localhost:5173), point the indexer at a GitHub repo, and explore the graph.
+## Graph Tools
+
+The built-in chat agent has access to these tools:
+
+| Tool | Description |
+|------|-------------|
+| `search_graph` | Full-text search across nodes by name or properties |
+| `list_nodes` | List nodes by type with optional property filters |
+| `get_node` | Get full details of a single node by ID |
+| `traverse_graph` | BFS traversal to discover connected nodes |
+| `load_source` | Fetch source code for an indexed file or symbol |
 
 ## Repository Structure
 
@@ -44,86 +72,44 @@ Open [http://localhost:5173](http://localhost:5173), point the indexer at a GitH
 ui/                   — React/TypeScript frontend (graph explorer + browser indexer)
 proto/                — Protobuf definitions (shared API contracts)
 claude-code-plugin/   — Claude Code plugin (MCP server config)
-tests/                — Cross-validation and integration test fixtures
 ```
-
-## Components
-
-### `ui/` — React/TypeScript Frontend
-
-Graph explorer with a built-in browser-based code indexer. The indexer runs tree-sitter WASM parsers inside a Web Worker to extract symbols, calls, and relationships directly in the browser — no server-side processing needed.
-
-The graph is stored in-browser using **KuzuDB WASM** — an embedded graph database compiled to WebAssembly. An in-memory store is also available as a fallback (no WASM, no COOP/COEP headers required).
-
-```bash
-cd ui
-npm install
-npm run dev
-```
-
-### `proto/` — Protobuf Definitions
-
-Shared API contracts for the platform. Currently generates TypeScript types for the UI:
-
-```bash
-make proto   # generates TS types (py/go targets run when agent/api dirs exist)
-```
-
-## Graph Tools
-
-The UI exposes these graph tools to the built-in chat agent:
-
-| Tool | Description |
-|------|-------------|
-| `search_graph` | Full-text search across graph nodes by name or properties |
-| `list_nodes` | List nodes of a specific type with optional property filters |
-| `get_node` | Get full details of a single node by its ID |
-| `traverse_graph` | BFS traversal from a node to discover connected nodes and relationships |
-| `load_source` | Fetch source code for an indexed file or symbol |
-
-## Claude Code Plugin
-
-OpenTrace ships a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins) that connects Claude to an OpenTrace MCP server.
-
-The plugin is configured in `claude-code-plugin/.mcp.json` and points to `http://localhost:8080/mcp`.
-
-## Supported Languages
-
-The browser-based indexer parses source code using tree-sitter WASM grammars. Languages with **full extraction** get symbol-level detail (classes, functions, calls, imports). Others get **structural extraction** (classes and functions, no call graph).
-
-| Full Extraction | Structural Extraction |
-|---|---|
-| Python, TypeScript/JavaScript, Go | Rust, Java, Kotlin, C#, C/C++, Ruby, Swift |
-
-Config and data files (JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash) are indexed as file nodes.
 
 ## Development
 
-```bash
-# Build the UI
-make build
+### Prerequisites
 
-# Run tests
-make test
+- Node.js 22+ (see `ui/.nvmrc`)
+- npm
 
-# Format code
-make fmt
-
-# Lint
-make lint
-
-# Generate protobuf code
-make proto
-```
-
-### Static / Browser-Only Build
-
-Build the UI without an API server dependency (all indexing runs in-browser):
+### Commands
 
 ```bash
-make ui-build-static
+make install          # Install dependencies
+make ui               # Start dev server (localhost:5173)
+make build            # Production build
+make test             # Run tests
+make fmt              # Format code
+make lint             # Lint
+make proto            # Generate protobuf types
+make ui-build-static  # Static build (no API server dependency)
 ```
 
-### Graph Node Types
+### Running Tests
 
-`Service` `Repo` `Repository` `Class` `Module` `Function` `File` `Directory` `Cluster` `Namespace` `Deployment` `InstrumentedService` `Span` `Log` `Metric` `Endpoint` `Database` `DBTable`
+```bash
+cd ui
+npm test              # Run all tests
+npm run lint          # ESLint + Prettier check
+```
+
+## Claude Code Plugin
+
+OpenTrace ships a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins) that connects Claude to an OpenTrace MCP server. See `claude-code-plugin/` for configuration.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in OpenTrace, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please email **security@opentrace.ai** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+We will acknowledge receipt within 48 hours and aim to provide a fix or mitigation within 7 days for critical issues.
+
+## Scope
+
+OpenTrace runs entirely in the browser. The primary attack surface is:
+
+- **GitHub/GitLab API tokens** — stored in browser localStorage, used to fetch repository contents
+- **KuzuDB WASM** — embedded database running in-browser
+- **tree-sitter WASM parsers** — parse untrusted source code in a Web Worker
+
+## Supported Versions
+
+We provide security fixes for the latest release only.


### PR DESCRIPTION
## Add open-source project documentation
📝 **Docs**

This PR adds foundational documentation for the open-source release: a contributing guide, security policy, and restructured README with quick start instructions, architecture overview, and development commands.

The README is reorganized to prioritize onboarding — quick start at the top, followed by what the project does, supported languages, and graph tools. The previous structure buried the setup instructions below architecture details.

### Complexity
🟢 Low · `3 files changed, 180 insertions(+), 77 deletions(-)`

This is purely documentation — no code, no behavior changes. The new files follow standard OSS templates (contributing guide, security policy). The README restructuring is editorial and focused on improving first-impression clarity.
<!-- opentrace:jid=a15ed480-4664-47b8-9d72-7f13159caeba|sha=db1c52685bc03d964fcc2ac20a03da26eb2f3bcd -->