### PR TITLE
Enhance AI co-author detection to check commit actor names

### DIFF
--- a/.github/workflows/ai-coauthor-check.yml
+++ b/.github/workflows/ai-coauthor-check.yml
@@ -40,7 +40,22 @@ jobs:
 
           PATTERN=$(IFS='|'; echo "${AI_PATTERNS[*]}")
 
+          # Check co-author trailers in commit bodies
           if git log --format='%b' "$BASE_SHA".."$HEAD_SHA" | grep -qiE "$PATTERN"; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check if any committer or author is an AI bot
+          AI_ACTOR_PATTERNS=(
+            "claude-code\[bot\]"
+            "copilot\[bot\]"
+            "devin\[bot\]"
+            "github-actions\[bot\]"
+          )
+          ACTOR_PATTERN=$(IFS='|'; echo "${AI_ACTOR_PATTERNS[*]}")
+
+          if git log --format='%an%n%cn%n%ae%n%ce' "$BASE_SHA".."$HEAD_SHA" | grep -qiE "$ACTOR_PATTERN"; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Enhanced the AI co-author check workflow to detect AI-generated commits not only by commit message patterns but also by checking if the commit author or committer is an AI bot account. This provides more comprehensive detection of AI-assisted contributions.

## Changes

- Added early exit after finding AI co-author patterns in commit bodies to avoid redundant checks
- Introduced new AI actor pattern matching that checks commit author names (`%an`), committer names (`%cn`), author emails (`%ae`), and committer emails (`%ce`)
- Added detection for common AI bot accounts: `claude-code[bot]`, `copilot[bot]`, `devin[bot]`, and `github-actions[bot]`
- Restructured the conditional logic to check both commit message patterns and actor names before setting the final output

## Test plan

The workflow will be tested through CI when commits are made with AI bot accounts or when commits contain AI co-author trailers. The existing workflow infrastructure will validate that the detection logic correctly identifies AI-assisted commits.

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or noted above)

https://claude.ai/code/session_014GcUkLepyneF6x3ad7X25n