### PR TITLE
chore(ui): add vite port to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
+# Port to run the UI dev server on (default: 5173)
+VITE_PORT=5173
+
 # Archive proxy URL used by the UI to fetch repo zipballs
 VITE_ARCHIVE_URL=https://oss.opentrace.ai/fn/archive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ go test ./...
 ```
 
 KuzuDB (embedded graph database) requires the shared library in `LD_LIBRARY_PATH` for tests:
+
 ```bash
 LD_LIBRARY_PATH=$(go env GOPATH)/pkg/mod/github.com/kuzudb/go-kuzu@v0.11.3/lib/dynamic/linux-amd64/ go test ./...
 ```
@@ -66,27 +67,27 @@ npm run dev
 
 The API server exposes an MCP endpoint at `/mcp` with these tools:
 
-| Tool | Description |
-|------|-------------|
-| `query_graph` | Search or list nodes by type with optional property filters |
-| `get_node` | Fetch a single node by ID with its immediate neighbors |
+| Tool             | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| `query_graph`    | Search or list nodes by type with optional property filters      |
+| `get_node`       | Fetch a single node by ID with its immediate neighbors           |
 | `traverse_graph` | Walk relationships from a starting node (outgoing/incoming/both) |
-| `search_graph` | Search nodes by name and return a subgraph with relationships |
-| `load_source` | Fetch file contents from registered GitHub/GitLab integrations |
+| `search_graph`   | Search nodes by name and return a subgraph with relationships    |
+| `load_source`    | Fetch file contents from registered GitHub/GitLab integrations   |
 
 ## Agents
 
-| Agent | Description |
-|-------|-------------|
-| `@code-explorer` | Explore indexed code structure — find classes, functions, services and their relationships |
-| `@dependency-analyzer` | Analyze dependencies and blast radius for code changes |
+| Agent                  | Description                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| `@code-explorer`       | Explore indexed code structure — find classes, functions, services and their relationships |
+| `@dependency-analyzer` | Analyze dependencies and blast radius for code changes                                     |
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `/graph-status` | Show overview of indexed nodes by type, list repos and services |
-| `/explore <name>` | Quick exploration of a named component in the graph |
+| Command           | Description                                                     |
+| ----------------- | --------------------------------------------------------------- |
+| `/graph-status`   | Show overview of indexed nodes by type, list repos and services |
+| `/explore <name>` | Quick exploration of a named component in the graph             |
 
 ## Graph Node Types
 
@@ -95,12 +96,13 @@ Service, Repo, Repository, Class, Module, Function, File, Directory, Cluster, Na
 ## Configuration
 
 Server config is in `config.yaml`:
+
 ```yaml
 server:
   port: 8080
   env: dev
   cors_hosts:
-    - http://localhost:5173   # UI auto-selects 5173–5180; add more if needed
+    - http://localhost:5173 # UI auto-selects 5173–5180; add more if needed
 graph:
   db_path: ./data/graph.kuzu
 ```

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig, loadEnv, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { existsSync, readFileSync, createReadStream } from 'fs';
 import { execSync } from 'child_process';
@@ -111,31 +111,42 @@ function crossOriginIsolation(): Plugin {
 }
 
 // https://vite.dev/config/
-export default defineConfig({
-  envDir: resolveEnvDir(),
-  define: {
-    __APP_VERSION__: JSON.stringify(`${pkg.version}+${gitSha}`),
-    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
-  },
-  plugins: [react(), crossOriginIsolation()],
-  server: {
-    port: Number(process.env.PORT) || 5173,
-    strictPort: true,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-      },
-      '/fn': {
-        target: 'http://localhost:5001/handy-amplifier-455315-e6/europe-west1',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const envDir = resolveEnvDir();
+  const env = loadEnv(mode, envDir, '');
+  const port =
+    Number(process.env.PORT) ||
+    Number(process.env.VITE_PORT) ||
+    Number(env.VITE_PORT) ||
+    5173;
+
+  return {
+    envDir,
+    define: {
+      __APP_VERSION__: JSON.stringify(`${pkg.version}+${gitSha}`),
+      __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+    },
+    plugins: [react(), crossOriginIsolation()],
+    server: {
+      port,
+      strictPort: true,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
+        '/fn': {
+          target:
+            'http://localhost:5001/handy-amplifier-455315-e6/europe-west1',
+          changeOrigin: true,
+        },
       },
     },
-  },
-  optimizeDeps: {
-    exclude: ['web-tree-sitter', 'kuzu-wasm'],
-  },
-  worker: {
-    format: 'es',
-  },
+    optimizeDeps: {
+      exclude: ['web-tree-sitter', 'kuzu-wasm'],
+    },
+    worker: {
+      format: 'es',
+    },
+  };
 });


### PR DESCRIPTION
## Make Vite dev server port configurable
✨ **Improvement** · 📝 **Docs**

Makes the UI dev server port configurable via `VITE_PORT` environment variable. The port resolution now follows a priority chain: `PORT` env var → `VITE_PORT` env var → `VITE_PORT` from .env file → default 5173.

Also includes minor documentation formatting fixes in `CLAUDE.md`.

### Complexity
🟢 Low · `3 files changed, 57 insertions(+), 41 deletions(-)`

Straightforward configuration enhancement touching a single concern (dev server port). The Vite config change is mechanical — wrapping the config export in a function to access `loadEnv` — and the fallback logic is simple sequential checks. Documentation changes are pure formatting.

### Review focus
Pay particular attention to the following areas:

- **Port resolution precedence** — verify the fallback chain works correctly across all three sources (process env, loaded env file, and default)
<!-- opentrace:jid=j-23f1b291-0e34-4654-a068-18a561ba0ae6|sha=01d7e4c21b53a2aa3566008bafec3dfb087e4251 -->