### PR TITLE
feat: add /devstatus slash command

### DIFF
--- a/.claude/commands/devstatus.md
+++ b/.claude/commands/devstatus.md
@@ -1,5 +1,5 @@
 ---
-name: status
+name: devstatus
 description: |
   Report the current session state: branch, changes, PR status, and a summary.
   Use when: "what's the status", "where are we", "session status", "what have we done"


### PR DESCRIPTION
## Rename /status command to /devstatus
🔧 **Chore**

Renames the `/status` slash command to `/devstatus` to avoid conflicts with other commands or tooling that may already use that name.

### Complexity
🟢 Trivial · `1 file changed, 78 insertions(+)`

Single file rename with a one-word change to the command name. No logic changes, no other files affected.
<!-- opentrace:jid=e2ff0998-28a8-42c4-9db6-2c53490cd9e9|sha=fc377d3d7adc59c2a67c65ab79d7176c71db2261 -->