### PR TITLE
feat(ui): add collapse/expand all to discover panel

### DIFF
--- a/components/src/panels/DiscoverPanel.css
+++ b/components/src/panels/DiscoverPanel.css
@@ -70,6 +70,35 @@
   color: var(--foreground);
 }
 
+/* Expand / Collapse all controls */
+.discover-tree-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.discover-tree-control-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.discover-tree-control-btn:hover {
+  color: var(--foreground);
+  background: color-mix(in oklch, var(--accent) 40%, transparent);
+  border-color: color-mix(in oklch, var(--border) 30%, transparent);
+}
+
 .discover-panel-empty {
   padding: 24px 16px;
   color: var(--muted-foreground);
@@ -125,8 +154,11 @@
   opacity: 0.7;
 }
 
-/* Graph-only toggle */
+/* Graph-only toggle + tree controls row */
 .discover-graph-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 0 10px 8px;
 }
 

--- a/components/src/panels/DiscoverPanel.tsx
+++ b/components/src/panels/DiscoverPanel.tsx
@@ -270,6 +270,8 @@ export default function DiscoverPanel({
   childrenMap,
   expanded,
   onToggleExpand,
+  onCollapseAll,
+  onExpandAll,
   onSelectNode,
   selectedNodeId,
   graphNodeIds,
@@ -383,17 +385,71 @@ export default function DiscoverPanel({
           </button>
         )}
       </div>
-      {graphNodeIdSet && (
+      {(graphNodeIdSet || onExpandAll || onCollapseAll) && (
         <div className="discover-graph-toggle">
-          <label className="discover-graph-toggle-label">
-            <input
-              type="checkbox"
-              checked={hideOffGraph}
-              onChange={(e) => setHideOffGraph(e.target.checked)}
-            />
-            <span className="discover-toggle-track" />
-            <span>In graph only</span>
-          </label>
+          {graphNodeIdSet && (
+            <label className="discover-graph-toggle-label">
+              <input
+                type="checkbox"
+                checked={hideOffGraph}
+                onChange={(e) => setHideOffGraph(e.target.checked)}
+              />
+              <span className="discover-toggle-track" />
+              <span>In graph only</span>
+            </label>
+          )}
+          {(onExpandAll || onCollapseAll) && (
+            <div className="discover-tree-controls">
+              {onExpandAll && (
+                <button
+                  className="discover-tree-control-btn"
+                  onClick={onExpandAll}
+                  title="Expand all"
+                >
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <path
+                      d="M4 5.5L7 8.5L10 5.5"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M4 2L7 5L10 2"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              )}
+              {onCollapseAll && (
+                <button
+                  className="discover-tree-control-btn"
+                  onClick={onCollapseAll}
+                  title="Collapse all"
+                >
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <path
+                      d="M4 8.5L7 5.5L10 8.5"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M4 12L7 9L10 12"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+          )}
         </div>
       )}
       {flatRows.length === 0 ? (

--- a/components/src/panels/__tests__/DiscoverPanel.test.tsx
+++ b/components/src/panels/__tests__/DiscoverPanel.test.tsx
@@ -319,6 +319,58 @@ describe('DiscoverPanel', () => {
     });
   });
 
+  describe('collapse/expand all controls', () => {
+    it('renders expand all and collapse all buttons when callbacks provided', () => {
+      const { container } = render(
+        React.createElement(
+          DiscoverPanel,
+          makeProps({
+            onExpandAll: vi.fn(),
+            onCollapseAll: vi.fn(),
+          }),
+        ),
+      );
+      const controls = container.querySelectorAll(
+        '.discover-tree-control-btn',
+      );
+      expect(controls.length).toBe(2);
+    });
+
+    it('does not render controls when callbacks are not provided', () => {
+      const { container } = render(
+        React.createElement(DiscoverPanel, makeProps()),
+      );
+      const controls = container.querySelector('.discover-tree-controls');
+      expect(controls).toBeNull();
+    });
+
+    it('fires onExpandAll when expand all button is clicked', () => {
+      const onExpandAll = vi.fn();
+      const { container } = render(
+        React.createElement(
+          DiscoverPanel,
+          makeProps({ onExpandAll, onCollapseAll: vi.fn() }),
+        ),
+      );
+      const btns = container.querySelectorAll('.discover-tree-control-btn');
+      fireEvent.click(btns[0]); // expand all is first
+      expect(onExpandAll).toHaveBeenCalledOnce();
+    });
+
+    it('fires onCollapseAll when collapse all button is clicked', () => {
+      const onCollapseAll = vi.fn();
+      const { container } = render(
+        React.createElement(
+          DiscoverPanel,
+          makeProps({ onCollapseAll, onExpandAll: vi.fn() }),
+        ),
+      );
+      const btns = container.querySelectorAll('.discover-tree-control-btn');
+      fireEvent.click(btns[1]); // collapse all is second
+      expect(onCollapseAll).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('displayName', () => {
     it('shows only the last path segment', () => {
       const deepFile: TreeNodeData = {

--- a/components/src/panels/types.ts
+++ b/components/src/panels/types.ts
@@ -155,6 +155,10 @@ export interface DiscoverPanelProps {
   onToggleExpand: (nodeId: string) => void;
   /** Called when a node name is clicked */
   onSelectNode: (nodeId: string) => void;
+  /** Collapse all expanded nodes */
+  onCollapseAll?: () => void;
+  /** Expand all loaded expandable nodes */
+  onExpandAll?: () => void;
   /** Currently selected node ID */
   selectedNodeId?: string;
   /** Node IDs currently visible in the graph */

--- a/ui/src/components/DiscoverPanelContainer.tsx
+++ b/ui/src/components/DiscoverPanelContainer.tsx
@@ -326,6 +326,20 @@ export default function DiscoverPanelContainer({
     };
   }, [selectedNodeId, store, loadChildren, findNodeType, expanded]);
 
+  const handleCollapseAll = useCallback(() => {
+    setExpanded(new Set());
+  }, []);
+
+  const handleExpandAll = useCallback(() => {
+    const allExpandable = new Set<string>();
+    for (const [parentId, children] of childrenMap.entries()) {
+      if (children.length > 0) {
+        allExpandable.add(parentId);
+      }
+    }
+    setExpanded(allExpandable);
+  }, [childrenMap]);
+
   if (loading) {
     return (
       <div className="discover-panel">
@@ -340,6 +354,8 @@ export default function DiscoverPanelContainer({
       childrenMap={childrenMap}
       expanded={expanded}
       onToggleExpand={handleToggle}
+      onCollapseAll={handleCollapseAll}
+      onExpandAll={handleExpandAll}
       onSelectNode={onSelectNode}
       selectedNodeId={isActive ? selectedNodeId : undefined}
       graphNodeIds={graphNodeIds}


### PR DESCRIPTION
## Add expand/collapse all buttons to DiscoverPanel tree
🆕 **New Feature**

Adds "Expand all" and "Collapse all" icon buttons to the `DiscoverPanel` toolbar, letting users quickly open or close the entire tree without clicking each node individually. The buttons are optional — they only render when the parent passes the new `onExpandAll` / `onCollapseAll` callbacks.

### Complexity
🟢 Low · `5 files changed, 171 insertions(+), 11 deletions(-)`

Self-contained UI addition touching one panel component, its container, its type definitions, and CSS. The logic in `handleExpandAll` derives the expandable set directly from the already-loaded `childrenMap`, so there are no async or state-ordering subtleties to worry about.

### Tests
🧪 Four new unit tests cover rendering presence/absence of the buttons and that each callback fires on click.

### Review focus
Pay particular attention to the following areas:

- **Expand-all scope** — `handleExpandAll` only expands nodes already present in `childrenMap` (i.e. lazily-loaded children that haven't been fetched yet will remain collapsed); verify this is the intended behaviour.
<!-- opentrace:jid=c5824501-db4d-40c1-acab-85b95760a2a3|sha=2df7060227772db943c4aac940ee9a4fe1264e13 -->