### PR TITLE
fix(ui): prevent loading screen from replacing visible graph

### DIFF
--- a/ui/src/components/GraphViewer.tsx
+++ b/ui/src/components/GraphViewer.tsx
@@ -772,18 +772,18 @@ const GraphViewer = memo(
           .sort((a, b) => b.count - a.count);
       }, [filteredGraphData.links]);
 
+      const isEmpty = graphData.nodes.length === 0;
+      const isSearchEmpty = isEmpty && !!lastSearchQuery;
+
       // Determine whether to show the full indexing progress modal
       const showFullModal =
         jobState.status === 'running' ||
         jobState.status === 'persisted' ||
         jobState.status === 'error' ||
         ((jobState.status === 'enriching' || jobState.status === 'done') &&
-          jobExpanded);
+          (jobExpanded || (loading && isEmpty)));
 
       const graphWidth = showChat ? width - chatWidth : width;
-
-      const isEmpty = graphData.nodes.length === 0;
-      const isSearchEmpty = isEmpty && !!lastSearchQuery;
 
       // Auto-minimize once graph data has arrived (bridges "Loading graph..." modal
       // to the "Computing layout" overlay without flashing "no data").
@@ -827,7 +827,7 @@ const GraphViewer = memo(
 
       // --- Early returns for loading/error/empty states ---
 
-      if (loading && !showAddRepo && !showFullModal) {
+      if (loading && isEmpty && !showAddRepo && !showFullModal) {
         return (
           <div className="graph-viewport">
             <div className="loading">

--- a/ui/src/hooks/useGraphData.ts
+++ b/ui/src/hooks/useGraphData.ts
@@ -40,7 +40,7 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
     nodes: GraphNode[];
     links: GraphLink[];
   }>({ nodes: [], links: [] });
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(() => store.hasData());
   const [error, setError] = useState<string | null>(null);
   const [stats, setStats] = useState<GraphStats | null>(null);
   const [lastSearchQuery, setLastApiQuery] = useState('');


### PR DESCRIPTION
## Fix loading flash when graph data is already cached
🐛 **Bug Fix**

Fixes a UI flash where the "Loading graph…" spinner would briefly appear on top of existing graph data when navigating back to a view that already has cached data. The fix ensures the loading state initialises based on whether the store already holds data, and gates the loading overlay on the graph being empty.

### Complexity
🟢 Low · `2 files changed, 6 insertions(+), 6 deletions(-)`

Two small, focused changes — the initial loading state and a guard condition — both scoped to the graph loading/display path. Low risk of unintended side effects; the logic is easy to verify in isolation.

### Tests
🧪 No tests included for this visual/state initialisation fix.

### Review focus
Pay particular attention to the following areas:

- **`store.hasData()` as initial state** — verify `store.hasData()` is a reliable signal that cached data is present, so `loading` doesn't start as `false` prematurely when the store is empty but a fetch is about to begin.
- **`showFullModal` expansion condition** — the new `loading && isEmpty` clause keeps the indexing progress modal visible during initial load; confirm this doesn't cause the modal to appear unexpectedly in edge cases (e.g. an empty repo with an active job).
<!-- opentrace:jid=j-25cc384d-a51b-4bd7-b922-c8278694f61e|sha=8eb1c3aedbc02e689172b95b37df8b20df58577b -->