### PR TITLE
fix(ci): correct PyPI pre-release version ordering and add README

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -22,14 +22,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Set dev version
+      - name: Set rc version
         working-directory: agent
         run: |
           BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          DEV_VERSION="${BASE_VERSION}.dev${GITHUB_RUN_NUMBER}"
-          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
-          sed -i "s/^__version__ = .*/__version__ = \"${DEV_VERSION}\"/" src/opentrace_agent/__init__.py
-          echo "Published version: ${DEV_VERSION}"
+          RC_VERSION="${BASE_VERSION}rc${GITHUB_RUN_NUMBER}"
+          sed -i "s/^version = .*/version = \"${RC_VERSION}\"/" pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"${RC_VERSION}\"/" src/opentrace_agent/__init__.py
+          echo "Published version: ${RC_VERSION}"
 
       - name: Build package
         working-directory: agent

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: agent
         run: |
           BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          PREVIEW_VERSION="${BASE_VERSION}rc${{ github.event.pull_request.number }}.dev${GITHUB_RUN_NUMBER}"
+          PREVIEW_VERSION="${BASE_VERSION}.dev${{ github.event.pull_request.number }}${GITHUB_RUN_NUMBER}"
           sed -i "s/^version = .*/version = \"${PREVIEW_VERSION}\"/" pyproject.toml
           sed -i "s/^__version__ = .*/__version__ = \"${PREVIEW_VERSION}\"/" src/opentrace_agent/__init__.py
           echo "PREVIEW_VERSION=${PREVIEW_VERSION}" >> "$GITHUB_ENV"

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,115 @@
+# OpenTrace
+
+[![PyPI - Version](https://img.shields.io/pypi/v/opentraceai)](https://pypi.org/project/opentraceai/)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/opentrace/opentrace/blob/main/LICENSE)
+
+Index any codebase into a knowledge graph — then query it with AI via MCP.
+
+OpenTrace parses source code with [tree-sitter](https://tree-sitter.github.io/tree-sitter/), extracts classes, functions, imports, and call relationships, and stores the result in an embedded graph database. The graph is queryable through a built-in [MCP](https://modelcontextprotocol.io/) server, so tools like Claude Code can search, traverse, and understand your codebase structure.
+
+## Install
+
+```bash
+pip install opentraceai
+```
+
+Or run directly with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uvx opentraceai index .
+```
+
+Requires Python 3.12+.
+
+## Quick Start
+
+### 1. Index a codebase
+
+```bash
+opentraceai index /path/to/repo
+```
+
+This parses every supported file, extracts symbols and relationships, and writes the graph to `./otindex.db`.
+
+```
+$ opentraceai index ~/projects/myapp
+Opening LadybugDB at ./otindex.db ...
+Indexing /home/user/projects/myapp ...
+  1284 nodes, 3421 relationships, 187 files, 95 classes, 412 functions
+Done in 4.2s.
+```
+
+### 2. Query via MCP
+
+Start a stdio MCP server against the indexed database:
+
+```bash
+opentraceai mcp --db ./otindex.db
+```
+
+This exposes graph query tools over stdin/stdout for any MCP-compatible client.
+
+### Claude Code
+
+Add OpenTrace to Claude Code as a plugin, or configure it manually in your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "opentrace": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["opentraceai", "mcp", "--db", "./otindex.db"]
+    }
+  }
+}
+```
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_graph` | Full-text search across nodes by name or properties |
+| `list_nodes` | List nodes by type (Class, Function, Service, etc.) |
+| `get_node` | Get a node's full details and immediate neighbors |
+| `traverse_graph` | Walk relationships from a node (outgoing, incoming, or both) |
+| `get_stats` | Get graph statistics — node/edge counts broken down by type |
+
+## Supported Languages
+
+| Full extraction (symbols + calls + imports) | Structural extraction (symbols only) |
+|---------------------------------------------|--------------------------------------|
+| Python, TypeScript/JavaScript, Go | Rust, Java, Kotlin, C#, C/C++, Ruby, Swift |
+
+Config and data files (JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash) are indexed as file nodes.
+
+## CLI Reference
+
+```
+opentraceai index [PATH] [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `PATH` | `.` | Directory to index |
+| `--db` | `./otindex.db` | Database path |
+| `--repo-id` | directory name | Repository identifier |
+| `--batch-size` | 200 | Items per write batch |
+| `-v, --verbose` | off | Debug logging |
+
+```
+opentraceai mcp [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--db` | `./otindex.db` | Database path |
+| `-v, --verbose` | off | Debug logging |
+
+## Part of OpenTrace
+
+This package is the CLI/MCP component of [OpenTrace](https://github.com/opentrace/opentrace), an open-source platform for mapping system architecture into knowledge graphs. The full project also includes a browser-based graph explorer at [oss.opentrace.ai](https://oss.opentrace.ai).
+
+## License
+
+Apache License 2.0


### PR DESCRIPTION
## Add README and fix CI version string formats
📝 **Docs** · 🔧 **Chore**

Adds a full `README.md` for the `agent` package and fixes two version-string format issues in the CI publish workflows. The `publish-dev` workflow now generates `rc`-style versions instead of `.dev` suffixes, and the `publish-preview` workflow swaps the format to use `.dev` for preview builds.

### Complexity
🟢 Low · `3 files changed, 121 insertions(+), 6 deletions(-)`

The README is purely additive documentation. The workflow changes are two small, isolated sed-command string tweaks with no logic involved — easy to verify by inspection.

### Review focus
Pay particular attention to the following areas:

- **Version format swap** — the `rc` and `.dev` suffixes have been exchanged between the two workflows; confirm the intended convention for each publish target is now correct and won't break PyPI version ordering or downstream tooling.
<!-- opentrace:jid=j-89abe186-9b51-411d-8494-7c0308ceeac9|sha=c81d444fbb8239e3a44cf7f62850300978e0d2b2 -->