### PR TITLE
feat(ui): responsive chat panel with full-screen mobile overlay

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1453,6 +1453,30 @@ header h1 {
     border-bottom: 1px solid var(--border);
   }
 
+  /* Chat panel: full-screen overlay on tablet/mobile */
+  .chat-panel {
+    position: fixed !important;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100% !important;
+    z-index: 50;
+    border-left: none;
+  }
+
+  .chat-panel-drag-handle {
+    display: none;
+  }
+
+  .chat-input-area {
+    padding: 12px 16px 20px;
+  }
+
+  .api-key-config {
+    padding: 30px 20px;
+  }
+
   /* Hide the desktop side panel on tablet/mobile */
   .side-panel {
     display: none;
@@ -1491,5 +1515,35 @@ header h1 {
 
   .header-menu .search-container {
     margin: 4px 8px;
+  }
+
+  .version-footer {
+    display: none;
+  }
+
+  /* Chat panel: tighter spacing on mobile */
+  .panel-header {
+    padding: 12px 16px;
+  }
+
+  .messages {
+    padding: 12px 14px;
+  }
+
+  .chat-input-area {
+    padding: 10px 12px 16px;
+  }
+
+  .message {
+    font-size: 0.85rem;
+  }
+
+  .message.user {
+    max-width: 90%;
+  }
+
+  .empty-chat {
+    margin-top: 24px;
+    padding: 0 8px;
   }
 }

--- a/ui/src/components/ChatPanel.css
+++ b/ui/src/components/ChatPanel.css
@@ -224,3 +224,31 @@
   color: var(--muted-foreground);
   line-height: 1.4;
 }
+
+/* ── Responsive: tablet/mobile ── */
+@media (max-width: 1024px) {
+  .chat-templates {
+    max-width: none;
+  }
+
+  .provider-selector {
+    flex-wrap: wrap;
+  }
+
+  .provider-selector button {
+    flex: 0 1 auto;
+    min-width: 0;
+    padding: 8px 12px;
+  }
+}
+
+@media (max-width: 640px) {
+  .templates-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .provider-selector button {
+    font-size: 0.7rem;
+    padding: 6px 8px;
+  }
+}


### PR DESCRIPTION
## Responsive chat panel for tablet and mobile
✨ **Improvement**

Makes the chat panel responsive on tablet (≤1024px) and mobile (≤640px) screens. On smaller viewports the panel becomes a fixed full-screen overlay instead of a side-by-side split, and spacing/font sizes are tightened to fit.

### Complexity
🟢 Low · `2 files changed, 82 insertions(+)`

Pure CSS changes scoped to two files, both inside media queries. The logic is straightforward — override layout and spacing at two breakpoints — so the review surface is narrow and the consequence of a missed issue is limited to visual regressions.

### Tests
🧪 No automated tests — CSS layout changes are best verified by manual visual testing at the target breakpoints.

### Review focus
Pay particular attention to the following areas:

- **`!important` overrides** — `position: fixed !important` and `width: 100% !important` on `.chat-panel` could conflict with future JS-driven inline styles; worth checking whether the overrides are necessary or if the specificity problem can be solved another way.
<!-- opentrace:jid=j-82fea6e9-3588-4a3a-b406-f4d3b90179e7|sha=ef0accc14059acb39c2c6df94db61a48aa880d11 -->