### PR TITLE
fix(ui): remove misleading +0-0 stats from PR list

### DIFF
--- a/ui/src/components/PRListPanel.tsx
+++ b/ui/src/components/PRListPanel.tsx
@@ -280,10 +280,6 @@ export default function PRListPanel({
               <div className="pr-item-meta">
                 <span className="pr-item-author">{pr.author}</span>
                 <span className="pr-item-branch">{pr.head_branch}</span>
-                <span className="pr-item-stats">
-                  <span className="pr-stat-add">+{pr.additions}</span>
-                  <span className="pr-stat-del">-{pr.deletions}</span>
-                </span>
                 <span className="pr-item-time">{timeAgo(pr.updated_at)}</span>
               </div>
             </button>

--- a/ui/src/pr/azuredevopsPR.ts
+++ b/ui/src/pr/azuredevopsPR.ts
@@ -80,8 +80,6 @@ function toPRSummary(pr: any): PRSummary {
     head_branch: sourceRef.startsWith(refPrefix)
       ? sourceRef.slice(refPrefix.length)
       : sourceRef,
-    additions: 0,
-    deletions: 0,
     draft: pr.isDraft,
   };
 }
@@ -152,6 +150,8 @@ export async function fetchAzureDevOpsPRDetail(
   return {
     ...toPRSummary(pr),
     body: pr.description ?? '',
+    additions: 0,
+    deletions: 0,
     files,
     comments_count: 0,
     review_comments_count: 0,

--- a/ui/src/pr/bitbucketPR.ts
+++ b/ui/src/pr/bitbucketPR.ts
@@ -69,8 +69,6 @@ function toPRSummary(pr: any): PRSummary {
     updated_at: pr.updated_on,
     base_branch: pr.destination?.branch?.name ?? '',
     head_branch: pr.source?.branch?.name ?? '',
-    additions: 0,
-    deletions: 0,
   };
 }
 
@@ -116,6 +114,8 @@ export async function fetchBitbucketPRDetail(
   return {
     ...toPRSummary(pr),
     body: pr.description ?? '',
+    additions: 0,
+    deletions: 0,
     files,
     comments_count: pr.comment_count ?? 0,
     review_comments_count: 0,

--- a/ui/src/pr/githubPR.ts
+++ b/ui/src/pr/githubPR.ts
@@ -128,8 +128,6 @@ function toPRSummary(pr: any): PRSummary {
     updated_at: pr.updated_at,
     base_branch: pr.base?.ref ?? '',
     head_branch: pr.head?.ref ?? '',
-    additions: pr.additions ?? 0,
-    deletions: pr.deletions ?? 0,
     draft: pr.draft,
   };
 }
@@ -167,6 +165,8 @@ export async function fetchGitHubPRDetail(
   return {
     ...toPRSummary(pr),
     body: pr.body ?? '',
+    additions: pr.additions ?? 0,
+    deletions: pr.deletions ?? 0,
     comments_count: pr.comments ?? 0,
     review_comments_count: pr.review_comments ?? 0,
     mergeable: pr.mergeable ?? undefined,

--- a/ui/src/pr/gitlabPR.ts
+++ b/ui/src/pr/gitlabPR.ts
@@ -72,8 +72,6 @@ function toMRSummary(mr: any): PRSummary {
     updated_at: mr.updated_at,
     base_branch: mr.target_branch ?? '',
     head_branch: mr.source_branch ?? '',
-    additions: 0,
-    deletions: 0,
     draft: mr.draft,
   };
 }
@@ -125,6 +123,8 @@ export async function fetchGitLabMRDetail(
   return {
     ...toMRSummary(mr),
     body: mr.description ?? '',
+    additions: 0,
+    deletions: 0,
     files,
     comments_count: mr.user_notes_count ?? 0,
     review_comments_count: 0,

--- a/ui/src/pr/types.ts
+++ b/ui/src/pr/types.ts
@@ -26,8 +26,6 @@ export interface PRSummary {
   updated_at: string;
   base_branch: string;
   head_branch: string;
-  additions: number;
-  deletions: number;
   draft?: boolean;
 }
 
@@ -42,6 +40,8 @@ export interface PRFileDiff {
 
 export interface PRDetail extends PRSummary {
   body: string;
+  additions: number;
+  deletions: number;
   files: PRFileDiff[];
   comments_count: number;
   review_comments_count: number;


### PR DESCRIPTION
## Move additions/deletions from PRSummary to PRDetail
♻️ **Refactor** · ✨ **Improvement**

Moves `additions` and `deletions` from the `PRSummary` type to `PRDetail`, and removes the diff-stat display from the PR list panel. These counts are only meaningful once the full PR detail is fetched, so surfacing them in the list summary was misleading (non-GitHub providers always returned zeros).

### Complexity
🟢 Low · `6 files changed, 10 insertions(+), 14 deletions(-)`

Single-concern type reshaping across four provider files and one UI component. The change is mechanical and self-consistent — all providers are updated in the same way, and the UI simply drops the stat display that depended on the removed fields.

### Tests
🧪 No tests included; this is a type-level refactor with a corresponding UI removal.

### Review focus
Pay particular attention to the following areas:

- **Type contract** — confirm no other consumers of PRSummary still reference additions/deletions after this move
<!-- opentrace:jid=b67dd9c6-fe92-4fc0-9dd4-b5e18f5f6917|sha=c1507e39d6513df36ffd9b0606ac21f78dbdab5c -->