### PR TITLE
feat(ui): add zoom-on-select toggle to graph controls

### DIFF
--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -1358,7 +1358,11 @@ const GraphViewer = memo(
             <button
               className={`graph-control-btn${zoomOnSelect ? ' graph-control-btn--active' : ''}`}
               onClick={() => setZoomOnSelect((z) => !z)}
-              title={zoomOnSelect ? 'Zoom to node on click (on)' : 'Zoom to node on click (off)'}
+              title={
+                zoomOnSelect
+                  ? 'Zoom to node on click (on)'
+                  : 'Zoom to node on click (off)'
+              }
             >
               <svg
                 width="16"


### PR DESCRIPTION
## Add toggleable zoom-on-select for graph nodes
🆕 **New Feature**

Adds a toolbar button to the graph viewer that lets users toggle whether the view automatically zooms to a node's neighbourhood when a node is clicked. Previously, zoom-on-select was always on with no way to disable it.

### Complexity
🟢 Trivial · `1 file changed, 30 insertions(+), 2 deletions(-)`

Single boolean state added to one component, wired to an existing code path and a new toolbar button. No data flow, API, or cross-component concerns.

### Tests
🧪 No tests included — the change is purely UI/interaction behaviour with no associated test updates.
<!-- opentrace:jid=j-389382bc-9bc7-4155-a2b7-45d9e57325ae|sha=3f615c57e835c853f0788c5be833648b33c28371 -->