### PR TITLE
feat: add @opentrace/components library package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,46 @@
+name: npm Publish
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.1.1, 0.1.1-rc.5, 0.1.1-pr.110.3)"
+        required: true
+        type: string
+      tag:
+        description: "npm dist-tag (latest, next, preview)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set version
+        working-directory: components
+        run: |
+          npm version "${{ inputs.version }}" --no-git-tag-version
+          echo "Publishing @opentrace/components@${{ inputs.version }} with tag ${{ inputs.tag }}"
+
+      - name: Install dependencies
+        working-directory: components
+        run: npm ci
+
+      - name: Build
+        working-directory: components
+        run: npm run build
+
+      - name: Publish to npm
+        working-directory: components
+        run: NODE_AUTH_TOKEN="" npm publish --tag "${{ inputs.tag }}"

--- a/.github/workflows/preview-npm.yml
+++ b/.github/workflows/preview-npm.yml
@@ -7,45 +7,38 @@ on:
       - "components/**"
 
 jobs:
-  preview-npm:
-    name: Publish preview to npm
+  version:
+    name: Compute preview version
     if: contains(github.event.pull_request.labels.*.name, 'preview-npm')
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        working-directory: components
-        run: npm ci
-
-      - name: Set preview version
+      - id: version
         working-directory: components
         run: |
           BASE_VERSION=$(node -p "require('./package.json').version")
-          PREVIEW_VERSION="${BASE_VERSION}-pr.${{ github.event.pull_request.number }}.${GITHUB_RUN_NUMBER}"
-          npm version "${PREVIEW_VERSION}" --no-git-tag-version
-          echo "PREVIEW_VERSION=${PREVIEW_VERSION}" >> "$GITHUB_ENV"
-          echo "Preview version: ${PREVIEW_VERSION}"
+          VERSION="${BASE_VERSION}-pr.${{ github.event.pull_request.number }}.${GITHUB_RUN_NUMBER}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build
-        working-directory: components
-        run: npm run build
+  publish:
+    needs: version
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      tag: preview
 
-      - name: Publish to npm
-        working-directory: components
-        run: NODE_AUTH_TOKEN="" npm publish --tag preview
-
-      - name: Comment on PR
-        uses: actions/github-script@v7
+  comment:
+    name: Comment on PR
+    needs: [version, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          PREVIEW_VERSION: ${{ needs.version.outputs.version }}
         with:
           script: |
             const marker = '<!-- opentrace-components-preview -->';

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -5,10 +5,31 @@ on:
     branches: [main]
     paths:
       - "agent/**"
+      - "components/**"
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      agent: ${{ steps.filter.outputs.agent }}
+      components: ${{ steps.filter.outputs.components }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          token: ''
+          filters: |
+            agent:
+              - 'agent/**'
+            components:
+              - 'components/**'
+
   publish-dev:
     name: Publish dev to PyPI
+    needs: changes
+    if: needs.changes.outputs.agent == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -41,3 +62,27 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: agent/dist/
+
+  npm-version:
+    name: Compute npm rc version
+    needs: changes
+    if: needs.changes.outputs.components == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: version
+        working-directory: components
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          VERSION="${BASE_VERSION}-rc.${GITHUB_RUN_NUMBER}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  publish-npm-dev:
+    name: Publish dev to npm
+    needs: npm-version
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      version: ${{ needs.npm-version.outputs.version }}
+      tag: next

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,38 +47,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-  publish-npm:
-    name: Publish to npm
-    runs-on: ubuntu-latest
+  npm-version:
+    name: Extract npm version from tag
     needs: release
-    permissions:
-      contents: read
-      id-token: write
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Set version from tag
-        working-directory: components
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version "${VERSION}" --no-git-tag-version
-
-      - name: Install dependencies
-        working-directory: components
-        run: npm ci
-
-      - name: Build
-        working-directory: components
-        run: npm run build
-
-      - name: Publish to npm
-        working-directory: components
-        run: NODE_AUTH_TOKEN="" npm publish
+  publish-npm:
+    needs: npm-version
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      version: ${{ needs.npm-version.outputs.version }}
+      tag: latest
 
   publish-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
## Extract graph visualisation into @opentrace/components npm package
🆕 **New Feature** · ♻️ **Refactor** · 🔧 **Chore**

Extracts the graph visualisation layer (Sigma.js/Graphology hooks, layout pipeline, colour utilities, and types) from the `ui` package into a standalone, publishable npm library: `@opentrace/components`. The `ui` app is then updated to import shared types and colour utilities from the new package while keeping its own local graph hooks in place. New CI workflows handle preview, dev (`next`), and release publishing to npm using a shared reusable workflow.

### Complexity
🟠 High · `60 files changed, 5047 insertions(+), 152 deletions(-)`

This PR introduces a new independently-published package (`@opentrace/components`) that becomes a dependency of `ui` — creating a hard coupling between the two. Several dimensions make careful review warranted:

1. **Boundary ambiguity** — some graph hooks (`useGraphInstance`, `useGraphFilters`, `useGraphVisuals`, `LayoutPipeline`) stay in `ui` while others (`useCommunities`, `useHighlights`, colour utils) move to the library. The split is non-obvious and reviewers should verify the chosen boundary makes sense long-term.
2. **Worker bundling** — `d3LayoutWorker` and `spacingWorker` are new additions inside `components/src`, but `ui/src/hooks/useSigmaGraph.ts` re-declares the `LayoutRequest`/`LayoutResponse` interfaces locally (with a comment "worker is bundled in @opentrace/components"). This duplication may signal incomplete extraction or a subtle interface mismatch.
3. **CI pipeline changes** — three workflows are modified/created (`ci.yml`, `preview-npm.yml`, `publish-dev.yml`, `release.yml`) plus a new reusable `npm-publish.yml`. The publish workflow uses `id-token: write` with provenance; the `NODE_AUTH_TOKEN=""` pattern in the publish step and dist-tag logic (`latest`/`next`/`preview`) should be verified.
4. **Public API surface** — `components/src/index.ts` exports a broad set of hooks, constants, and types as the public contract. Changes here will affect downstream consumers once published.

### Tests
🧪 No new tests are added for the components library itself; existing `ui` tests are updated to import from `@opentrace/components/utils` but the library's own hooks and layout logic remain untested.

### Note
⚠️ The `components` package is published to npm as `@opentrace/components`. Once merged and a release is cut, the public API in `components/src/index.ts` becomes a versioned contract. Reviewers should be aware that changes to exported types/hooks after v0.1.x will require semver-major bumps.

### Review focus
Pay particular attention to the following areas:

- **Hook extraction boundary** — verify the split between hooks kept in `ui` vs. moved to `components` is intentional and won't create version-skew bugs as the library evolves independently.
- **Worker interface duplication** — `LayoutRequest`/`LayoutResponse` are re-declared inline in `ui/src/hooks/useSigmaGraph.ts`; confirm this won't silently diverge from the worker implementation bundled in `components`.
- **npm publish workflow** — check the `NODE_AUTH_TOKEN=""` pattern in `npm-publish.yml` is correct for OIDC-based provenance publishing, and that `--access public` / `--provenance` flags are present as intended.
- **CI trigger for UI job** — the `ui` CI job now also triggers on `components/**` changes and builds `components` first; verify the build order and cache-dependency-path are correct to avoid stale build artefacts.

---

<details>
<summary><strong>Additional details</strong></summary>

### Architecture

The `@opentrace/components` package is built as a Vite library (ESM + CJS) with two entry points:
- **`@opentrace/components`** — full re-export including React hooks (requires React as a peer dep)
- **`@opentrace/components/utils`** — lightweight non-React utilities (types, colour functions) suitable for import in non-component files like `graphContext.ts`

React and react-dom are the only externals; Sigma.js, Graphology, and d3-force are all bundled, making the package self-contained for consumers.

### Publishing pipeline

A new reusable workflow (`npm-publish.yml`) is called by three callers with different `tag` values:
- **`preview`** — triggered by PRs labelled `preview-npm`, versioned as `{base}-pr.{pr}.{run}`
- **`next`** — triggered on main pushes that touch `components/`, versioned as `{base}-rc.{run}`
- **`latest`** — triggered by the release workflow, version stripped from the git tag

### What stayed in `ui`

`useGraphInstance`, `useGraphFilters`, `useGraphVisuals`, `LayoutPipeline`, `drawNodeHover`, and `zoomToNodes` remain in `ui/src/`. The `ui` app imports the shared hooks (`useCommunities`, `useHighlights`) and utilities from the package while keeping the more tightly-coupled Sigma wiring local.

</details>
<!-- opentrace:jid=j-326f6a53-c5d4-4617-8b68-e3a8db3f55c6|sha=24180e13c7f45cab90c0e28cf438936bde950b89 -->