### PR TITLE
ci: add semantic PR title validation workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,20 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Add semantic PR title validation workflow
🔧 **Chore**

Adds a GitHub Actions workflow to enforce semantic PR title conventions. The workflow runs on PR open, edit, reopen, and sync events to validate that PR titles follow conventional commit format.

### Complexity
🟢 Low · `1 file changed, 20 insertions(+)`

This adds a single GitHub Actions workflow that runs a third-party action to validate PR titles. The workflow configuration is straightforward with standard trigger events and minimal permissions. The change is isolated to CI automation and has no impact on application code or behavior.

### Review focus
Pay particular attention to the following areas:

- **Workflow trigger** — uses `pull_request_target` instead of `pull_request`, which runs with write access to the base repository even for forks
<!-- opentrace:jid=j-9de08510-65af-42f4-9b6d-d6ac2a954b86|sha=d8b5225848802aecc92ecce6a20d09fe3ef388e0 -->