### PR TITLE
fix(ui): toolbar overlaps chat panel when drawer is open

### DIFF
--- a/components/src/panels/GraphToolbar.css
+++ b/components/src/panels/GraphToolbar.css
@@ -17,11 +17,11 @@
 /* ── Toolbar layout ─────────────────────────── */
 
 .ot-toolbar {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  z-index: 10;
+  z-index: 20;
   display: flex;
   align-items: center;
   gap: 12px;

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -392,6 +392,7 @@
   flex-direction: column;
   z-index: 10;
   position: relative;
+  padding-top: 64px;
 }
 
 /* Drag handle on the left edge */


### PR DESCRIPTION
## Fix toolbar scroll behaviour with fixed positioning
🐛 **Bug Fix**

Switches the graph toolbar from `position: absolute` to `position: fixed` so it stays visible when the panel content scrolls. A compensating `padding-top: 64px` on the panel container prevents content from being hidden behind the toolbar.

### Complexity
🟢 Low · `2 files changed, 3 insertions(+), 2 deletions(-)`

Two-line CSS change with a direct cause-and-effect relationship. The z-index bump and padding offset are mechanical consequences of switching to fixed positioning — straightforward to verify visually.

### Tests
🧪 CSS-only change; no automated tests apply.

### Review focus
Pay particular attention to the following areas:

- **Padding value** — the hardcoded 64px must match the actual rendered toolbar height across all viewport sizes and content states, otherwise content will be clipped or overlap.
<!-- opentrace:jid=f0094412-a35e-4ae1-b898-93510bf4b7a4|sha=99271e3071529c0a55c2cf7cdf20464b0c1fa09d -->