### PR TITLE
feat(agent): add opentraceai CLI alias

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -41,6 +41,7 @@ Issues = "https://github.com/opentrace/opentrace/issues"
 
 [project.scripts]
 opentrace = "opentrace_agent.cli.main:app"
+opentraceai = "opentrace_agent.cli.main:app"
 
 [dependency-groups]
 dev = ["pytest", "pytest-anyio", "ruff"]


### PR DESCRIPTION
## Add opentraceai alias for the CLI entrypoint
🆕 **New Feature**

Registers `opentraceai` as a second CLI entrypoint alongside the existing `opentrace` command. Both commands point to the same `app` entrypoint, so behaviour is identical — this is purely an alias addition.

### Complexity
🟢 Trivial · `1 file changed, 1 insertion(+)`

Single-line addition to `pyproject.toml` registering a script alias. No logic changes, no new code paths.

### Tests
🧪 No tests needed — the alias maps directly to the existing, already-tested entrypoint.

### Review focus
Pay particular attention to the following areas:

- **Entrypoint target** — confirm the alias resolves to the correct `app` object and won't silently break if the module path changes in future
<!-- opentrace:jid=a668fa49-70ca-4b9d-8a54-f35b9a04cb19|sha=c57b0cb32a3b7e32fc70717088ec3d9ba6b33fb1 -->