### PR TITLE
fix(ui): fix PR Index into Graph for LadybugStore

### DIFF
--- a/ui/src/components/PRListPanel.tsx
+++ b/ui/src/components/PRListPanel.tsx
@@ -127,6 +127,7 @@ export default function PRListPanel({
 
   const handleIndexPR = async (pr: PRDetail) => {
     await indexPRIntoGraph(store, pr, prClient.meta);
+    await store.flush();
     const prId = `${prClient.meta.owner}/${prClient.meta.repo}/pr/${pr.number}`;
     await onGraphChange?.(prId);
   };
@@ -154,6 +155,7 @@ export default function PRListPanel({
     if (errors.length) {
       setError(`Failed to index ${errors.length} PR(s): ${errors.join('; ')}`);
     }
+    await store.flush();
     await onGraphChange?.(lastPrId);
     setIndexingAll(false);
   };

--- a/ui/src/pr/__tests__/indexer.test.ts
+++ b/ui/src/pr/__tests__/indexer.test.ts
@@ -228,6 +228,59 @@ describe('indexPRIntoGraph', () => {
     await indexPRIntoGraph(store, makePR({ body: '' }), meta);
     expect(store.storeSource).not.toHaveBeenCalled();
   });
+
+  it('skips File/Directory nodes that already exist in the store', async () => {
+    const store = createMockStore({
+      importBatch: vi
+        .fn()
+        .mockResolvedValue({ nodes_created: 1, relationships_created: 2 }),
+      // Simulate src/main.ts and the src/ directory already indexed
+      getNode: vi.fn().mockImplementation((id: string) => {
+        if (id === 'owner/repo/src/main.ts')
+          return Promise.resolve({ id, type: 'File', name: 'main.ts' });
+        if (id === 'owner/repo/src')
+          return Promise.resolve({ id, type: 'Directory', name: 'src' });
+        return Promise.resolve(null);
+      }),
+    });
+    const pr = makePR({
+      files: [
+        {
+          path: 'src/main.ts',
+          status: 'modified',
+          additions: 1,
+          deletions: 0,
+        },
+      ],
+    });
+    await indexPRIntoGraph(store, pr, meta);
+
+    const batch = (store.importBatch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+
+    // Should NOT include the existing File or Directory node
+    const fileNodes = batch.nodes.filter(
+      (n: { type: string }) => n.type === 'File',
+    );
+    const dirNodes = batch.nodes.filter(
+      (n: { type: string }) => n.type === 'Directory',
+    );
+    expect(fileNodes).toHaveLength(0);
+    expect(dirNodes).toHaveLength(0);
+
+    // Should still include the CHANGES edge
+    const changesEdges = batch.relationships.filter(
+      (r: { type: string }) => r.type === 'CHANGES',
+    );
+    expect(changesEdges).toHaveLength(1);
+    expect(changesEdges[0].target_id).toBe('owner/repo/src/main.ts');
+
+    // Should NOT include defined_in edges for existing nodes
+    const definedInEdges = batch.relationships.filter(
+      (r: { type: string }) => r.type === 'defined_in',
+    );
+    expect(definedInEdges).toHaveLength(0);
+  });
 });
 
 describe('indexMultiplePRs', () => {

--- a/ui/src/pr/indexer.ts
+++ b/ui/src/pr/indexer.ts
@@ -98,26 +98,47 @@ export async function indexPRIntoGraph(
     ],
   };
 
-  // Collect all directory paths we need to ensure exist.
-  // Use a Set to avoid creating duplicate nodes/edges.
+  // Build the set of File/Directory IDs we need, then check which already
+  // exist in the store so we only create genuinely new nodes. The store's
+  // COPY FROM does not support MERGE, so duplicate primary keys throw.
   const ensuredDirs = new Set<string>();
+  const neededIds = new Set<string>();
+
+  for (const file of pr.files) {
+    neededIds.add(`${repoId}/${file.path}`);
+    const parts = file.path.split('/');
+    for (let i = parts.length - 1; i >= 1; i--) {
+      neededIds.add(`${repoId}/${parts.slice(0, i).join('/')}`);
+    }
+  }
+
+  // Probe the store for existing nodes — getNode returns null for missing
+  const existingIds = new Set<string>();
+  await Promise.all(
+    [...neededIds].map(async (id) => {
+      try {
+        const node = await store.getNode(id);
+        if (node) existingIds.add(id);
+      } catch {
+        /* treat lookup failure as "not found" */
+      }
+    }),
+  );
 
   for (const file of pr.files) {
     const fileId = `${repoId}/${file.path}`;
 
-    // Ensure the File node exists — the store uses MERGE so this is
-    // safe even if the file was already indexed during repo ingestion.
-    // Use basename as name to match the code indexer convention.
-    const fileName = file.path.split('/').pop() || file.path;
-    batch.nodes.push({
-      id: fileId,
-      type: 'File',
-      name: fileName,
-      properties: { path: file.path },
-    });
+    if (!existingIds.has(fileId)) {
+      const fileName = file.path.split('/').pop() || file.path;
+      batch.nodes.push({
+        id: fileId,
+        type: 'File',
+        name: fileName,
+        properties: { path: file.path },
+      });
+    }
 
     // Ensure the full directory chain exists so defined_in edges connect.
-    // Walk from the file's parent dir up to the repo root.
     const parts = file.path.split('/');
     for (let i = parts.length - 1; i >= 1; i--) {
       const dirPath = parts.slice(0, i).join('/');
@@ -125,36 +146,43 @@ export async function indexPRIntoGraph(
       ensuredDirs.add(dirPath);
 
       const dirId = `${repoId}/${dirPath}`;
-      const dirName = dirPath.split('/').pop() || dirPath;
-      batch.nodes.push({
-        id: dirId,
-        type: 'Directory',
-        name: dirName,
-        properties: { path: dirPath },
-      });
+      if (!existingIds.has(dirId)) {
+        const dirName = dirPath.split('/').pop() || dirPath;
+        batch.nodes.push({
+          id: dirId,
+          type: 'Directory',
+          name: dirName,
+          properties: { path: dirPath },
+        });
+      }
 
-      // Link directory to its parent (or repo root)
-      const parentDirPath = parts.slice(0, i - 1).join('/');
-      const parentId = parentDirPath ? `${repoId}/${parentDirPath}` : repoId;
+      // Only add defined_in edge if the directory node is new
+      if (!existingIds.has(dirId)) {
+        const parentDirPath = parts.slice(0, i - 1).join('/');
+        const parentId = parentDirPath ? `${repoId}/${parentDirPath}` : repoId;
+        batch.relationships.push({
+          id: `${dirId}->defined_in->${parentId}`,
+          type: 'defined_in',
+          source_id: dirId,
+          target_id: parentId,
+        });
+      }
+    }
+
+    // Only add file→directory edge if the file node is new
+    if (!existingIds.has(fileId)) {
+      const lastSlash = file.path.lastIndexOf('/');
+      const parentId =
+        lastSlash > 0 ? `${repoId}/${file.path.slice(0, lastSlash)}` : repoId;
       batch.relationships.push({
-        id: `${dirId}->defined_in->${parentId}`,
+        id: `${fileId}->defined_in->${parentId}`,
         type: 'defined_in',
-        source_id: dirId,
+        source_id: fileId,
         target_id: parentId,
       });
     }
 
-    // Link file to its immediate parent directory (or repo root)
-    const lastSlash = file.path.lastIndexOf('/');
-    const parentId =
-      lastSlash > 0 ? `${repoId}/${file.path.slice(0, lastSlash)}` : repoId;
-    batch.relationships.push({
-      id: `${fileId}->defined_in->${parentId}`,
-      type: 'defined_in',
-      source_id: fileId,
-      target_id: parentId,
-    });
-
+    // Always add the CHANGES edge — this is the PR-specific data
     batch.relationships.push({
       id: `${prId}->changes:${fileId}`,
       type: 'CHANGES',

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -56,6 +56,7 @@ const NODE_TYPES = [
   'Package',
   'Class',
   'Function',
+  'PullRequest',
 ] as const;
 type NodeType = (typeof NODE_TYPES)[number];
 
@@ -75,6 +76,8 @@ const REL_PAIRS: readonly [NodeType, NodeType][] = [
   ['Directory', 'Directory'],
   ['Directory', 'Repository'],
   ['Repository', 'Package'],
+  ['PullRequest', 'Repository'],
+  ['PullRequest', 'File'],
 ];
 
 /** Set of valid "FromType_ToType" keys for fast lookup. */


### PR DESCRIPTION
## Fix duplicate node errors when indexing PRs
🐛 **Bug Fix** · 🧪 **Tests**

When indexing PRs whose files are already present in the graph (e.g. from a prior repo ingestion), the indexer was unconditionally pushing `File` and `Directory` nodes into the batch. Because the store's `COPY FROM` path does not support `MERGE`, duplicate primary keys caused errors. This PR pre-checks which nodes already exist and skips creating them, while still always writing the `CHANGES` edge.

### Complexity
🟡 Moderate · `4 files changed, 122 insertions(+), 36 deletions(-)`

The fix touches the indexer's core batching logic and requires correctly threading the "skip if exists" guard through both node creation and `defined_in` edge creation without accidentally suppressing the `CHANGES` edge. The async pre-flight lookup (`Promise.all` over `getNode`) is a new pattern with its own failure mode (swallowed errors treated as "not found"). Two call sites in `PRListPanel` also needed `store.flush()` added. The change is contained to a single feature area, but the correctness of the node-vs-edge skipping logic deserves careful checking.

### Tests
🧪 A new test case covers the key scenario: existing File and Directory nodes are skipped while the CHANGES edge is still emitted.

### Note
⚠️ The `PullRequest` node type and its relationship pairs (`PullRequest→Repository`, `PullRequest→File`) are added to `ladybugStore.ts` as part of this diff — these schema additions are load-bearing for the indexer to function correctly.

### Review focus
Pay particular attention to the following areas:

- **defined_in edge suppression** — edges are skipped based solely on whether the directory node is new, but if a directory was already indexed its parent link may also already exist; confirm no orphaned edges are possible
- **getNode error swallowing** — lookup failures silently fall through to not-found, meaning a transient store error could cause the indexer to re-attempt inserting a node that already exists and trigger the original duplicate-key error
- **store.flush() placement** — flush is now called after both single and bulk index operations; verify this is safe to call even when some PRs in the bulk path errored

---

<details>
<summary><strong>Additional details</strong></summary>

### Approach

The indexer now does a pre-flight batch of `getNode` lookups (in parallel via `Promise.all`) to build an `existingIds` set before constructing the import batch. Node creation and `defined_in` edge creation are both gated on `!existingIds.has(id)`. The `CHANGES` edge is unconditionally added because it is always PR-specific data that should not already exist.

### Why flush() was missing

`store.flush()` ensures buffered writes are committed before `onGraphChange` triggers a re-render of the graph. Without it, callers could observe a stale graph immediately after indexing. Both the single-PR and bulk-PR paths were missing this call.

</details>
<!-- opentrace:jid=j-47774eb5-bfa9-4672-8e77-08c3360c4230|sha=119229d6067938743055dc83dd89ce2f0ec60d84 -->