### PR TITLE
fix(ci): skip non-conventional commits in changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -38,12 +38,14 @@ commit_parsers = [
   { message = "^fix", group = "Bug Fixes" },
   { message = "^refactor", group = "Refactoring" },
   { message = "^perf", group = "Performance" },
-  { message = "^doc", group = "Documentation" },
+  { message = "^docs?", group = "Documentation" },
   { message = "^ci", group = "CI/CD" },
   { message = "^chore", group = "Miscellaneous" },
   { message = "^test", group = "Testing" },
   { message = "^build", group = "Build" },
   { message = "^style", group = "Styling" },
+  # Skip anything that doesn't match a known conventional type
+  { message = ".*", skip = true },
 ]
 protect_breaking_commits = false
 filter_commits = false


### PR DESCRIPTION
## Filter non-conventional commits from changelog
🔧 **Chore**

Updates the `cliff.toml` changelog config to skip commits that don't match a known conventional commit type, keeping the generated changelog clean. Also fixes the `doc` pattern to match both `doc` and `docs` prefixes.

### Complexity
🟢 Trivial · `1 file changed, 3 insertions(+), 1 deletion(-)`

Two-line config change with no functional code — one regex fix and one catch-all skip rule.
<!-- opentrace:jid=e9f290e1-5219-44e3-87c3-30e5a5d42bbb|sha=b957d49bafc81efdcaf0d25a73c3d4d54b882cd1 -->