### PR TITLE
feat(ui): add size indicators to example repos

### DIFF
--- a/ui/src/components/AddRepoModal.css
+++ b/ui/src/components/AddRepoModal.css
@@ -350,6 +350,31 @@
   background: color-mix(in oklch, var(--primary) 8%, transparent);
 }
 
+.example-repo-size {
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border-radius: 4px;
+  line-height: 1.3;
+}
+
+.example-repo-size--s {
+  color: #4ade80;
+  background: color-mix(in oklch, #4ade80 12%, transparent);
+}
+
+.example-repo-size--m {
+  color: #fbbf24;
+  background: color-mix(in oklch, #fbbf24 12%, transparent);
+}
+
+.example-repo-size--l {
+  color: #f87171;
+  background: color-mix(in oklch, #f87171 12%, transparent);
+}
+
 /* ── CTA Button ──────────────────────────────── */
 .btn-cta {
   display: flex;

--- a/ui/src/components/AddRepoModal.tsx
+++ b/ui/src/components/AddRepoModal.tsx
@@ -244,26 +244,49 @@ const PROVIDER_DISPLAY_NAME: Record<string, string> = {
 
 // --- Example Repositories ---
 
-const EXAMPLE_REPOS = [
+type RepoSize = 'S' | 'M' | 'L';
+
+const EXAMPLE_REPOS: {
+  name: string;
+  url: string;
+  description: string;
+  size: RepoSize;
+}[] = [
   {
     name: 'OpenTrace',
     url: 'https://github.com/opentrace/opentrace',
     description: 'Knowledge graph for system architecture and code structure',
+    size: 'M',
   },
   {
     name: 'OpenTelemetry Demo',
     url: 'https://github.com/open-telemetry/opentelemetry-demo',
     description: 'Microservices demo with OTel instrumentation',
+    size: 'M',
   },
   {
     name: 'Express.js',
     url: 'https://github.com/expressjs/express',
     description: 'Fast, minimalist web framework for Node.js',
+    size: 'S',
   },
   {
     name: 'Podinfo',
     url: 'https://github.com/stefanprodan/podinfo',
     description: 'Go microservice template for Kubernetes',
+    size: 'S',
+  },
+  {
+    name: 'Grafana',
+    url: 'https://github.com/grafana/grafana',
+    description: 'Open-source observability and monitoring platform',
+    size: 'L',
+  },
+  {
+    name: 'Linux',
+    url: 'https://github.com/torvalds/linux',
+    description: 'Linux kernel source tree',
+    size: 'L',
   },
 ];
 
@@ -487,6 +510,11 @@ export default function AddRepoModal({
                         title={repo.description}
                       >
                         {repo.name}
+                        <span
+                          className={`example-repo-size example-repo-size--${repo.size.toLowerCase()}`}
+                        >
+                          {repo.size}
+                        </span>
                       </button>
                     ))}
                   </div>


### PR DESCRIPTION
## Add size badges to example repos in Add Repo modal
🆕 **New Feature** · ✨ **Improvement**

Adds colour-coded size badges (S / M / L) to the example repository chips in the Add Repo modal, and expands the list with three new examples: OpenTrace, Grafana, and Linux kernel.

The badges give users an at-a-glance sense of indexing cost before they pick a repo.

### Complexity
🟢 Trivial · `2 files changed, 62 insertions(+), 4 deletions(-)`

Purely additive UI change — new CSS classes, a typed `size` field on the example repo list, and a single badge `<span>` in the render. No logic, no data flow, no side effects.

### Tests
🧪 No tests added; the change is limited to static display data and CSS.
<!-- opentrace:jid=db75eff8-d88e-4e2e-8160-11fdf2382653|sha=99d8e78d9eadb57f87eb4f11ea5c7b3a456a8e5c -->