### PR TITLE
ci: add preview-npm workflow and components CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       api: ${{ steps.filter.outputs.api }}
       agent: ${{ steps.filter.outputs.agent }}
       ui: ${{ steps.filter.outputs.ui }}
+      components: ${{ steps.filter.outputs.components }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -25,6 +26,8 @@ jobs:
               - 'agent/**'
             ui:
               - 'ui/**'
+            components:
+              - 'components/**'
 
   api:
     name: API (Go)
@@ -116,6 +119,29 @@ jobs:
 
       - name: Test
         run: npx vitest run
+
+      - name: Build
+        run: npm run build
+
+  components:
+    name: Components (TypeScript)
+    needs: changes
+    if: needs.changes.outputs.components == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: components
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: components/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/.github/workflows/preview-npm.yml
+++ b/.github/workflows/preview-npm.yml
@@ -1,0 +1,82 @@
+name: Preview npm Release
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    paths:
+      - "components/**"
+
+jobs:
+  preview-npm:
+    name: Publish preview to npm
+    if: contains(github.event.pull_request.labels.*.name, 'preview-npm')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        working-directory: components
+        run: npm ci
+
+      - name: Set preview version
+        working-directory: components
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          PREVIEW_VERSION="${BASE_VERSION}-pr.${{ github.event.pull_request.number }}.${GITHUB_RUN_NUMBER}"
+          npm version "${PREVIEW_VERSION}" --no-git-tag-version
+          echo "PREVIEW_VERSION=${PREVIEW_VERSION}" >> "$GITHUB_ENV"
+          echo "Preview version: ${PREVIEW_VERSION}"
+
+      - name: Build
+        working-directory: components
+        run: npm run build
+
+      - name: Publish to npm
+        working-directory: components
+        run: npm publish --tag preview --access public --provenance
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- opentrace-components-preview -->';
+            const body = [
+              marker,
+              `📦 Preview published: \`@opentrace/components@${process.env.PREVIEW_VERSION}\``,
+              '',
+              '```bash',
+              `npm install @opentrace/components@${process.env.PREVIEW_VERSION}`,
+              '```',
+              '',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,38 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set version from tag
+        working-directory: components
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "${VERSION}" --no-git-tag-version
+
+      - name: Install dependencies
+        working-directory: components
+        run: npm ci
+
+      - name: Build
+        working-directory: components
+        run: npm run build
+
+      - name: Publish to npm
+        working-directory: components
+        run: npm publish --access public --provenance
+
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `preview-npm.yml` workflow for label-triggered npm preview publishes with OIDC provenance
- Add `publish-npm` job to `release.yml` for tag-based npm releases
- Add `components` job to `ci.yml` for PR build checks

Needs to be on main before the trusted publisher OIDC flow works for `@opentrace/components`.

## Test plan
- [x] Workflow files are valid YAML
- [ ] Merge to main, then re-run preview-npm on #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)