### PR TITLE
fix(ui): re-enable Add Repository toolbar button

### DIFF
--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -1241,7 +1241,6 @@ const GraphViewer = memo(
                   <button
                     className="add-repo-btn"
                     onClick={onAddRepoOpen}
-                    disabled
                     title="Add Repository"
                   >
                     <svg


### PR DESCRIPTION
## Enable "Add Repository" button in GraphViewer
🐛 **Bug Fix**

Removes the `disabled` attribute from the "Add Repository" button in the `GraphViewer` component, making it interactive. The button was previously rendered but non-functional.

### Complexity
🟢 Trivial · `1 file changed, 1 deletion(-)`

Single-line change removing a `disabled` attribute. The button's click handler (`onAddRepoOpen`) was already wired up, so no other code changes are needed.

### Tests
🧪 No tests included — UI interaction change that would require manual or E2E testing to verify the add-repo flow works end-to-end.

### Review focus
Pay particular attention to the following areas:

- **Add repo flow readiness** — confirm the `onAddRepoOpen` handler and any downstream dialog/form are fully implemented and stable before this button is enabled in production.
<!-- opentrace:jid=j-4ae03159-3e90-4d5e-bfef-bf9e035f599c|sha=642170e36d261e8164c4bffa0d58bb88a6dc80f6 -->