### PR TITLE
feat(ui): enable source maps in production build

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -142,6 +142,9 @@ export default defineConfig(({ mode }) => {
       },
       dedupe: ['react', 'react-dom'],
     },
+    build: {
+      sourcemap: true,
+    },
     plugins: [react(), crossOriginIsolation()],
     server: {
       port,


### PR DESCRIPTION
## Enable source maps in UI production build
✨ **Improvement**

Enables source map generation in the Vite production build config. This makes it possible to get meaningful stack traces and debug production errors in the UI.

### Complexity
🟢 Trivial · `1 file changed, 3 insertions(+)`

Single-line config change in Vite with no logic, no interactions with other systems, and no risk of breakage.

### Note
⚠️ Source maps will be included in the build output, which slightly increases artifact size. If there are privacy or IP concerns about shipping source maps to end users, consider using `hidden` source maps (uploaded to an error tracker only) instead of `true`.
<!-- opentrace:jid=f329615f-6e29-4aaf-9404-c87fb1607d83|sha=d51e1c956accd20d98d5425e88da54aa7ec9587d -->