### PR TITLE
feat(ui): add community focus target button

### DIFF
--- a/components/src/panels/FilterPanel.css
+++ b/components/src/panels/FilterPanel.css
@@ -199,3 +199,31 @@
   width: 6px !important;
   height: 6px !important;
 }
+
+/* Focus / target button */
+.filter-focus-btn {
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 3px;
+  opacity: 0;
+  transition:
+    opacity 0.15s,
+    color 0.15s,
+    background 0.1s;
+}
+
+.filter-item:hover .filter-focus-btn {
+  opacity: 1;
+}
+
+.filter-focus-btn:hover {
+  color: var(--primary);
+  background: color-mix(in oklch, var(--primary) 12%, transparent);
+}

--- a/components/src/panels/FilterPanel.tsx
+++ b/components/src/panels/FilterPanel.tsx
@@ -26,6 +26,7 @@ export default function FilterPanel({
   onHideAll,
   indicator = 'dot',
   emptyMessage,
+  onFocus,
 }: FilterPanelProps) {
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
 
@@ -130,6 +131,33 @@ export default function FilterPanel({
                 )}
                 <span className="filter-type-name">{item.label}</span>
                 <span className="filter-count">{item.count}</span>
+                {onFocus && (
+                  <button
+                    className="filter-focus-btn"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onFocus(item.key);
+                    }}
+                    title={`Focus on ${item.label}`}
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                    >
+                      <circle cx="8" cy="8" r="5.5" />
+                      <circle cx="8" cy="8" r="2" />
+                      <line x1="8" y1="0" x2="8" y2="3" />
+                      <line x1="8" y1="13" x2="8" y2="16" />
+                      <line x1="0" y1="8" x2="3" y2="8" />
+                      <line x1="13" y1="8" x2="16" y2="8" />
+                    </svg>
+                  </button>
+                )}
               </label>
               {hasChildren && isExpanded && (
                 <div className="filter-subtypes">

--- a/components/src/panels/types.ts
+++ b/components/src/panels/types.ts
@@ -41,6 +41,8 @@ export interface FilterPanelProps {
   indicator?: 'dot' | 'line';
   /** Message when items is empty. */
   emptyMessage?: string;
+  /** Called when the focus/target button is clicked for an item. */
+  onFocus?: (key: string) => void;
 }
 
 // ─── GraphLegend types ──────────────────────────────────────────────

--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -333,6 +333,10 @@ const GraphViewer = memo(
         new Set(),
       );
 
+      // Community-focus highlight override state
+      const [focusedCommunityNodes, setFocusedCommunityNodes] =
+        useState<Set<string>>(EMPTY_SET);
+
       // Optimize status (from GraphCanvas callback)
       const [optimizeStatus, setOptimizeStatus] =
         useState<OptimizeStatus | null>(null);
@@ -568,16 +572,39 @@ const GraphViewer = memo(
         (node: GraphNode) => {
           setSelectedNode(node);
           setSelectedLink(null);
-          // Clear edge-click highlights (use stable empty sets)
+          // Clear edge-click and community-focus highlights (use stable empty sets)
           setEdgeHighlightNodes(EMPTY_SET);
           setEdgeHighlightLinks(EMPTY_SET);
           setEdgeLabelNodes(EMPTY_SET);
+          setFocusedCommunityNodes(EMPTY_SET);
           if (zoomOnSelect) {
             canvasRef.current?.zoomToNodes([node.id], 600);
           }
         },
         [zoomOnSelect],
       );
+
+      const onCommunityFocus = useCallback(
+        (key: string) => {
+          const cid = Number(key);
+          const nodeIds = Object.entries(communityData.assignments)
+            .filter(([, id]) => id === cid)
+            .map(([nodeId]) => nodeId);
+          if (nodeIds.length > 0) {
+            setFocusedCommunityNodes(new Set(nodeIds));
+            setSelectedNode(null);
+            setSelectedLink(null);
+          }
+        },
+        [communityData.assignments],
+      );
+
+      // Zoom camera to focused community nodes when they change
+      useEffect(() => {
+        if (focusedCommunityNodes.size > 0) {
+          canvasRef.current?.zoomToNodes(focusedCommunityNodes, 600);
+        }
+      }, [focusedCommunityNodes]);
 
       // Expose imperative handle for parent/sibling access
       useImperativeHandle(
@@ -791,10 +818,11 @@ const GraphViewer = memo(
       const handleStageClick = useCallback(() => {
         setSelectedNode(null);
         setSelectedLink(null);
-        // Clear edge-click highlights
-        setEdgeHighlightNodes(new Set());
-        setEdgeHighlightLinks(new Set());
-        setEdgeLabelNodes(new Set());
+        // Clear edge-click and community-focus highlights
+        setEdgeHighlightNodes(EMPTY_SET);
+        setEdgeHighlightLinks(EMPTY_SET);
+        setFocusedCommunityNodes(EMPTY_SET);
+        setEdgeLabelNodes(EMPTY_SET);
       }, []);
 
       // --- Early returns for loading/error/empty states ---
@@ -1046,6 +1074,7 @@ const GraphViewer = memo(
             setHiddenCommunities(
               new Set(availableCommunities.map((c) => c.communityId)),
             ),
+          onFocus: onCommunityFocus,
         });
       }
 
@@ -1400,12 +1429,26 @@ const GraphViewer = memo(
             hops={hops}
             getSubType={getSubType}
             highlightNodes={
-              selectedLink ? edgeHighlightNodes : highlights.highlightNodes
+              selectedLink
+                ? edgeHighlightNodes
+                : focusedCommunityNodes.size > 0
+                  ? focusedCommunityNodes
+                  : highlights.highlightNodes
             }
             highlightLinks={
-              selectedLink ? edgeHighlightLinks : highlights.highlightLinks
+              selectedLink
+                ? edgeHighlightLinks
+                : focusedCommunityNodes.size > 0
+                  ? EMPTY_SET
+                  : highlights.highlightLinks
             }
-            labelNodes={selectedLink ? edgeLabelNodes : highlights.labelNodes}
+            labelNodes={
+              selectedLink
+                ? edgeLabelNodes
+                : focusedCommunityNodes.size > 0
+                  ? focusedCommunityNodes
+                  : highlights.labelNodes
+            }
             availableSubTypes={availableSubTypes}
             zIndex
             communityData={communityData}


### PR DESCRIPTION
## Add community focus button to filter panel
🆕 **New Feature**

Adds a focus/target button to each community entry in the filter panel. Clicking it highlights all nodes belonging to that community and zooms the graph canvas to fit them — giving users a quick way to inspect a specific community without manually hunting for its nodes.

### Complexity
🟢 Low · `4 files changed, 105 insertions(+), 8 deletions(-)`

Self-contained feature addition: a new optional `onFocus` prop on `FilterPanel`, a single new piece of UI state (`focusedCommunityNodes`), and straightforward wiring into the existing highlight/label/zoom machinery in `GraphViewer`. The highlight priority logic (edge-click takes precedence over community focus) is the only subtlety, and it's localised to a handful of ternaries.

### Tests
🧪 No tests included for the new focus interaction.

### Review focus
Pay particular attention to the following areas:

- **Highlight priority ordering** — edge-click highlights take precedence over community focus via nested ternaries; verify the precedence is correct and that community focus is properly cleared when a node or edge is clicked.
- **`EMPTY_SET` usage** — a frozen shared empty set is passed to avoid unnecessary re-renders; confirm no call site mutates it.

---

<details>
<summary><strong>Additional details</strong></summary>

### State management approach

`focusedCommunityNodes` is a new piece of state in `GraphViewer` that holds the node IDs belonging to the focused community. It is reset to the shared `EMPTY_SET` constant (rather than `new Set()`) in every clear path — stage click, node click — to keep reference equality stable and avoid spurious re-renders on `GraphCanvas`.

### Highlight plumbing

The existing `highlightNodes` / `highlightLinks` / `labelNodes` props on `GraphCanvas` already supported arbitrary node sets. Community focus reuses them: nodes get highlighted and labelled, but no links are highlighted (an explicit `EMPTY_SET` is passed for links), so only the nodes themselves are emphasised when zooming to a community.

</details>
<!-- opentrace:jid=j-1ddfa569-7910-4bcf-89b9-8875dbcf2b91|sha=853bfcab81b73f67a604b9f518d98987495a9ca5 -->