### PR TITLE
fix(ui): fix indexing modal close behavior

### DIFF
--- a/components/src/indexing/IndexingProgress.tsx
+++ b/components/src/indexing/IndexingProgress.tsx
@@ -164,8 +164,6 @@ export default function IndexingProgress({
   stages: stageConfig,
   icon,
   onClose,
-  onCancel,
-  onMinimize,
   title,
   message,
 }: IndexingProgressProps) {
@@ -280,11 +278,8 @@ export default function IndexingProgress({
 
             {message && <p className="indexing-message">{message}</p>}
 
-            <button
-              className="btn-cta btn-cta--secondary"
-              onClick={onMinimize ?? onClose}
-            >
-              {onMinimize ? 'Minimize' : 'Close'}
+            <button className="btn-cta btn-cta--secondary" onClick={onClose}>
+              Close
             </button>
           </div>
         </div>
@@ -313,12 +308,6 @@ export default function IndexingProgress({
             relationships={state.relationshipsCreated}
           />
           {message && <p className="indexing-message">{message}</p>}
-          <button
-            className="btn-cta btn-cta--secondary"
-            onClick={onMinimize ?? onCancel}
-          >
-            {onMinimize ? 'Minimize' : 'Cancel'}
-          </button>
         </div>
       </div>
     </div>

--- a/components/src/indexing/types.ts
+++ b/components/src/indexing/types.ts
@@ -75,8 +75,6 @@ export interface IndexingProgressProps {
   /** Icon shown in the header while running (e.g. a provider logo). */
   icon?: import('react').ReactNode;
   onClose: () => void;
-  onCancel: () => void;
-  onMinimize?: () => void;
   /** Override the header title (default: "Indexing Repository" when running, "Complete" when done). */
   title?: string;
   /** Supplementary message shown below stats (e.g. "Loading graph..."). */

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -57,10 +57,15 @@
   transition: all 0.2s;
 }
 
-.add-repo-btn:hover {
+.add-repo-btn:hover:not(:disabled) {
   background: color-mix(in oklch, var(--primary) 10%, transparent);
   color: var(--primary);
   border-color: color-mix(in oklch, var(--primary) 30%, transparent);
+}
+
+.add-repo-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* FilterPanel styles are now in @opentrace/components */

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -84,7 +84,10 @@ function App() {
     setJobExpanded(false);
   }, [cancelJob]);
 
-  const handleJobMinimize = useCallback(() => minimizeJob(), [minimizeJob]);
+  const handleJobMinimize = useCallback(() => {
+    minimizeJob();
+    setJobExpanded(false);
+  }, [minimizeJob]);
   const handleJobExpand = useCallback(() => setJobExpanded(true), []);
   const handleAddRepoOpen = useCallback(() => setShowAddRepo(true), []);
   const handleAddRepoClose = useCallback(() => setShowAddRepo(false), []);

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -872,8 +872,6 @@ const GraphViewer = memo(
                 {...toIndexingProps(jobState, activeRepoUrl)}
                 stages={INDEXING_STAGES}
                 onClose={onJobClose}
-                onCancel={onJobCancel}
-                onMinimize={onJobMinimize}
               />
             )}
 
@@ -1195,6 +1193,7 @@ const GraphViewer = memo(
                   <button
                     className="add-repo-btn"
                     onClick={onAddRepoOpen}
+                    disabled
                     title="Add Repository"
                   >
                     <svg
@@ -1293,8 +1292,6 @@ const GraphViewer = memo(
               {...toIndexingProps(jobState, activeRepoUrl)}
               stages={INDEXING_STAGES}
               onClose={onJobClose}
-              onCancel={onJobCancel}
-              onMinimize={onJobMinimize}
             />
           )}
 


### PR DESCRIPTION
## Remove cancel/minimize from indexing UI, disable add-repo
✨ **Improvement** · 🐛 **Bug Fix**

Strips the `onCancel` and `onMinimize` props from `IndexingProgress` and their associated buttons, leaving only a single "Close" action. Also permanently disables the "Add Repository" button in `GraphViewer` and fixes a minimize-state bug in `App.tsx`.

### Complexity
🟢 Low · `5 files changed, 13 insertions(+), 21 deletions(-)`

Touches three layers (component library, UI app, CSS) but the changes are straightforward removals and a one-liner disable. The contract change to `IndexingProgressProps` is the most consequential part — any other callers of the component not in this diff would break — but the risk is contained to a single, well-defined interface.

### Tests
🧪 No tests included; the removed props and buttons are UI-only with no added logic.

### Note
⚠️ The `onCancel` and `onMinimize` props are **removed from the exported component interface** in `@opentrace/components`. Any downstream consumers not updated in this PR will have a TypeScript compile error.

### Review focus
Pay particular attention to the following areas:

- **Prop removal breaking callers** — `onCancel` and `onMinimize` are deleted from the public `IndexingProgressProps` interface; verify no other consumers of the component package still pass these props.
- **Disabled Add Repo button** — the button is hardcoded `disabled` with no feature-flag or runtime condition; confirm this is intentional and not accidentally left in.

---

<details>
<summary><strong>Additional details</strong></summary>

### Minimize bug fix

`handleJobMinimize` previously called `minimizeJob()` but did not call `setJobExpanded(false)`. This left the expanded panel open in the UI even after the job was minimized to the tray. The fix adds the missing state reset.

</details>
<!-- opentrace:jid=ee7f99f0-cf1e-498d-bf85-28e81d6bec58|sha=31a4424ab0b99cf690a07b12713c71585e21fe90 -->