### PR TITLE
fix(ui): dedupe React to prevent dual-instance crash with linked components

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -142,6 +142,9 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    resolve: {
+      dedupe: ['react', 'react-dom'],
+    },
     optimizeDeps: {
       exclude: ['web-tree-sitter', '@lbug/lbug-wasm'],
     },


### PR DESCRIPTION
## Fix dual-React crash for linked component package
🐛 **Bug Fix**

Adds `resolve.dedupe` for `react` and `react-dom` in the Vite config to fix a crash when `@opentrace/components` is linked via the `file:` protocol. Without deduplication, Vite resolves React from the linked package's own `node_modules`, creating two React instances and triggering the classic `"Cannot read properties of null (reading 'useMemo')"` error.

### Complexity
🟢 Trivial · `1 file changed, 3 insertions(+)`

Single three-line config addition with a well-understood Vite mechanism. No logic, no tests, no cross-cutting concerns — a reviewer can verify correctness in seconds.

### Tests
🧪 No tests applicable — this is a build-tool config fix that manifests only at runtime with a locally linked package.
<!-- opentrace:jid=j-0c6e8916-0d7b-456a-9205-23ad0279d8a7|sha=9a6f37c8e743c94c15c5b6bb0680c7c8b988c2d6 -->