### PR TITLE
feat(ui): support ?repo= query parameter for deep linking

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -101,10 +101,7 @@ function App() {
       if (existing) {
         setActiveRepoUrl(repoUrl);
         await graphViewerRef.current?.reload(existing.id, 2);
-        setTimeout(
-          () => graphViewerRef.current?.selectNode(existing.id),
-          100,
-        );
+        setTimeout(() => graphViewerRef.current?.selectNode(existing.id), 100);
       } else {
         const provider = detectProvider(repoUrl);
         const token = provider


### PR DESCRIPTION
## Summary

- Add `?repo=` URL query parameter support to the UI so external tools (e.g. a Chrome extension) can deep link to OpenTrace with a repo pre-loaded
- On mount, reads `?repo=` param — if the repo is already indexed, navigates to it; otherwise auto-triggers indexing using any stored PAT
- Suppresses the auto-open AddRepoModal while the deep link is being processed to prevent a race condition

## Test plan

- [x] Open `http://localhost:5173?repo=https://github.com/expressjs/express` — should auto-index Express
- [x] Index a repo first, then reload with `?repo=<that-url>` — should navigate to it without re-indexing
- [x] Open `http://localhost:5173` (no param) — should behave exactly as before
- [x] Verify "Add Repository" button still works after deep link completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)