### PR TITLE
refactor(components): extract GraphBadge into shared library

### DIFF
--- a/components/src/index.ts
+++ b/components/src/index.ts
@@ -102,10 +102,11 @@ export {
 } from './colors/communityColors';
 
 // ─── Panel components ───────────────────────────────────────────────────
-export { FilterPanel, GraphLegend, DiscoverPanel } from './panels';
+export { FilterPanel, GraphBadge, GraphLegend, DiscoverPanel } from './panels';
 export type {
   FilterItem,
   FilterPanelProps,
+  GraphBadgeProps,
   LegendItem,
   GraphLegendProps,
   TreeNodeData,

--- a/components/src/panels/GraphBadge.css
+++ b/components/src/panels/GraphBadge.css
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.graph-badge {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  background: color-mix(in oklch, var(--background) 85%, transparent);
+  backdrop-filter: blur(8px);
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 14px;
+  border-radius: calc(var(--radius) + 2px);
+  border: 1px solid color-mix(in oklch, var(--border) 25%, transparent);
+  pointer-events: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.graph-badge-rendered {
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.graph-badge-total {
+  color: var(--muted-foreground);
+  font-weight: 400;
+}
+
+.graph-badge-sep {
+  margin: 0 3px;
+}

--- a/components/src/panels/GraphBadge.tsx
+++ b/components/src/panels/GraphBadge.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GraphBadgeProps } from './types';
+import './GraphBadge.css';
+
+export default function GraphBadge({
+  nodeCount,
+  edgeCount,
+  totalNodes,
+  totalEdges,
+}: GraphBadgeProps) {
+  return (
+    <span className="graph-badge">
+      <span className="graph-badge-rendered">{nodeCount}</span>
+      {totalNodes != null && (
+        <span className="graph-badge-total">({totalNodes})</span>
+      )}
+      <span>nodes</span>
+      <span className="graph-badge-sep">&middot;</span>
+      <span className="graph-badge-rendered">{edgeCount}</span>
+      {totalEdges != null && (
+        <span className="graph-badge-total">({totalEdges})</span>
+      )}
+      <span>edges</span>
+    </span>
+  );
+}

--- a/components/src/panels/index.ts
+++ b/components/src/panels/index.ts
@@ -15,12 +15,14 @@
  */
 
 export { default as FilterPanel } from './FilterPanel';
+export { default as GraphBadge } from './GraphBadge';
 export { default as GraphLegend } from './GraphLegend';
 export { default as DiscoverPanel } from './DiscoverPanel';
 
 export type {
   FilterItem,
   FilterPanelProps,
+  GraphBadgeProps,
   LegendItem,
   GraphLegendProps,
   TreeNodeData,

--- a/components/src/panels/types.ts
+++ b/components/src/panels/types.ts
@@ -60,6 +60,19 @@ export interface GraphLegendProps {
   maxVisible?: number;
 }
 
+// ─── GraphBadge types ────────────────────────────────────────────────
+
+export interface GraphBadgeProps {
+  /** Number of currently rendered/filtered nodes. */
+  nodeCount: number;
+  /** Number of currently rendered/filtered edges. */
+  edgeCount: number;
+  /** Total node count from the API (shown in parentheses). */
+  totalNodes?: number;
+  /** Total edge count from the API (shown in parentheses). */
+  totalEdges?: number;
+}
+
 // ─── DiscoverPanel types ────────────────────────────────────────────
 
 export interface TreeNodeData {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -201,35 +201,7 @@ header h1 {
   border-color: color-mix(in oklch, var(--primary) 30%, transparent);
 }
 
-.badge {
-  font-size: 0.75rem;
-  color: var(--muted-foreground);
-  background: color-mix(in oklch, var(--background) 85%, transparent);
-  backdrop-filter: blur(8px);
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 0 14px;
-  border-radius: calc(var(--radius) + 2px);
-  border: 1px solid color-mix(in oklch, var(--border) 25%, transparent);
-  pointer-events: auto;
-  font-variant-numeric: tabular-nums;
-}
-
-.badge-rendered {
-  font-weight: 600;
-  color: var(--foreground);
-}
-
-.badge-total {
-  color: var(--muted-foreground);
-  font-weight: 400;
-}
-
-.badge-sep {
-  margin: 0 3px;
-}
+/* GraphBadge styles are now in @opentrace/components */
 
 .add-repo-btn {
   margin-left: auto;
@@ -1155,7 +1127,7 @@ header h1 {
   }
 
   /* Badge as menu row */
-  .header-menu .badge {
+  .header-menu .graph-badge {
     border: none;
     border-radius: 0;
     background: transparent;

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -42,6 +42,7 @@ import {
   useHighlights,
 } from '@opentrace/components/utils';
 import {
+  GraphBadge,
   GraphLegend,
   type FilterItem,
   type FilterPanelProps,
@@ -1395,23 +1396,12 @@ const GraphViewer = memo(
                   Show All
                 </button>
               )}
-              <span className="badge">
-                <span className="badge-rendered">
-                  {filteredGraphData.nodes.length}
-                </span>
-                {stats && (
-                  <span className="badge-total">({stats.total_nodes})</span>
-                )}
-                <span>nodes</span>
-                <span className="badge-sep">&middot;</span>
-                <span className="badge-rendered">
-                  {filteredGraphData.links.length}
-                </span>
-                {stats && (
-                  <span className="badge-total">({stats.total_edges})</span>
-                )}
-                <span>edges</span>
-              </span>
+              <GraphBadge
+                nodeCount={filteredGraphData.nodes.length}
+                edgeCount={filteredGraphData.links.length}
+                totalNodes={stats?.total_nodes}
+                totalEdges={stats?.total_edges}
+              />
               {(jobState.status === 'enriching' ||
                 jobState.status === 'done') &&
               !jobExpanded ? (


### PR DESCRIPTION
## Extract panel components into shared library
🆕 **New Feature** · ♻️ **Refactor**

Promotes `DiscoverPanel`, `FilterPanel`, `GraphLegend`, and `GraphBadge` from the `ui` app into the `@opentrace/components` library so they can be consumed by external projects. The `ui` app is updated to import these components from the package rather than owning the source directly.

### Complexity
🟠 High · `35 files changed, 3896 insertions(+), 1944 deletions(-)`

**Scope:** Touches both the component library and the UI app in a coordinated way — new public API surface, virtualised rendering logic, lazy tree loading, cross-package wiring, and CI pipeline changes all land together.

**Key risk areas:**
1. **New public API** — `FilterPanel`, `DiscoverPanel`, `GraphLegend`, `GraphBadge`, and their prop types are now exported. Shape mistakes here are hard to roll back once consumers adopt them.
2. **DiscoverPanel virtualisation** — The `react-window` List renders into a fixed-height container; the `flattenTree` / `flatRows` memoisation and the scroll-to-selected `useEffect` interact subtly and are worth reading carefully.
3. **DiscoverPanelContainer async tree loading** — Auto-expands 3 levels on mount with cancellation guards; the `expanded`/`childrenMap` state updates use functional setters to avoid races, but the `findNodeType` lookup scans all children linearly.
4. **CI restructuring** — `npm-publish.yml` changes from `workflow_call` to standalone triggers (PR label, push to main, `workflow_dispatch`), and the release workflow now dispatches it rather than calling it. The "watch triggered run" polling approach in deploy workflows is a new pattern that could time out silently.

### Tests
🧪 Vitest tests added for `DiscoverPanel`, `FilterPanel`, and `GraphLegend` in the components package; the `DiscoverPanelContainer` and SidePanel wiring in the `ui` app have no new tests.

### Note
⚠️ The `npm-publish.yml` workflow is no longer a reusable `workflow_call` — callers in `publish-dev.yml` and `release.yml` have been updated to use `gh workflow run` dispatch instead. If any other workflows call `npm-publish.yml` as a reusable workflow they will silently break.

### Review focus
Pay particular attention to the following areas:

- **Public API shape** — FilterPanelProps, DiscoverPanelProps, and the re-exported types in components/src/index.ts are now part of the library contract; verify naming and type completeness before merge.
- **DiscoverPanel flattenTree** — the hideOffGraph + text filter interaction relies on matchesFilter and isInGraph recursing into childrenMap; confirm ancestors remain visible when only a deep descendant matches.
- **CI polling in deploy workflows** — the new Watch triggered run loop polls up to 30x2s for a run whose displayTitle contains the triggering run_id; verify the deployment repo actually sets a matching title, otherwise the step will always time out.
- **npm-publish workflow trigger change** — converting from workflow_call to direct triggers (label, push, dispatch) changes who can kick off a publish and removes the previous gating; confirm the label-guard and path filter are sufficient to prevent accidental publishes.

---

<details>
<summary><strong>Additional details</strong></summary>

### Component extraction approach

The four panel components move into `components/src/panels/` with a shared `types.ts` defining the prop interfaces. `DiscoverPanel` is the most complex: it owns only presentation and virtualised rendering (via `react-window`), while all data fetching and state (expanded nodes, children cache, auto-expansion) lives in the new `DiscoverPanelContainer` in the `ui` app. This keeps the library component pure and testable without store dependencies.

### Virtualised tree rendering

`DiscoverPanel` flattens the tree into a `FlatRow[]` array via `flattenTree`, which is memoised. `react-window`'s `List` renders only the visible slice. The `rowProps` object is also stabilised with `useMemo` to avoid re-rendering all rows on every parent render.

### Auto-expand and lazy loading

`DiscoverPanelContainer` eagerly expands 3 levels on mount using `fetchChildren` (without writing to state) and then batch-updates `childrenMap` and `expanded`. Subsequent interactive toggles use `loadChildren`, which writes incrementally. A cancellation flag guards against stale async updates when `graphVersion` changes.

### CI workflow consolidation

`preview-npm.yml` is deleted; its logic is absorbed into `npm-publish.yml`, which now handles all three publish scenarios (PR preview, RC on push to main, release via dispatch). The deploy workflows gain a "watch triggered run" step that correlates by `displayTitle` — this requires the deployment repo's workflow to include the triggering `run_id` in its run name.

</details>
<!-- opentrace:jid=j-825f8c28-a78e-4a5a-98b0-204695681bd8|sha=e0d33291c402bacc0083c5d4f38b45fd7ea84c17 -->