### PR TITLE
chore: show branch and worktree name in statusline

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -3,6 +3,7 @@ input=$(cat)
 model=$(echo "$input" | jq -r '.model.display_name // .model.id // "unknown"')
 used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 ctx_size=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // empty')
 
 if [ -n "$ctx_size" ]; then
   ctx_size_fmt=$(awk -v n="$ctx_size" 'BEGIN { if (n >= 1000000) printf "%.0fM", n/1000000; else if (n >= 1000) printf "%.0fK", n/1000; else printf "%d", n }')
@@ -10,13 +11,24 @@ else
   ctx_size_fmt="?"
 fi
 
-# Git branch
-branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "")
+# Worktree name from JSON input
+worktree_name=$(echo "$input" | jq -r '.worktree.name // empty')
 
-# Worktree detection
-worktree=""
-if [ -f "$(git rev-parse --git-dir 2>/dev/null)/commondir" ]; then
-  worktree=" [worktree]"
+# Git branch — use cwd from JSON so git runs in the right directory
+branch=""
+worktree_label=""
+if [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null \
+           || GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --short HEAD 2>/dev/null \
+           || echo "")
+  gitdir=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --git-dir 2>/dev/null)
+  if [ -n "$gitdir" ] && [ -f "$gitdir/commondir" ]; then
+    if [ -n "$worktree_name" ]; then
+      worktree_label=" [worktree: $worktree_name]"
+    else
+      worktree_label=" [worktree]"
+    fi
+  fi
 fi
 
 out="$model | ctx: $ctx_size_fmt"
@@ -25,7 +37,9 @@ if [ -n "$used" ]; then
   out="$out | ${used_int}% used"
 fi
 if [ -n "$branch" ]; then
-  out="$out | $branch$worktree"
+  out="$out | $branch$worktree_label"
+elif [ -n "$worktree_label" ]; then
+  out="$out |$worktree_label"
 fi
 
 printf "%s" "$out"


### PR DESCRIPTION
## Summary
- Use `cwd` from JSON input with `git -C` so git resolves the branch correctly regardless of shell working directory
- Display the worktree name (e.g. `[worktree: hazy-questing-moonbeam]`) instead of generic `[worktree]`
- Use `GIT_OPTIONAL_LOCKS=0` to avoid lock contention from frequent statusline updates

## Test plan
- [ ] Run Claude Code in a worktree and verify the statusline shows the worktree name
- [ ] Run Claude Code in the main working tree and verify no worktree label appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)