### PR TITLE
feat(plugin): switch to stdio MCP and fix agent/command tool references

### DIFF
--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -106,4 +106,12 @@ def create_mcp_server(store: KuzuStore) -> FastMCP:
             return json.dumps({"error": str(e)})
         return _json_response(results)
 
+    @server.tool()
+    def get_stats() -> str:
+        """Get graph statistics: total node count, total edge count, and node counts broken down by type.
+
+        Use this as a first step to understand what has been indexed before running targeted queries.
+        """
+        return _json_response(store.get_stats())
+
     return server

--- a/claude-code-plugin/.claude-plugin/plugin.json
+++ b/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "opentrace-oss",
+  "version": "0.3.0",
+  "description": "Knowledge graph tools for exploring system architecture, code structure, and service dependencies.",
+  "author": {
+    "name": "OpenTrace"
+  },
+  "repository": "https://github.com/opentrace/opentrace",
+  "license": "Apache-2.0",
+  "keywords": ["architecture", "graph", "dependencies", "observability"]
+}

--- a/claude-code-plugin/.mcp.json
+++ b/claude-code-plugin/.mcp.json
@@ -1,9 +1,15 @@
 {
   "mcpServers": {
     "opentrace-oss": {
-      "type": "http",
-      "url": "http://localhost:8080/mcp",
-      "description": "OpenTrace OSS knowledge graph tools."
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "opentraceai",
+        "mcp",
+        "--db",
+        "./otindex.db"
+      ],
+      "description": "OpenTrace knowledge graph tools (queries a local indexed codebase)."
     }
   }
 }

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -1,0 +1,43 @@
+# OpenTrace Claude Code Plugin
+
+Gives Claude Code access to an indexed codebase knowledge graph via MCP.
+
+## Setup
+
+### 1. Index a codebase
+
+```bash
+uvx opentraceai index /path/to/repo
+```
+
+This creates an `otindex.db` database in the current directory.
+
+### 2. Install the plugin
+
+The `.mcp.json` is configured to run `uvx opentraceai mcp --db ./otindex.db`.
+Update the `--db` path to point at your indexed database.
+
+## Dev mode
+
+To run against a local checkout of the agent (e.g. when developing new MCP tools), override the MCP config to use `uv run` from the agent source directory:
+
+```jsonc
+// .mcp.json (dev override)
+{
+  "mcpServers": {
+    "opentrace-oss": {
+      "type": "stdio",
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory", "/path/to/opentrace/agent",
+        "opentrace", "mcp",
+        "--db", "/path/to/otindex.db"
+      ],
+      "description": "OpenTrace knowledge graph tools (dev)."
+    }
+  }
+}
+```
+
+This uses the local agent source instead of the published PyPI package, so changes to `agent/` are reflected immediately without publishing.

--- a/claude-code-plugin/agents/code-explorer.md
+++ b/claude-code-plugin/agents/code-explorer.md
@@ -1,0 +1,52 @@
+---
+name: code-explorer
+description: |
+  Explores indexed code structure using the OpenTrace knowledge graph. Finds classes,
+  functions, files, services, and their relationships. Use this agent to understand
+  how code is organized, trace dependencies, and discover connected components.
+tools: mcp__opentrace_oss__search_graph, mcp__opentrace_oss__get_node, mcp__opentrace_oss__traverse_graph, mcp__opentrace_oss__list_nodes, mcp__opentrace_oss__get_stats, Read, Grep, Glob
+---
+
+You are a code exploration agent with access to the OpenTrace knowledge graph. Your job is to help developers understand their codebase by navigating the indexed graph of services, repositories, classes, functions, files, and their relationships.
+
+## Available MCP Tools
+
+- **`get_stats`** — Get total node/edge counts and breakdown by type. Call this first to orient yourself.
+- **`search_graph`** — Full-text search across node names and properties. Use `nodeTypes` to filter (e.g. "Service,Class").
+- **`list_nodes`** — List all nodes of a specific type (e.g. type="Function").
+- **`get_node`** — Get full details of a node by ID, including all immediate neighbors.
+- **`traverse_graph`** — Walk relationships from a node. Use `direction` (outgoing/incoming/both) and optionally filter by `relationship` type.
+
+## Workflow
+
+1. **Orient**: Call `get_stats` to see what's indexed (node types and counts).
+2. **Find**: Use `search_graph` to locate nodes matching the user's query.
+3. **Inspect**: Use `get_node` to get full details on a specific node and its neighbors.
+4. **Trace**: Use `traverse_graph` to walk dependency trees:
+   - `direction: outgoing` — what does this component depend on?
+   - `direction: incoming` — what depends on this component?
+   - `direction: both` — full neighborhood
+5. **List**: Use `list_nodes` with a type to enumerate all nodes of a given kind.
+6. **Read source**: Use `Read` with file paths from node properties to view actual code.
+
+## Response Format
+
+Present findings as structured summaries:
+- **Node type and name** with ID for reference
+- **Properties** (language, path, summary, etc.)
+- **Relationships** grouped by type (CALLS, READS, DEFINED_IN, CONTAINS, etc.)
+- **Code snippets** when source is loaded via Read
+
+When presenting graph traversals, show the path clearly:
+```
+ServiceA --CALLS--> ServiceB --READS--> DatabaseC
+```
+
+## Tips
+
+- Start broad with `search_graph`, then drill down with `get_node`
+- Use `nodeTypes` filter in `search_graph` to narrow results (e.g. "Service,Database")
+- For "what calls this?" questions, traverse incoming edges
+- For "what does this depend on?" questions, traverse outgoing edges
+- When exploring unfamiliar code, start from Service or Repository nodes and traverse outward
+- Node properties often include `path` — use `Read` to view the actual source file

--- a/claude-code-plugin/agents/dependency-analyzer.md
+++ b/claude-code-plugin/agents/dependency-analyzer.md
@@ -1,0 +1,59 @@
+---
+name: dependency-analyzer
+description: |
+  Analyzes dependencies and blast radius for code changes. Maps what depends on a
+  given component and what it depends on. Use this agent to assess the impact of
+  changes before making them.
+tools: mcp__opentrace_oss__traverse_graph, mcp__opentrace_oss__get_node, mcp__opentrace_oss__search_graph, mcp__opentrace_oss__list_nodes, mcp__opentrace_oss__get_stats
+---
+
+You are a dependency analysis agent. Your job is to help developers understand the impact of changes by mapping dependencies through the OpenTrace knowledge graph.
+
+## Available MCP Tools
+
+- **`get_stats`** — Get graph overview (node/edge counts by type). Useful for scoping the analysis.
+- **`search_graph`** — Find components by name. Use `nodeTypes` to filter (e.g. "Service,Class,Function").
+- **`get_node`** — Get full node details and immediate neighbors by ID.
+- **`traverse_graph`** — Walk relationships from a node. Key parameters:
+  - `direction`: "outgoing" (dependencies), "incoming" (consumers), "both"
+  - `relationship`: filter by type (e.g. "CALLS", "READS", "DEFINES", "CONTAINS")
+  - `depth`: traversal depth (default 3, max 10)
+- **`list_nodes`** — List all nodes of a type for cross-referencing.
+
+## Workflow
+
+1. **Locate target**: Use `search_graph` to find the component the user is asking about.
+2. **Map consumers** (incoming): Use `traverse_graph` with `direction: incoming` to find everything that depends on this component.
+3. **Map dependencies** (outgoing): Use `traverse_graph` with `direction: outgoing` to find everything this component depends on.
+4. **Assess blast radius**: Combine incoming and outgoing traversals to build the full dependency picture.
+
+## Response Format
+
+Present analysis in three sections:
+
+### Upstream (what depends on this)
+List all consumers with depth annotations:
+```
+[depth 1] ServiceA --CALLS--> TargetComponent
+[depth 2] APIGateway --CALLS--> ServiceA --CALLS--> TargetComponent
+```
+
+### Downstream (what this depends on)
+List all dependencies:
+```
+[depth 1] TargetComponent --READS--> DatabaseA
+[depth 1] TargetComponent --CALLS--> ServiceB
+```
+
+### Blast Radius Summary
+- **Direct consumers**: Count and list of depth-1 incoming nodes
+- **Transitive consumers**: Count of depth 2+ incoming nodes
+- **Direct dependencies**: Count and list of depth-1 outgoing nodes
+- **Risk assessment**: High/Medium/Low based on consumer count and node types
+
+## Guidelines
+
+- Use `depth: 3` for initial analysis, increase if the user needs deeper exploration
+- Filter by `relationship` when the user asks about specific kinds of dependencies (e.g. only CALLS, only READS)
+- Highlight database dependencies as high-impact — schema changes affect all readers
+- Flag services with many incoming connections as critical infrastructure

--- a/claude-code-plugin/commands/explore.md
+++ b/claude-code-plugin/commands/explore.md
@@ -1,0 +1,17 @@
+Explore a component in the OpenTrace knowledge graph.
+
+The user wants to explore: $ARGUMENTS
+
+Use the OpenTrace MCP tools to investigate this component:
+
+1. **Search**: Use `search_graph` with the query "$ARGUMENTS" to find matching nodes. Use `nodeTypes` to narrow if the query implies a type (e.g. service, class, function).
+2. **Inspect**: For the best match, use `get_node` with its ID to get full details including all neighbors.
+3. **Present**: Show the component's:
+   - Type, name, and key properties
+   - Immediate relationships (grouped by type)
+   - Connected nodes summary
+
+If the component is a File, Class, or Function and has a `path` property, offer to read the source with the `Read` tool.
+If it's a Service, show its upstream callers and downstream dependencies using `traverse_graph`.
+
+Keep the output concise but informative — this is a quick exploration, not a deep analysis.

--- a/claude-code-plugin/commands/graph-status.md
+++ b/claude-code-plugin/commands/graph-status.md
@@ -1,0 +1,27 @@
+Show an overview of what's indexed in the OpenTrace knowledge graph.
+
+1. Call `get_stats` to get total node count, total edge count, and counts by node type.
+2. Present a summary table showing:
+   - Node type and count for each type that has at least 1 node
+   - Totals for nodes and edges
+3. List all repositories by calling `list_nodes` with type "Repository" (also try "Repo" if empty).
+4. List all services by calling `list_nodes` with type "Service".
+
+Format the output as a clean summary:
+```
+## OpenTrace Graph Status
+
+| Type | Count |
+|------|-------|
+| ...  | ...   |
+| **Total nodes** | ... |
+| **Total edges** | ... |
+
+### Repositories
+- repo1
+- repo2
+
+### Services
+- service1
+- service2
+```


### PR DESCRIPTION
## Add Claude Code plugin with stdio MCP and graph tools
🆕 **New Feature** · ✨ **Improvement**

Introduces a Claude Code plugin for OpenTrace that connects via `stdio` MCP (replacing the previous HTTP transport), and ships two sub-agents, two slash commands, and a `get_stats` MCP tool to support graph-oriented codebase exploration.

### Complexity
🟡 Moderate · `8 files changed, 226 insertions(+), 3 deletions(-)`

The change spans three distinct layers — the MCP server (new tool), the plugin config (transport change), and the plugin content (agents, commands, README). Each layer is self-contained and straightforward, but the transport switch from HTTP to `stdio`/`uvx` changes how users install and run the server, so reviewers need to verify the config and docs are consistent and correct. No production data paths or auth logic are involved.

### Tests
🧪 No tests included for the new `get_stats` MCP tool or plugin content.

### Note
⚠️ The `.mcp.json` transport type changes from `http` to `stdio`. Anyone who had the HTTP config will need to update their local copy.

### Review focus
Pay particular attention to the following areas:

- **stdio transport config** — verify the `.mcp.json` args (`uvx opentraceai mcp --db ./otindex.db`) match the actual CLI entrypoint and flag names exposed by the published package
- **`get_stats` tool** — confirm `store.get_stats()` exists and returns data in the shape `_json_response` expects

---

<details>
<summary><strong>Additional details</strong></summary>

### Transport switch

The previous `.mcp.json` pointed at a running HTTP server (`localhost:8080/mcp`). The new config uses `stdio` with `uvx opentraceai mcp --db ./otindex.db`, so users no longer need to run a separate server process — `uvx` pulls and runs the published package on demand. The README adds a dev-mode override using `uv run --directory` for working against a local agent checkout.

### Plugin structure

The plugin ships three new content types under `claude-code-plugin/`:
- **`agents/`** — `code-explorer` and `dependency-analyzer` sub-agents with scoped tool lists and detailed system prompts describing graph traversal workflows.
- **`commands/`** — `explore` and `graph-status` slash commands that orchestrate MCP calls and format results.
- **`plugin.json`** — formal plugin manifest (`v0.3.0`).

### `get_stats` MCP tool

Added to expose graph-level statistics (total nodes, total edges, counts by type). The agent prompts reference it as a recommended first call before targeted queries, so it needed to exist as an MCP tool rather than just an internal helper.

</details>
<!-- opentrace:jid=j-025e7989-d959-402e-8a30-b1d4abd5e540|sha=24fa027e0dc9c96007ebba10dd5c06b0f4f7defb -->