### PR TITLE
Increase default max nodes/edges from 2000/5000 to 20000/20000

### DIFF
--- a/ui/src/components/SettingsDrawer.tsx
+++ b/ui/src/components/SettingsDrawer.tsx
@@ -25,8 +25,8 @@ import type { SummarizationStrategyType } from '../runner/browser/enricher/summa
 import { useStore } from '../store';
 import './SettingsDrawer.css';
 
-const DEFAULT_MAX_NODES = 2000;
-const DEFAULT_MAX_EDGES = 5000;
+const DEFAULT_MAX_NODES = 20000;
+const DEFAULT_MAX_EDGES = 20000;
 const LS_KEY_NODES = 'ot:maxVisNodes';
 const LS_KEY_EDGES = 'ot:maxVisEdges';
 

--- a/ui/src/store/kuzuStore.ts
+++ b/ui/src/store/kuzuStore.ts
@@ -212,8 +212,8 @@ export class KuzuGraphStore implements GraphStore {
   private flushedPackageIds = new Set<string>();
 
   // --- Visualization limits ---
-  private maxVisNodes = 2000;
-  private maxVisEdges = 5000;
+  private maxVisNodes = 20000;
+  private maxVisEdges = 20000;
 
   // --- Serialization queue (lbug-wasm wraps single-threaded C++ engine) ---
   private queue: Promise<void> = Promise.resolve();


### PR DESCRIPTION
## Increase visualization limits for larger graphs
✨ **Improvement**

Increases the default maximum nodes from 2,000 to 20,000 and maximum edges from 5,000 to 20,000 to support visualization of larger graphs without manual configuration.

The change updates both the initial defaults (used for new users) and the class-level defaults in the graph store.

### Complexity
🟢 Low · `2 files changed, 4 insertions(+), 4 deletions(-)`

Changes only constants in two files with no logic modifications. The review focus is on checking for inconsistency between the new defaults and a separate set of fallback values that still reference the old limits.

### Review focus
Pay particular attention to the following areas:

- **Hardcoded fallback values** — the localStorage loading logic still uses old 2000/5000 values (lines 233-234 in kuzuStore.ts), which will override the new defaults if localStorage is set but empty
<!-- opentrace:jid=e9b263cd-7889-476b-90bc-4b8271ca3d82|sha=139c7d86e095676f3ae481dd0e34b0b36be404b5 -->