### PR TITLE
fix(ui): theme the Save button on chat settings panel

### DIFF
--- a/ui/src/components/ChatPanel.css
+++ b/ui/src/components/ChatPanel.css
@@ -52,6 +52,22 @@
   margin-top: 8px;
 }
 
+.settings-save-btn {
+  padding: 8px 16px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border-radius: var(--radius);
+  border: 1px solid var(--primary);
+  background: color-mix(in oklch, var(--primary) 15%, transparent);
+  color: var(--ring);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.settings-save-btn:hover {
+  background: color-mix(in oklch, var(--primary) 25%, transparent);
+}
+
 .settings-back-btn {
   padding: 8px 16px;
   font-size: 0.8rem;

--- a/ui/src/components/ChatPanel.tsx
+++ b/ui/src/components/ChatPanel.tsx
@@ -726,7 +726,7 @@ export default function ChatPanel({
           )}
           <div className="settings-actions">
             <button
-              className="api-search-btn"
+              className="settings-save-btn"
               style={{ flex: 1, padding: '8px' }}
               onClick={handleSaveKey}
             >


### PR DESCRIPTION
## Add dedicated CSS class for settings save button
✨ **Improvement** · ♻️ **Refactor**

Introduces a dedicated `settings-save-btn` CSS class for the save button in the settings panel, replacing the reused `api-search-btn` class. This separates the styling concerns of two visually distinct buttons that previously shared a class.

### Complexity
🟢 Trivial · `2 files changed, 17 insertions(+), 1 deletion(-)`

Two-file change: a new CSS class and a one-line class name swap. No logic is touched and the visual impact is isolated to a single button in the settings panel.
<!-- opentrace:jid=j-909404c0-336a-46a4-8d0b-6f691735c9f3|sha=d3b30f4b1c97728f146b81c60608cc3dff6a113b -->