### PR TITLE
fix(store): fix JSON parse error and rename kuzu → ladybug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,4 +65,3 @@ npm run dev
 ## Graph Node Types
 
 Service, Repo, Repository, Class, Module, Function, File, Directory, Cluster, Namespace, Deployment, InstrumentedService, Span, Log, Metric, Endpoint, Database, DBTable
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Use concise, descriptive commit messages:
 ui/                   — React/TypeScript frontend
   src/pipeline/       — Indexing pipeline (scanning → processing → resolving)
   src/runner/         — Browser-based parser workers
-  src/store/          — Graph store implementations (KuzuDB WASM, in-memory)
+  src/store/          — Graph store implementations (LadybugDB WASM, in-memory)
   src/components/     — React components
   src/chat/           — Chat agent and graph tools
 proto/                — Protobuf definitions

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OpenTrace indexes source code directly in your browser — no server required. P
 
 1. **Parse** every file using tree-sitter WASM grammars (12 languages)
 2. **Extract** classes, functions, imports, and call relationships
-3. **Build** a knowledge graph stored in KuzuDB WASM (embedded graph database)
+3. **Build** a knowledge graph stored in LadybugDB WASM (embedded graph database)
 4. **Summarize** every node using template-based identifier analysis
 5. **Expose** the graph to an in-app chat agent via MCP tools
 
@@ -46,7 +46,7 @@ OpenTrace indexes source code directly in your browser — no server required. P
 │                                  │  WASM parsers   │ │
 │                                  └─────────────────┘ │
 │                                  ┌─────────────────┐ │
-│                                  │  KuzuDB WASM    │ │
+│                                  │  LadybugDB WASM    │ │
 │                                  │  graph store    │ │
 │                                  └─────────────────┘ │
 └──────────────────────────────────────────────────────┘

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ We will acknowledge receipt within 48 hours and aim to provide a fix or mitigati
 OpenTrace runs entirely in the browser. The primary attack surface is:
 
 - **GitHub/GitLab API tokens** — stored in browser localStorage, used to fetch repository contents
-- **KuzuDB WASM** — embedded database running in-browser
+- **LadybugDB WASM** — embedded database running in-browser
 - **tree-sitter WASM parsers** — parse untrusted source code in a Web Worker
 
 ## Supported Versions

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
-  kuzu-explorer:
-    image: kuzudb/explorer:latest
+  ladybug-explorer:
+    image: ladybugdb/explorer:latest
     ports:
       - "8000:8000"
     volumes:
-      - ./db.kuzu:/database/db.kuzu
+      - ./db.ladybug:/database/db.ladybug
     environment:
       MODE: READ_ONLY
-      KUZU_FILE: db.kuzu
+      LADYBUG_FILE: db.ladybug

--- a/agent/src/opentrace_agent/cli/augment.py
+++ b/agent/src/opentrace_agent/cli/augment.py
@@ -63,12 +63,12 @@ def run_augment(pattern: str, db_path: str | None) -> None:
         return
 
     try:
-        from opentrace_agent.store import KuzuStore
+        from opentrace_agent.store import GraphStore
     except Exception:
         return
 
     try:
-        store = KuzuStore(db_path, read_only=True)
+        store = GraphStore(db_path, read_only=True)
     except Exception:
         return
 

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -156,8 +156,8 @@ def index(
     _configure_logging(verbose)
 
     from opentrace_agent.pipeline import PipelineInput, run_pipeline
-    from opentrace_agent.pipeline.adapters import KuzuStoreAdapter
-    from opentrace_agent.store import KuzuStore
+    from opentrace_agent.pipeline.adapters import GraphStoreAdapter
+    from opentrace_agent.store import GraphStore
 
     root = Path(path)
     if repo_id is None:
@@ -169,8 +169,8 @@ def index(
     _ensure_gitignore(db_dir)
 
     click.echo(f"Opening database at {resolved_db} ...")
-    kuzu_store = KuzuStore(resolved_db)
-    store = KuzuStoreAdapter(kuzu_store, batch_size=batch_size)
+    graph_store = GraphStore(resolved_db)
+    store = GraphStoreAdapter(graph_store, batch_size=batch_size)
 
     click.echo(f"Indexing {root} ...")
     t0 = time.monotonic()
@@ -237,10 +237,10 @@ def stats(db_path: str | None, output_format: str) -> None:
     """Display graph statistics."""
     import json
 
-    from opentrace_agent.store import KuzuStore
+    from opentrace_agent.store import GraphStore
 
     resolved_db = _resolve_db(db_path, must_exist=True)
-    store = KuzuStore(resolved_db, read_only=True)
+    store = GraphStore(resolved_db, read_only=True)
     try:
         data = store.get_stats()
     finally:
@@ -270,10 +270,10 @@ def mcp_cmd(db_path: str | None, verbose: bool) -> None:
     _configure_logging(verbose)
 
     from opentrace_agent.cli.mcp_server import create_mcp_server
-    from opentrace_agent.store import KuzuStore
+    from opentrace_agent.store import GraphStore
 
     resolved_db = _resolve_db(db_path, must_exist=True)
-    store = KuzuStore(resolved_db)
+    store = GraphStore(resolved_db)
 
     def _shutdown(signum: int, _frame: object) -> None:
         store.close()

--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
-from opentrace_agent.store import KuzuStore
+from opentrace_agent.store import GraphStore
 
 MAX_RESULT_CHARS = 4000
 
@@ -36,7 +36,7 @@ def _json_response(data: Any) -> str:
     return _truncate(json.dumps(data, default=str))
 
 
-def create_mcp_server(store: KuzuStore) -> FastMCP:
+def create_mcp_server(store: GraphStore) -> FastMCP:
     """Create a FastMCP server with graph query tools backed by *store*."""
     server = FastMCP("opentrace")
 

--- a/agent/src/opentrace_agent/pipeline/adapters.py
+++ b/agent/src/opentrace_agent/pipeline/adapters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Store adapter wrapping KuzuStore to conform to the pipeline Store protocol."""
+"""Store adapter wrapping GraphStore to conform to the pipeline Store protocol."""
 
 from __future__ import annotations
 
@@ -43,16 +43,16 @@ def _rel_to_dict(rel: GraphRelationship) -> dict[str, Any]:
     }
 
 
-class KuzuStoreAdapter:
-    """Wraps KuzuStore to conform to the pipeline Store protocol.
+class GraphStoreAdapter:
+    """Wraps GraphStore to conform to the pipeline Store protocol.
 
     Accumulates nodes/relationships and flushes in batches.
     Nodes are always flushed before relationships since rels
     reference nodes via MATCH.
     """
 
-    def __init__(self, kuzu_store: Any, batch_size: int = 200) -> None:
-        self._store = kuzu_store
+    def __init__(self, graph_store: Any, batch_size: int = 200) -> None:
+        self._store = graph_store
         self._batch_size = batch_size
         self._nodes: list[dict[str, Any]] = []
         self._rels: list[dict[str, Any]] = []

--- a/agent/src/opentrace_agent/store/__init__.py
+++ b/agent/src/opentrace_agent/store/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from opentrace_agent.store.kuzu_store import KuzuStore
+from opentrace_agent.store.graph_store import GraphStore
 
-__all__ = ["KuzuStore"]
+__all__ = ["GraphStore"]

--- a/agent/src/opentrace_agent/store/graph_store.py
+++ b/agent/src/opentrace_agent/store/graph_store.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""LadybugDB-backed graph store — Python equivalent of ``api/pkg/graph/kuzu.go``.
+"""LadybugDB-backed graph store.
 
 Same schema, same Cypher queries, interoperable databases.
 """
@@ -24,12 +24,12 @@ import logging
 from collections import deque
 from typing import Any
 
-import real_ladybug as kuzu
+import real_ladybug as ladybug
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Helpers (mirrors Go helpers.go)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -74,14 +74,14 @@ def _parse_props(raw: Any) -> dict[str, Any] | None:
 
 
 # ---------------------------------------------------------------------------
-# KuzuStore
+# GraphStore
 # ---------------------------------------------------------------------------
 
 
-class KuzuStore:
+class GraphStore:
     """Embedded graph store backed by LadybugDB.
 
-    Schema matches the Go ``KuzuStore`` exactly::
+    Schema::
 
         Node(id PK, type, name, properties, search_text)
         RELATES(FROM Node TO Node, id STRING, type STRING, properties STRING)
@@ -89,8 +89,8 @@ class KuzuStore:
     """
 
     def __init__(self, db_path: str, *, read_only: bool = False) -> None:
-        self._db = kuzu.Database(db_path, read_only=read_only)
-        self._conn = kuzu.Connection(self._db)
+        self._db = ladybug.Database(db_path, read_only=read_only)
+        self._conn = ladybug.Connection(self._db)
         if not read_only:
             self._ensure_schema()
 
@@ -469,7 +469,7 @@ class KuzuStore:
         self._conn.close()
         self._db.close()
 
-    def __enter__(self) -> KuzuStore:
+    def __enter__(self) -> GraphStore:
         return self
 
     def __exit__(self, *exc: object) -> None:

--- a/agent/tests/opentrace_agent/cli/test_augment.py
+++ b/agent/tests/opentrace_agent/cli/test_augment.py
@@ -68,7 +68,7 @@ def test_run_augment_no_matches(tmp_path, capsys):
     mock_store = MagicMock()
     mock_store.search_nodes.return_value = []
 
-    with patch("opentrace_agent.store.KuzuStore", return_value=mock_store):
+    with patch("opentrace_agent.store.GraphStore", return_value=mock_store):
         run_augment("nonexistent", str(tmp_path / "fake.db"))
 
     assert capsys.readouterr().out == ""
@@ -85,7 +85,7 @@ def test_run_augment_with_matches(tmp_path, capsys):
     mock_store.search_nodes.return_value = [node]
     mock_store._get_neighbors.return_value = [(neighbor, rel)]
 
-    with patch("opentrace_agent.store.KuzuStore", return_value=mock_store):
+    with patch("opentrace_agent.store.GraphStore", return_value=mock_store):
         run_augment("handle_request", str(tmp_path / "fake.db"))
 
     out = capsys.readouterr().out
@@ -98,7 +98,7 @@ def test_run_augment_with_matches(tmp_path, capsys):
 
 def test_run_augment_db_open_fails(tmp_path, capsys):
     """Should silently no-op when the store can't be opened."""
-    with patch("opentrace_agent.store.KuzuStore", side_effect=RuntimeError("locked")):
+    with patch("opentrace_agent.store.GraphStore", side_effect=RuntimeError("locked")):
         run_augment("anything", str(tmp_path / "fake.db"))
 
     assert capsys.readouterr().out == ""
@@ -120,7 +120,7 @@ def test_run_augment_caps_relationships(tmp_path, capsys):
     mock_store.search_nodes.return_value = [node]
     mock_store._get_neighbors.return_value = neighbors
 
-    with patch("opentrace_agent.store.KuzuStore", return_value=mock_store):
+    with patch("opentrace_agent.store.GraphStore", return_value=mock_store):
         run_augment("BigClass", str(tmp_path / "fake.db"))
 
     out = capsys.readouterr().out

--- a/agent/tests/opentrace_agent/graph/test_graph_store.py
+++ b/agent/tests/opentrace_agent/graph/test_graph_store.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for KuzuStore helpers and integration."""
+"""Tests for GraphStore helpers and integration."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ import json
 
 import pytest
 
-from opentrace_agent.store.kuzu_store import (
+from opentrace_agent.store.graph_store import (
     _marshal_props,
     _parse_props,
     _row_to_node,
@@ -159,7 +159,7 @@ class TestRowToNode:
         }
 
     def test_dict_properties(self):
-        """When KuzuDB returns properties already deserialized as a dict."""
+        """When LadybugDB returns properties already deserialized as a dict."""
         row = ["node-2", "Class", "Bar", {"language": "python"}]
         result = _row_to_node(row)
         assert result["properties"] == {"language": "python"}
@@ -191,23 +191,23 @@ class TestRowToNode:
 
 
 # ---------------------------------------------------------------------------
-# KuzuStore integration tests (require real_ladybug)
+# GraphStore integration tests (require real_ladybug)
 # ---------------------------------------------------------------------------
 
-kuzu = pytest.importorskip("real_ladybug")
+ladybug = pytest.importorskip("real_ladybug")
 
-from opentrace_agent.store import KuzuStore  # noqa: E402
+from opentrace_agent.store import GraphStore  # noqa: E402
 
 
 @pytest.fixture()
 def store(tmp_path):
     db_path = str(tmp_path / "testdb")
-    s = KuzuStore(db_path)
+    s = GraphStore(db_path)
     yield s
     s.close()
 
 
-def _seed(store: KuzuStore) -> None:
+def _seed(store: GraphStore) -> None:
     """Insert a small graph for testing."""
     store.add_node("svc-api", "Service", "api-gateway", {"language": "go", "port": 8080})
     store.add_node("svc-db", "Database", "postgres", {"engine": "postgresql", "version": "16"})
@@ -220,7 +220,7 @@ def _seed(store: KuzuStore) -> None:
     store.add_relationship("r4", "CONTAINS", "svc-api", "cls-user")
 
 
-class TestKuzuStoreGetNode:
+class TestGraphStoreGetNode:
     def test_get_existing(self, store):
         store.add_node("n1", "File", "main.py", {"language": "python"})
         node = store.get_node("n1")
@@ -247,7 +247,7 @@ class TestKuzuStoreGetNode:
         assert node["properties"] is None
 
 
-class TestKuzuStoreListNodes:
+class TestGraphStoreListNodes:
     def test_list_by_type(self, store):
         _seed(store)
         functions = store.list_nodes("Function")
@@ -271,7 +271,7 @@ class TestKuzuStoreListNodes:
         assert len(result) == 1
 
 
-class TestKuzuStoreSearchNodes:
+class TestGraphStoreSearchNodes:
     def test_substring_search(self, store):
         _seed(store)
         results = store.search_nodes("query")
@@ -300,7 +300,7 @@ class TestKuzuStoreSearchNodes:
         assert len(results) <= 2
 
 
-class TestKuzuStoreSearchGraph:
+class TestGraphStoreSearchGraph:
     def test_search_graph_returns_neighbors(self, store):
         _seed(store)
         nodes, rels = store.search_graph("handleRequest", hops=1)
@@ -333,7 +333,7 @@ class TestKuzuStoreSearchGraph:
         assert isinstance(nodes, list)
 
 
-class TestKuzuStoreTraverse:
+class TestGraphStoreTraverse:
     def test_outgoing(self, store):
         _seed(store)
         results = store.traverse("fn-handle", direction="outgoing", max_depth=1)
@@ -396,7 +396,7 @@ class TestKuzuStoreTraverse:
         assert depths.get("fn-query") == 2
 
 
-class TestKuzuStoreStats:
+class TestGraphStoreStats:
     def test_stats_empty(self, store):
         stats = store.get_stats()
         assert stats["total_nodes"] == 0
@@ -419,7 +419,7 @@ class TestKuzuStoreStats:
         assert stats["total_nodes"] == 1
 
 
-class TestKuzuStoreImportBatch:
+class TestGraphStoreImportBatch:
     def test_batch_import(self, store):
         nodes = [
             {"id": "b1", "type": "File", "name": "a.py", "properties": {"lang": "py"}},
@@ -437,12 +437,12 @@ class TestKuzuStoreImportBatch:
         assert summary["relationships_created"] == 0
 
 
-class TestKuzuStoreContextManager:
+class TestGraphStoreContextManager:
     def test_context_manager(self, tmp_path):
         db_path = str(tmp_path / "ctxdb")
-        with KuzuStore(db_path) as s:
+        with GraphStore(db_path) as s:
             s.add_node("cm-1", "File", "test.py")
             assert s.get_node("cm-1") is not None
         # After __exit__, re-opening should still see the data
-        with KuzuStore(db_path) as s2:
+        with GraphStore(db_path) as s2:
             assert s2.get_node("cm-1") is not None

--- a/agent/tests/opentrace_agent/pipeline/test_graph_adapter.py
+++ b/agent/tests/opentrace_agent/pipeline/test_graph_adapter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for KuzuStoreAdapter — verifies batching, flush ordering, and close."""
+"""Tests for GraphStoreAdapter — verifies batching, flush ordering, and close."""
 
 from __future__ import annotations
 
@@ -21,25 +21,25 @@ import pytest
 from opentrace_agent.pipeline.types import GraphNode, GraphRelationship
 
 # Skip entire module if real_ladybug (LadybugDB) is not installed
-kuzu = pytest.importorskip("real_ladybug")
+ladybug = pytest.importorskip("real_ladybug")
 
-KuzuStoreAdapter = pytest.importorskip("opentrace_agent.pipeline.adapters").KuzuStoreAdapter
-KuzuStore = pytest.importorskip("opentrace_agent.store").KuzuStore
+GraphStoreAdapter = pytest.importorskip("opentrace_agent.pipeline.adapters").GraphStoreAdapter
+GraphStore = pytest.importorskip("opentrace_agent.store").GraphStore
 
 
 @pytest.fixture()
-def kuzu_store(tmp_path):
-    """Create a KuzuStore in a temp directory."""
+def graph_store(tmp_path):
+    """Create a GraphStore in a temp directory."""
     db_path = str(tmp_path / "testdb")
-    store = KuzuStore(db_path)
+    store = GraphStore(db_path)
     yield store
     store.close()
 
 
 @pytest.fixture()
-def adapter(kuzu_store):
-    """Create a KuzuStoreAdapter wrapping the kuzu_store fixture."""
-    return KuzuStoreAdapter(kuzu_store, batch_size=5)
+def adapter(graph_store):
+    """Create a GraphStoreAdapter wrapping the graph_store fixture."""
+    return GraphStoreAdapter(graph_store, batch_size=5)
 
 
 def _make_node(i: int) -> GraphNode:
@@ -60,46 +60,46 @@ def _make_rel(i: int, src: int, tgt: int) -> GraphRelationship:
     )
 
 
-class TestKuzuStoreAdapter:
-    def test_save_node_and_flush(self, adapter, kuzu_store):
+class TestGraphStoreAdapter:
+    def test_save_node_and_flush(self, adapter, graph_store):
         """Nodes saved via adapter should be retrievable after flush."""
         adapter.save_node(_make_node(1))
         adapter.save_node(_make_node(2))
         adapter.flush()
 
-        n1 = kuzu_store.get_node("node-1")
+        n1 = graph_store.get_node("node-1")
         assert n1 is not None
         assert n1["name"] == "func_1"
         assert n1["type"] == "Function"
 
-        n2 = kuzu_store.get_node("node-2")
+        n2 = graph_store.get_node("node-2")
         assert n2 is not None
 
-    def test_save_relationship_after_nodes(self, adapter, kuzu_store):
+    def test_save_relationship_after_nodes(self, adapter, graph_store):
         """Relationships should reference existing nodes after flush."""
         adapter.save_node(_make_node(1))
         adapter.save_node(_make_node(2))
         adapter.save_relationship(_make_rel(1, src=1, tgt=2))
         adapter.flush()
 
-        stats = kuzu_store.get_stats()
+        stats = graph_store.get_stats()
         assert stats["total_nodes"] == 2
         assert stats["total_edges"] == 1
 
-    def test_auto_flush_at_batch_size(self, adapter, kuzu_store):
+    def test_auto_flush_at_batch_size(self, adapter, graph_store):
         """Nodes should auto-flush when batch_size (5) is reached."""
         for i in range(5):
             adapter.save_node(_make_node(i))
 
         # Should have been auto-flushed
-        nodes = kuzu_store.list_nodes("Function")
+        nodes = graph_store.list_nodes("Function")
         assert len(nodes) == 5
 
     def test_close_flushes_and_closes(self, tmp_path):
         """close() should flush remaining items and close the DB."""
         db_path = str(tmp_path / "closedb")
-        store = KuzuStore(db_path)
-        adapter = KuzuStoreAdapter(store, batch_size=100)
+        store = GraphStore(db_path)
+        adapter = GraphStoreAdapter(store, batch_size=100)
 
         adapter.save_node(_make_node(1))
         adapter.save_node(_make_node(2))
@@ -107,7 +107,7 @@ class TestKuzuStoreAdapter:
         adapter.close()
 
         # Re-open and verify data persisted
-        store2 = KuzuStore(db_path)
+        store2 = GraphStore(db_path)
         try:
             assert store2.get_node("node-1") is not None
             assert store2.get_node("node-2") is not None
@@ -116,14 +116,14 @@ class TestKuzuStoreAdapter:
         finally:
             store2.close()
 
-    def test_empty_flush_is_noop(self, adapter, kuzu_store):
+    def test_empty_flush_is_noop(self, adapter, graph_store):
         """Flushing with no pending items should not error."""
         adapter.flush()
-        stats = kuzu_store.get_stats()
+        stats = graph_store.get_stats()
         assert stats["total_nodes"] == 0
 
-    def test_node_properties_roundtrip(self, adapter, kuzu_store):
-        """Properties should survive the adapter → KuzuDB → read roundtrip."""
+    def test_node_properties_roundtrip(self, adapter, graph_store):
+        """Properties should survive the adapter → LadybugDB → read roundtrip."""
         node = GraphNode(
             id="prop-test",
             type="File",
@@ -133,7 +133,7 @@ class TestKuzuStoreAdapter:
         adapter.save_node(node)
         adapter.flush()
 
-        result = kuzu_store.get_node("prop-test")
+        result = graph_store.get_node("prop-test")
         assert result is not None
         assert result["properties"]["language"] == "python"
         assert result["properties"]["lines"] == 42

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,7 +10,7 @@
 │                                  │  WASM parsers   │ │
 │                                  └─────────────────┘ │
 │                                  ┌─────────────────┐ │
-│                                  │  KuzuDB WASM    │ │
+│                                  │  LadybugDB WASM    │ │
 │                                  │  graph store    │ │
 │                                  └─────────────────┘ │
 └──────────────────────────────────────────────────────┘
@@ -24,7 +24,7 @@ React/TypeScript frontend that runs entirely in the browser. Includes:
 
 - **Graph Explorer** — visual graph navigation and search
 - **Tree-sitter Web Worker** — parses source files using WASM grammars
-- **KuzuDB WASM** — embedded graph database for storing and querying the knowledge graph
+- **LadybugDB WASM** — embedded graph database for storing and querying the knowledge graph
 - **Chat Agent** — in-app AI agent with access to graph tools via MCP
 
 ### Protobuf Definitions (`proto/`)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -23,5 +23,5 @@ When you add a repository, OpenTrace will:
 1. Fetch the source code via the GitHub/GitLab API
 2. Parse every file using tree-sitter WASM grammars
 3. Extract symbols (classes, functions, imports) and relationships
-4. Build a knowledge graph in an embedded KuzuDB instance
+4. Build a knowledge graph in an embedded LadybugDB instance
 5. Make the graph available for exploration and querying

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ OpenTrace indexes source code directly in your browser — no server required. P
 
 1. **Parse** every file using tree-sitter WASM grammars (12 languages)
 2. **Extract** classes, functions, imports, and call relationships
-3. **Build** a knowledge graph stored in KuzuDB WASM (embedded graph database)
+3. **Build** a knowledge graph stored in LadybugDB WASM (embedded graph database)
 4. **Summarize** every node using template-based identifier analysis
 5. **Expose** the graph to an in-app chat agent via MCP tools
 

--- a/ui/src/pipeline/__tests__/cross-repo.test.ts
+++ b/ui/src/pipeline/__tests__/cross-repo.test.ts
@@ -199,9 +199,9 @@ describe('cross-repo: same project imported twice with different repo names', ()
     expect(flaskImports.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('pipeline emits duplicate Package nodes across runs (KuzuStore dedup required)', () => {
+  it('pipeline emits duplicate Package nodes across runs (LadybugStore dedup required)', () => {
     // The pipeline has no cross-run state, so each run independently emits
-    // shared Package nodes like pkg:pypi:flask. This is expected — KuzuStore
+    // shared Package nodes like pkg:pypi:flask. This is expected — LadybugStore
     // deduplicates Package nodes in flush() to avoid PK violations.
     const allEmittedNodes: { id: string; type: string; from: string }[] = [];
 

--- a/ui/src/runner/browser/parser/pipeline.ts
+++ b/ui/src/runner/browser/parser/pipeline.ts
@@ -432,7 +432,7 @@ export async function runPipeline(
 
       // (c) Summarize each symbol inline (using symbolInfoOut + file content lines)
       //     Merge summaries into the existing nodes in fileBatch rather than
-      //     emitting duplicate nodes (which causes PK violations in KuzuDB
+      //     emitting duplicate nodes (which causes PK violations in LadybugDB
       //     and property loss in the in-memory store).
       const lines = file.content.split('\n');
       const symbolNames: string[] = [];

--- a/ui/src/store/__tests__/context.test.tsx
+++ b/ui/src/store/__tests__/context.test.tsx
@@ -19,9 +19,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import React from 'react';
 
-// Mock KuzuGraphStore and crossOriginIsolated
-vi.mock('../kuzuStore', () => ({
-  KuzuGraphStore: vi.fn().mockImplementation(() => ({
+// Mock LadybugGraphStore and crossOriginIsolated
+vi.mock('../ladybugStore', () => ({
+  LadybugGraphStore: vi.fn().mockImplementation(() => ({
     fetchGraph: vi.fn().mockResolvedValue({ nodes: [], links: [] }),
     fetchStats: vi.fn().mockResolvedValue({
       total_nodes: 0,

--- a/ui/src/store/context.tsx
+++ b/ui/src/store/context.tsx
@@ -15,7 +15,7 @@
  */
 
 import { createContext, use, type ReactNode } from 'react';
-import { KuzuGraphStore } from './kuzuStore';
+import { LadybugGraphStore } from './ladybugStore';
 import type { GraphStore } from './types';
 
 interface StoreContextValue {
@@ -25,10 +25,10 @@ interface StoreContextValue {
 const StoreContext = createContext<StoreContextValue | null>(null);
 
 // Module-level singleton — survives React StrictMode double-invocation.
-// Without this, StrictMode creates two KuzuGraphStore instances (two workers,
+// Without this, StrictMode creates two LadybugGraphStore instances (two workers,
 // two independent in-memory databases), so imports go to one and reads to the other.
-let singletonStore: KuzuGraphStore | null = null;
-function getStore(): KuzuGraphStore {
+let singletonStore: LadybugGraphStore | null = null;
+function getStore(): LadybugGraphStore {
   if (!singletonStore) {
     if (!crossOriginIsolated) {
       throw new Error(
@@ -36,7 +36,7 @@ function getStore(): KuzuGraphStore {
           'for in-browser LadybugDB. Serve with appropriate headers.',
       );
     }
-    singletonStore = new KuzuGraphStore();
+    singletonStore = new LadybugGraphStore();
   }
   return singletonStore;
 }

--- a/ui/src/store/inMemoryStore.ts
+++ b/ui/src/store/inMemoryStore.ts
@@ -17,7 +17,7 @@
 /**
  * In-memory GraphStore implementation.
  *
- * Drop-in replacement for KuzuGraphStore (LadybugDB) that keeps everything in Maps.
+ * Drop-in replacement for LadybugGraphStore that keeps everything in Maps.
  * No WASM, no workers, no COOP/COEP headers required.
  */
 

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -182,7 +182,7 @@ function unionAllTextSearch(escapedLower: string): string {
 
 // ---- Store implementation ----
 
-export class KuzuGraphStore implements GraphStore {
+export class LadybugGraphStore implements GraphStore {
   private lbug!: LbugModule;
   private conn!: WebConnection;
   private ready: Promise<void>;
@@ -339,7 +339,7 @@ export class KuzuGraphStore implements GraphStore {
     }
 
     console.log(
-      `[KuzuStore] fetchGraph: ${data.nodes.length} nodes, ${data.links.length} edges in ${(performance.now() - t0).toFixed(0)}ms`,
+      `[LadybugStore] fetchGraph: ${data.nodes.length} nodes, ${data.links.length} edges in ${(performance.now() - t0).toFixed(0)}ms`,
     );
     return data;
   }
@@ -363,7 +363,7 @@ export class KuzuGraphStore implements GraphStore {
       totalNodes > this.maxVisNodes || totalEdges > this.maxVisEdges;
     if (isLarge) {
       console.log(
-        `[KuzuStore] Graph large: ${totalNodes} nodes, ${totalEdges} edges. Limiting to ${this.maxVisNodes}/${this.maxVisEdges}.`,
+        `[LadybugStore] Graph large: ${totalNodes} nodes, ${totalEdges} edges. Limiting to ${this.maxVisNodes}/${this.maxVisEdges}.`,
       );
     }
 
@@ -626,7 +626,7 @@ export class KuzuGraphStore implements GraphStore {
 
     // Deduplicate nodes by ID, merging properties. The pipeline may emit
     // the same node twice (e.g. structure batch + summary update) which
-    // would cause KuzuDB COPY FROM primary-key violations.
+    // would cause LadybugDB COPY FROM primary-key violations.
     const nodeDedup = new Map<string, (typeof rawNodes)[0]>();
     for (const node of rawNodes) {
       const existing = nodeDedup.get(node.id);
@@ -670,7 +670,7 @@ export class KuzuGraphStore implements GraphStore {
       for (const node of nodes) {
         if (!NODE_TYPE_SET.has(node.type)) {
           console.warn(
-            `[KuzuStore] Unknown node type '${node.type}' for node ${node.id}, skipping`,
+            `[LadybugStore] Unknown node type '${node.type}' for node ${node.id}, skipping`,
           );
           continue;
         }
@@ -707,13 +707,13 @@ export class KuzuGraphStore implements GraphStore {
         const tgtType = this.nodeTypeMap.get(rel.target_id);
         if (!srcType || !tgtType) {
           console.warn(
-            `[KuzuStore] Skipping rel ${rel.id}: unknown node type (src=${srcType}, tgt=${tgtType})`,
+            `[LadybugStore] Skipping rel ${rel.id}: unknown node type (src=${srcType}, tgt=${tgtType})`,
           );
           continue;
         }
         if (!REL_PAIR_SET.has(`${srcType}_${tgtType}`)) {
           console.warn(
-            `[KuzuStore] Skipping rel ${rel.id}: unsupported pair ${srcType} → ${tgtType}`,
+            `[LadybugStore] Skipping rel ${rel.id}: unsupported pair ${srcType} → ${tgtType}`,
           );
           continue;
         }
@@ -727,7 +727,7 @@ export class KuzuGraphStore implements GraphStore {
 
     const elapsed = performance.now() - t0;
     console.log(
-      `[KuzuStore] flush: ${nodes.length} nodes, ${rels.length} rels in ${elapsed.toFixed(0)}ms`,
+      `[LadybugStore] flush: ${nodes.length} nodes, ${rels.length} rels in ${elapsed.toFixed(0)}ms`,
     );
   }
 
@@ -760,7 +760,7 @@ export class KuzuGraphStore implements GraphStore {
       } catch (err) {
         // Last resort: per-row INSERT
         console.warn(
-          `[KuzuStore] COPY RELATES_${key} failed, inserting rows individually:`,
+          `[LadybugStore] COPY RELATES_${key} failed, inserting rows individually:`,
           err,
         );
         const [srcType, tgtType] = key.split('_');
@@ -772,7 +772,10 @@ export class KuzuGraphStore implements GraphStore {
                 `CREATE (a)-[:RELATES {id: '${esc(rel.id)}', type: '${esc(rel.type)}', properties: '${esc(props)}'}]->(b)`,
             );
           } catch (insertErr) {
-            console.warn(`[KuzuStore] INSERT rel failed: ${rel.id}`, insertErr);
+            console.warn(
+              `[LadybugStore] INSERT rel failed: ${rel.id}`,
+              insertErr,
+            );
           }
         }
       }

--- a/ui/src/store/types.ts
+++ b/ui/src/store/types.ts
@@ -16,7 +16,7 @@
 
 import type { GraphData, GraphStats } from '@opentrace/components/utils';
 
-// ---- Shared result types (previously in kuzuProtocol.ts) ----
+// ---- Shared result types ----
 
 export interface NodeResult {
   id: string;


### PR DESCRIPTION
## Rename KuzuDB references to LadybugDB
♻️ **Refactor** · 🐛 **Bug Fix**

This PR renames all references to `KuzuDB` and `KuzuStore`/`KuzuGraphStore` to `LadybugDB` and `GraphStore`/`LadybugGraphStore` across the entire codebase. The underlying embedded graph database has been rebranded, so this aligns code, comments, docs, and test identifiers with the new name. A small functional fix to property parsing is included alongside the rename.

### Complexity
🟢 Low · `22 files changed, 551 insertions(+), 134 deletions(-)`

Almost entirely a mechanical rename across Python, TypeScript, docs, and config. The one non-trivial change is the addition of `_parse_props` in `graph_store.py`, which handles the case where LadybugDB returns properties already deserialized as a `dict` rather than a JSON string — this is a real behaviour difference from KuzuDB that `_unmarshal_props` alone didn't handle. A new comprehensive test file covers both the helper functions and the `GraphStore` integration. The rename itself carries no risk of regressions, but the `_parse_props` change and its interaction with all call sites deserves a quick look.

### Tests
🧪 A new `test_graph_store.py` adds broad unit and integration tests for `GraphStore`, including specific coverage of the new `_parse_props` helper; the existing adapter test file is renamed and updated in place.

### Note
⚠️ The Go `api/` package and its `KuzuStore` equivalent have been removed from `CLAUDE.md` — it's unclear if the Go server was intentionally dropped from the project or just from the docs. Worth confirming before merge if the Go backend is still in the repo.

### Review focus
Pay particular attention to the following areas:

- **`_parse_props` correctness** — the new helper silently coerces falsy non-string/non-dict values (e.g. `0`) to `None`; verify this is safe for all call sites in `graph_store.py`
- **File renames** — `kuzu_store.py` → `graph_store.py` and `kuzuStore.ts` → `ladybugStore.ts`; confirm no import paths were missed that could cause runtime `ModuleNotFoundError` or bundler errors

---

<details>
<summary><strong>Additional details</strong></summary>

### Why `_parse_props` was needed

KuzuDB always returned graph properties serialised as JSON strings, so `_unmarshal_props(str(val))` was safe everywhere. LadybugDB can return properties already deserialised as a Python `dict`. The old code would call `str()` on the dict, producing a Python repr string (`{'key': 'value'}`) that `json.loads` then rejects with a `JSONDecodeError`. `_parse_props` short-circuits on `dict` inputs before reaching the JSON path.

### Scope of the rename

The rename touches Python agent code, TypeScript UI store, React context, inline comments, tests, docs, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `SECURITY.md`, and the agent `docker-compose.yml` (image name, volume path, and env var). The `api/` Go server section was removed from `CLAUDE.md` entirely — the diff doesn't show a Go file rename, so the Go package may still reference `Kuzu` internally.

</details>
<!-- opentrace:jid=j-41f388f7-2dd6-478b-8fa5-4b5fa7e14f1c|sha=f26ef6e90edf78d45441e9ad4b3350fdb4d802bd -->