### PR TITLE
feat(plugin): add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "opentrace-oss",
+  "description": "Knowledge graph tools for exploring system architecture, code structure, and service dependencies",
+  "owner": {
+    "name": "OpenTrace"
+  },
+  "plugins": [
+    {
+      "name": "opentrace-oss",
+      "description": "OpenTrace knowledge graph — search, traverse, and analyze indexed codebases",
+      "version": "0.3.0",
+      "author": {
+        "name": "OpenTrace"
+      },
+      "source": "./claude-code-plugin",
+      "category": "development"
+    }
+  ]
+}


### PR DESCRIPTION
## Add Claude Code marketplace metadata
🔧 **Chore** · 🆕 **New Feature**

Adds a `.claude-plugin/marketplace.json` manifest to register the OpenTrace plugin with the Claude Code marketplace. This enables plugin discovery so users can find and install the OpenTrace knowledge graph tools directly from the marketplace.

### Complexity
🟢 Trivial · `1 file changed, 20 insertions(+)`

Single new JSON config file with no logic — a reviewer can confirm the schema fields are correct and the `source` path resolves to the existing `./claude-code-plugin` directory.

### Review focus
Pay particular attention to the following areas:

- **source path** — verify `"./claude-code-plugin"` correctly resolves to the plugin directory relative to this manifest's location
<!-- opentrace:jid=b810cf6b-5020-449b-bdbe-f88e87d01425|sha=7b3aba4aa031d4a089747a9f2bfb86396d80cbb0 -->