### PR TITLE
feat(ui): add PR lookup input to load any PR by number or link

### DIFF
--- a/ui/src/components/PRListPanel.css
+++ b/ui/src/components/PRListPanel.css
@@ -22,6 +22,61 @@
   padding: 0;
 }
 
+.pr-lookup-bar {
+  display: flex;
+  gap: 6px;
+  padding: 12px 20px 0;
+}
+
+.pr-lookup-input {
+  flex: 1;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in oklch, var(--border) 40%, transparent);
+  background: var(--background);
+  color: var(--foreground);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.pr-lookup-input:focus {
+  border-color: var(--primary);
+}
+
+.pr-lookup-input::placeholder {
+  color: var(--muted-foreground);
+  opacity: 0.6;
+}
+
+.pr-lookup-btn {
+  padding: 6px 14px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in oklch, var(--primary) 30%, transparent);
+  background: color-mix(in oklch, var(--primary) 10%, transparent);
+  color: var(--primary);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.pr-lookup-btn:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--primary) 20%, transparent);
+}
+
+.pr-lookup-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pr-lookup-error {
+  padding: 4px 20px;
+  font-size: 0.72rem;
+  color: var(--destructive);
+}
+
 .pr-list-header {
   display: flex;
   align-items: center;

--- a/ui/src/components/PRListPanel.tsx
+++ b/ui/src/components/PRListPanel.tsx
@@ -24,6 +24,35 @@ import PRDetailPanel from './PRDetailPanel';
 import { OpenTraceLogo } from './OpenTraceLogo';
 import './PRListPanel.css';
 
+/**
+ * Parse user input that is either a bare PR/MR number or a full URL.
+ * Returns the extracted number, or null if unparseable.
+ */
+function parsePRInput(input: string): number | null {
+  const trimmed = input.trim().replace(/^#/, '');
+  // Plain number (with optional leading #)
+  const num = parseInt(trimmed, 10);
+  if (/^\d+$/.test(trimmed) && num > 0) return num;
+
+  // GitHub: /pull/123
+  const gh = trimmed.match(/\/pull\/(\d+)/);
+  if (gh) return parseInt(gh[1], 10);
+
+  // GitLab: /merge_requests/123 or /-/merge_requests/123
+  const gl = trimmed.match(/\/merge_requests\/(\d+)/);
+  if (gl) return parseInt(gl[1], 10);
+
+  // Bitbucket: /pull-requests/123
+  const bb = trimmed.match(/\/pull-requests\/(\d+)/);
+  if (bb) return parseInt(bb[1], 10);
+
+  // Azure DevOps: /pullrequest/123
+  const ado = trimmed.match(/\/pullrequest\/(\d+)/);
+  if (ado) return parseInt(ado[1], 10);
+
+  return null;
+}
+
 interface Props {
   prClient: PRClient;
   store: GraphStore;
@@ -58,6 +87,8 @@ export default function PRListPanel({
   const [selectedPR, setSelectedPR] = useState<PRDetail | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [indexingAll, setIndexingAll] = useState(false);
+  const [lookupInput, setLookupInput] = useState('');
+  const [lookupError, setLookupError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -127,6 +158,25 @@ export default function PRListPanel({
     setIndexingAll(false);
   };
 
+  const handleLookup = async () => {
+    const prNumber = parsePRInput(lookupInput);
+    if (prNumber === null) {
+      setLookupError('Enter a PR number (e.g. 123) or a link');
+      return;
+    }
+    setLookupError(null);
+    setLoadingDetail(true);
+    try {
+      const detail = await prClient.getPRDetail(prNumber);
+      setSelectedPR(detail);
+      setLookupInput('');
+    } catch (err) {
+      setLookupError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoadingDetail(false);
+    }
+  };
+
   if (selectedPR) {
     return (
       <PRDetailPanel
@@ -166,6 +216,29 @@ export default function PRListPanel({
 
   return (
     <div className="pr-list-panel">
+      <div className="pr-lookup-bar">
+        <input
+          className="pr-lookup-input"
+          type="text"
+          placeholder="Load PR by number or link..."
+          value={lookupInput}
+          onChange={(e) => {
+            setLookupInput(e.target.value);
+            setLookupError(null);
+          }}
+          onKeyDown={(e) => e.key === 'Enter' && handleLookup()}
+          disabled={loadingDetail}
+        />
+        <button
+          className="pr-lookup-btn"
+          onClick={handleLookup}
+          disabled={loadingDetail || !lookupInput.trim()}
+        >
+          {loadingDetail ? 'Loading...' : 'Go'}
+        </button>
+      </div>
+      {lookupError && <div className="pr-lookup-error">{lookupError}</div>}
+
       <div className="pr-list-header">
         <span className="pr-list-count">
           {prs.length} open {prs.length === 1 ? 'PR' : 'PRs'}


### PR DESCRIPTION
## Add direct PR lookup by number or URL
🆕 **New Feature**

Adds a lookup bar to the PR list panel so users can jump directly to any PR by entering a number (e.g. `123` or `#123`) or a full URL from GitHub, GitLab, Bitbucket, or Azure DevOps — without needing the PR to appear in the open-PR list.

### Complexity
🟢 Low · `2 files changed, 128 insertions(+)`

Self-contained addition of a single UI control and its parsing/fetching logic. Touches only one component and its stylesheet. No shared state, no new API surface — it reuses the existing `prClient.getPRDetail` call.

### Tests
🧪 No tests included for `parsePRInput`, which handles non-trivial URL pattern matching across four different hosting platforms.

### Review focus
Pay particular attention to the following areas:

- **URL parsing correctness** — `parsePRInput` uses sequential regex matches with no fallback deduplication; verify edge cases like URLs with query strings, fragments, or ambiguous paths don't silently return wrong PR numbers.
<!-- opentrace:jid=j-6d98fa06-881c-4be4-8e5f-0c11f47553fe|sha=01bd0c217a9bfa5ef2b2127eaac79f344bc31d8e -->