### PR TITLE
fix(ui): update Anthropic 4.6 model IDs

### DIFF
--- a/ui/src/chat/providers.ts
+++ b/ui/src/chat/providers.ts
@@ -36,11 +36,11 @@ export interface ProviderInfo {
 const anthropic: ProviderInfo = {
   name: 'Anthropic Claude',
   id: 'anthropic',
-  defaultModel: 'claude-sonnet-4-6-20250514',
+  defaultModel: 'claude-sonnet-4-6',
   models: [
-    { id: 'claude-opus-4-6-20250605', name: 'Claude Opus 4.6' },
+    { id: 'claude-opus-4-6', name: 'Claude Opus 4.6' },
     { id: 'claude-opus-4-5-20250529', name: 'Claude Opus 4.5' },
-    { id: 'claude-sonnet-4-6-20250514', name: 'Claude Sonnet 4.6' },
+    { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' },
     { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5' },
     { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' },
   ],


### PR DESCRIPTION
## Update Anthropic model IDs to alias format
🔧 **Chore**

Switches the Claude Opus 4.6 and Sonnet 4.6 model IDs from dated snapshot identifiers (e.g. `claude-sonnet-4-6-20250514`) to their stable alias equivalents (e.g. `claude-sonnet-4-6`). This ensures requests always resolve to the latest available version of each model without needing manual ID bumps.

### Complexity
🟢 Trivial · `1 file changed, 3 insertions(+), 3 deletions(-)`

Two model ID string changes in a single config file. No logic, no branching, no side-effects.
<!-- opentrace:jid=j-5eb864f0-4335-4c23-859c-9b36d1c5ac5b|sha=12e5a43736e31d8d3ee04df7e8ed11f5335c43b0 -->