### PR TITLE
fix(ui): fix Gemini tool schema compat and make default

### DIFF
--- a/ui/src/chat/__tests__/storage.test.ts
+++ b/ui/src/chat/__tests__/storage.test.ts
@@ -51,8 +51,8 @@ describe('storage', () => {
   });
 
   describe('loadProviderChoice / saveProviderChoice', () => {
-    it('defaults to anthropic', () => {
-      expect(loadProviderChoice()).toBe('anthropic');
+    it('defaults to gemini', () => {
+      expect(loadProviderChoice()).toBe('gemini');
     });
 
     it('saves and loads provider', () => {

--- a/ui/src/chat/providers.ts
+++ b/ui/src/chat/providers.ts
@@ -79,9 +79,9 @@ const local: ProviderInfo = {
 };
 
 export const PROVIDERS: Record<string, ProviderInfo> = {
+  gemini,
   anthropic,
   openai,
-  gemini,
   local,
 };
 
@@ -120,6 +120,10 @@ export const API_KEY_RESOURCES: Record<string, ApiKeyResource> = {
     dashboard: 'https://aistudio.google.com/api-keys',
     signup: 'https://aistudio.google.com/api-keys',
     signupLabel: 'Google AI Studio',
-    steps: ['Click "Get API key"', 'Create a key for your project'],
+    steps: [
+      'Click "Get API key"',
+      'Create a key for your project',
+      'Free tier available — no billing required',
+    ],
   },
 };

--- a/ui/src/chat/storage.ts
+++ b/ui/src/chat/storage.ts
@@ -32,7 +32,7 @@ export function saveApiKey(provider: string, key: string): void {
 }
 
 export function loadProviderChoice(): string {
-  return localStorage.getItem(PROVIDER_KEY) ?? 'anthropic';
+  return localStorage.getItem(PROVIDER_KEY) ?? 'gemini';
 }
 
 export function saveProviderChoice(provider: string): void {

--- a/ui/src/chat/tools.ts
+++ b/ui/src/chat/tools.ts
@@ -43,9 +43,11 @@ const listNodesSchema = z.object({
   type: z.string().describe('Node type to list'),
   limit: z.number().optional().describe('Max results (default 50, max 1000)'),
   filters: z
-    .record(z.string(), z.string())
+    .string()
     .optional()
-    .describe('Property filters as key-value pairs for AND matching'),
+    .describe(
+      'Property filters as a JSON object string for AND matching, e.g. \'{"language":"go","team":"platform"}\'',
+    ),
 });
 
 const getNodeSchema = z.object({
@@ -132,7 +134,15 @@ export function makeGraphTools(store: GraphStore) {
     ),
     tool(
       async ({ type, limit, filters }) => {
-        const nodes = await store.listNodes(type, limit, filters);
+        let parsedFilters: Record<string, string> | undefined;
+        if (filters) {
+          try {
+            parsedFilters = JSON.parse(filters);
+          } catch {
+            return JSON.stringify({ error: 'Invalid filters JSON', filters });
+          }
+        }
+        const nodes = await store.listNodes(type, limit, parsedFilters);
         return truncate(
           JSON.stringify({ nodes, count: nodes.length }),
           MAX_RESULT_CHARS,


### PR DESCRIPTION
## Set Gemini as default provider, fix filters schema
✨ **Improvement** · 🐛 **Bug Fix**

Changes the default AI provider from Anthropic to Gemini, promotes Gemini to the top of the provider list, and adds a note that Gemini's free tier requires no billing. Also fixes the `listNodes` tool's `filters` parameter to accept a JSON string instead of a raw object, working around LLM tool-calling constraints.

### Complexity
🟢 Low · `4 files changed, 22 insertions(+), 8 deletions(-)`

Two independent, well-scoped changes. The default provider swap is a one-liner with a matching test update. The filters fix is slightly more involved but self-contained — it changes only the schema type and adds a JSON.parse call with an error return path.

### Tests
🧪 Test updated to reflect the new default provider; the filters parse path has no dedicated test.

### Note
⚠️ Existing users who have never explicitly chosen a provider will be switched to Gemini automatically — their Anthropic key will remain stored but the UI will default to Gemini until they change it back.

### Review focus
Pay particular attention to the following areas:

- **Filters error handling** — the parse failure returns an error object rather than throwing; verify this is the intended contract and that callers handle it correctly
- **Default provider change** — any existing users without a saved provider choice will silently switch to Gemini on next load

---

<details>
<summary><strong>Additional details</strong></summary>

### Filters schema change

LLMs struggle to populate `Record<string, string>` tool parameters reliably. Switching `filters` to a plain `string` with an explicit JSON example in the description sidesteps this. The parse + graceful error return keeps the tool callable even if the model produces malformed JSON, rather than letting the error bubble up and break the tool-call loop.

</details>
<!-- opentrace:jid=j-4192dc40-2c98-4257-8897-63a7646efcf2|sha=170a1576e48b1a085b742a6c57a4881e0cdd9dfb -->