### PR TITLE
Publish opentraceai to PyPI on release, main, and PR

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,43 @@
+name: Publish Dev Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agent/**"
+
+jobs:
+  publish-dev:
+    name: Publish dev to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/opentraceai/
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set dev version
+        working-directory: agent
+        run: |
+          BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${BASE_VERSION}.dev${GITHUB_RUN_NUMBER}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"${DEV_VERSION}\"/" src/opentrace_agent/__init__.py
+          echo "Published version: ${DEV_VERSION}"
+
+      - name: Build package
+        working-directory: agent
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: agent/dist/

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,59 @@
+name: Publish Preview Release
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    paths:
+      - "agent/**"
+
+jobs:
+  publish-preview:
+    name: Publish preview to PyPI
+    if: contains(github.event.pull_request.labels.*.name, 'publish-preview')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pull-requests: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/opentraceai/
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set preview version
+        working-directory: agent
+        run: |
+          BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          PREVIEW_VERSION="${BASE_VERSION}rc${{ github.event.pull_request.number }}.dev${GITHUB_RUN_NUMBER}"
+          sed -i "s/^version = .*/version = \"${PREVIEW_VERSION}\"/" pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"${PREVIEW_VERSION}\"/" src/opentrace_agent/__init__.py
+          echo "PREVIEW_VERSION=${PREVIEW_VERSION}" >> "$GITHUB_ENV"
+          echo "Published version: ${PREVIEW_VERSION}"
+
+      - name: Build package
+        working-directory: agent
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: agent/dist/
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `📦 Preview published: \`opentraceai==${process.env.PREVIEW_VERSION}\`\n\n\`\`\`bash\npip install opentraceai==${process.env.PREVIEW_VERSION}\n\`\`\``
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,37 @@ jobs:
         with:
           files: opentrace-ui-${{ github.ref_name }}.zip
           generate_release_notes: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/opentraceai/
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set version from tag
+        working-directory: agent
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"${VERSION}\"/" src/opentrace_agent/__init__.py
+
+      - name: Build package
+        working-directory: agent
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: agent/dist/

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
-name = "opentrace-agent"
+name = "opentraceai"
 version = "0.1.0"
-description = "OpenTrace Python agent for collecting and reporting traces"
+description = "OpenTrace Python agent — maps system architecture, code structure, and service relationships into a knowledge graph"
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.12"
+authors = [
+    { name = "OpenTrace Contributors" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
     "langchain-core>=0.3",
     "langgraph>=0.2",
@@ -30,6 +43,11 @@ summarization = [
     "optimum[onnxruntime]>=1.17",
     "transformers>=4.38",
 ]
+
+[project.urls]
+Homepage = "https://github.com/opentrace/opentrace"
+Repository = "https://github.com/opentrace/opentrace"
+Issues = "https://github.com/opentrace/opentrace/issues"
 
 [project.scripts]
 opentrace = "opentrace_agent.cli.main:app"

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 ]
 
 [[package]]
-name = "opentrace-agent"
+name = "opentraceai"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Add PyPI publishing workflows and package metadata
🆕 **New Feature** · 🔧 **Chore**

Adds automated PyPI publishing for the `opentraceai` package via three workflows: stable releases on version tags, dev releases on every main commit, and preview releases for labeled PRs. Also renames the package from `opentrace-agent` to `opentraceai` and adds standard PyPI metadata.

### Complexity
🟡 Moderate · `5 files changed, 157 insertions(+), 3 deletions(-)`

Three new workflows with version-generation logic that mutates source files, plus a package rename that affects imports and installation commands. The workflows use OIDC authentication and environment protection, which requires correct GitHub configuration. The sed-based version injection is straightforward but must handle both pyproject.toml and __init__.py correctly to avoid breaking the build.

### Tests
🧪 No tests applicable — adds CI/CD workflows and package metadata.

### Note
⚠️ This PR renames the package from `opentrace-agent` to `opentraceai`. Any existing installations or references will need to be updated.

### Review focus
Pay particular attention to the following areas:

- **Version mutation logic** — verify the sed commands correctly update both pyproject.toml and __init__.py without breaking syntax
- **PyPI environment configuration** — confirm OIDC permissions and environment settings match your repository setup
- **Package rename impact** — ensure the opentrace-agent → opentraceai rename won't break existing users or internal references

---

<details>
<summary><strong>Additional details</strong></summary>

### Workflow triggers and versioning

- **Stable releases** (`release.yml`): triggered by version tags, strips the `v` prefix and uses the tag as-is
- **Dev releases** (`publish-dev.yml`): triggered by main commits touching `agent/**`, appends `.dev{run_number}` to the base version
- **Preview releases** (`publish-preview.yml`): triggered by PRs with the `publish-preview` label, uses `{version}rc{pr_number}.dev{run_number}` format

All three workflows use `sed` to mutate `pyproject.toml` and `src/opentrace_agent/__init__.py` in-place before building, ensuring the published wheel contains the correct version string.

### Package metadata changes

The `pyproject.toml` updates add standard PyPI fields (authors, classifiers, project URLs, license) and improve the description to better explain what OpenTrace does. The lock file reflects the package rename but has no functional changes.

</details>
<!-- opentrace:jid=e27e6097-673e-4d6e-8c32-e6f6e4f2c090|sha=9809499e71d0df4ded44a2a8af26ba2b6a01f527 -->