### PR TITLE
fix(ui): show DEPENDS_ON relationships by default

### DIFF
--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -297,9 +297,7 @@ const GraphViewer = memo(
       );
       const [hops, setHops] = useState(2);
       const [hiddenNodeTypes, setHiddenNodeTypes] = useState(new Set<string>());
-      const [hiddenLinkTypes, setHiddenLinkTypes] = useState(
-        new Set<string>(['DEPENDS_ON']),
-      );
+      const [hiddenLinkTypes, setHiddenLinkTypes] = useState(new Set<string>());
       const [hiddenSubTypes, setHiddenSubTypes] = useState(new Set<string>());
       const [hiddenCommunities, setHiddenCommunities] = useState(
         new Set<number>(),


### PR DESCRIPTION
## Show DEPENDS_ON links by default in graph viewer
✨ **Improvement**

Removes the default hidden state for `DEPENDS_ON` link type in the graph viewer, so dependency edges are now visible when the graph first loads.

### Complexity
🟢 Trivial · `1 file changed, 1 insertion(+), 3 deletions(-)`

Single-line initialiser change with no logic affected. The only impact is on the default UI state for one filter toggle.

### Tests
🧪 No tests included — the change affects only a default UI state value.
<!-- opentrace:jid=ef3788df-e20b-4fda-af65-afa6490c4732|sha=cc640243bd53e55419566d915557e8dd11d76d8c -->