### PR TITLE
feat(pixi): incremental graph updates for streaming node additions

### DIFF
--- a/ui/src/components/PixiGraphCanvas.tsx
+++ b/ui/src/components/PixiGraphCanvas.tsx
@@ -243,15 +243,60 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
     // setData is async — it awaits the Pixi init promise internally.
     // Snapshot positions because the worker may update entries in-place
     // during the async gap.
+    //
+    // For incremental updates (nodes only added), use addData to append
+    // new sprites without destroying existing ones.
+    const prevNodeIdsRef = useRef<Set<string>>(new Set());
     useEffect(() => {
       if (!layoutReady || !rendererRef.current) return;
+
+      const currentIds = new Set(nodes.map((n) => n.id));
+      const prevIds = prevNodeIdsRef.current;
+      const allPrevPresent =
+        prevIds.size > 0 && [...prevIds].every((id) => currentIds.has(id));
+      const isIncremental = allPrevPresent && currentIds.size > prevIds.size;
+      const isSameNodes = allPrevPresent && currentIds.size === prevIds.size;
+
+      prevNodeIdsRef.current = currentIds;
+
+      // Same nodes, only metadata changed — other effects handle colors etc.
+      if (isSameNodes) return;
+
       const posSnapshot = new Map(positions);
       let cancelled = false;
-      rendererRef.current
-        .setData(nodes, links, posSnapshot, nodeColors, nodeSizes, linkColors)
-        .then(() => {
-          if (!cancelled) setDataVersion((v) => v + 1);
+
+      if (isIncremental) {
+        const newNodes = nodes.filter((n) => !prevIds.has(n.id));
+        const newLinks = links.filter((l) => {
+          const s =
+            typeof l.source === 'string'
+              ? l.source
+              : (l.source as { id: string }).id;
+          const t =
+            typeof l.target === 'string'
+              ? l.target
+              : (l.target as { id: string }).id;
+          return !prevIds.has(s) || !prevIds.has(t);
         });
+        rendererRef.current
+          .addData(
+            newNodes,
+            newLinks,
+            posSnapshot,
+            nodeColors,
+            nodeSizes,
+            linkColors,
+          )
+          .then(() => {
+            if (!cancelled) setDataVersion((v) => v + 1);
+          });
+      } else {
+        rendererRef.current
+          .setData(nodes, links, posSnapshot, nodeColors, nodeSizes, linkColors)
+          .then(() => {
+            if (!cancelled) setDataVersion((v) => v + 1);
+          });
+      }
       return () => {
         cancelled = true;
       };

--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -452,6 +452,109 @@ export class PixiRenderer {
   }
 
   /**
+   * Incrementally add new nodes and edges without touching existing sprites.
+   */
+  async addData(
+    newNodes: GraphNode[],
+    newLinks: GraphLink[],
+    positions: Map<string, { x: number; y: number }>,
+    nodeColors: Map<string, string>,
+    nodeSizes: Map<string, number>,
+    linkColors: Map<string, string>,
+  ): Promise<void> {
+    if (this.initPromise) await this.initPromise;
+    if (
+      this.destroyed ||
+      !this.app ||
+      !this.nodeContainer ||
+      !this.labelContainer
+    )
+      return;
+
+    // Add only nodes not already present
+    for (const gn of newNodes) {
+      if (this.nodes.has(gn.id)) continue;
+
+      const pos = positions.get(gn.id) ?? { x: 0, y: 0 };
+      const color = nodeColors.get(gn.id) ?? '#888888';
+      const size = nodeSizes.get(gn.id) ?? 4;
+      const tex = getCircleTexture(this.app, color, this.textureCache);
+
+      const sprite = new Sprite(tex);
+      sprite.anchor.set(0.5);
+      sprite.scale.set(size / CIRCLE_RADIUS);
+      sprite.alpha = 0.9;
+      sprite.position.set(pos.x, pos.y);
+      this.nodeContainer.addChild(sprite);
+
+      const node: PixiNode = {
+        id: gn.id,
+        graphNode: gn,
+        x: pos.x,
+        y: pos.y,
+        size,
+        color,
+        sprite,
+        visible: true,
+      };
+      this.nodeIdToIndex.set(gn.id, this.nodeArray.length);
+      this.nodeArray.push(node);
+      this.nodes.set(gn.id, node);
+    }
+
+    // Add only edges not already present
+    const existingEdgeKeys = new Set(
+      this.edges.map((e) => `${e.sourceId}-${e.label}-${e.targetId}`),
+    );
+    for (const gl of newLinks) {
+      const sourceId =
+        typeof gl.source === 'string' ? gl.source : (gl.source as GraphNode).id;
+      const targetId =
+        typeof gl.target === 'string' ? gl.target : (gl.target as GraphNode).id;
+      if (!this.nodes.has(sourceId) || !this.nodes.has(targetId)) continue;
+      const key = `${sourceId}-${gl.label}-${targetId}`;
+      if (existingEdgeKeys.has(key)) continue;
+      existingEdgeKeys.add(key);
+
+      const idx = this.edges.length;
+      this.edges.push({
+        sourceId,
+        targetId,
+        label: gl.label,
+        graphLink: gl,
+        color: linkColors.get(gl.label) ?? '#3b4048',
+      });
+
+      let sIdx = this.edgeIndex.get(sourceId);
+      if (!sIdx) {
+        sIdx = [];
+        this.edgeIndex.set(sourceId, sIdx);
+      }
+      sIdx.push(idx);
+      let tIdx = this.edgeIndex.get(targetId);
+      if (!tIdx) {
+        tIdx = [];
+        this.edgeIndex.set(targetId, tIdx);
+      }
+      tIdx.push(idx);
+
+      const color = linkColors.get(gl.label) ?? '#3b4048';
+      let group = this.edgeColorGroups.get(color);
+      if (!group) {
+        group = [];
+        this.edgeColorGroups.set(color, group);
+      }
+      group.push(idx);
+    }
+
+    this.bp = selectBreakpoint(this.nodeArray.length, this.breakpoints);
+    this.layoutSettled = false;
+    this.redrawAllEdges();
+    this.rebuildQuadtree();
+    this.applyCounterScale();
+  }
+
+  /**
    * Compute the inverse-scale factor for sprites/labels, adjusted by zoom exponent.
    * At exponent 1: fully cancels world zoom (fixed screen size).
    * At exponent 0: no cancellation (world-space scaling).

--- a/ui/src/components/pixi/usePixiLayout.ts
+++ b/ui/src/components/pixi/usePixiLayout.ts
@@ -147,11 +147,13 @@ export function usePixiLayout(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allNodes, allLinks]);
 
-  // Apply Float64Array positions to the position map (in-place update, no allocation)
+  // Apply Float64Array positions to the position map (in-place update, no allocation).
+  // Guards against buffer/nodeOrder length mismatches during incremental updates.
   const applyPositionBuffer = useCallback((buffer: Float64Array) => {
     const nodeOrder = nodeOrderRef.current;
     const pos = positionsRef.current;
-    for (let i = 0; i < nodeOrder.length; i++) {
+    const count = Math.min(nodeOrder.length, buffer.length / 2);
+    for (let i = 0; i < count; i++) {
       const id = nodeOrder[i];
       const existing = pos.get(id);
       if (existing) {
@@ -163,41 +165,122 @@ export function usePixiLayout(
     }
   }, []);
 
-  // Main effect: spawn worker and init simulation
+  // Track previous node IDs to detect incremental additions
+  const prevNodeIdsRef = useRef<Set<string>>(new Set());
+
+  // Build layout-only links helper
+  const buildLayoutLinks = useCallback(
+    (nodeIdSet: Set<string>, linkArray: GraphLink[]) => {
+      const out: { source: string; target: string }[] = [];
+      for (const link of linkArray) {
+        if (!flatMode && link.label !== layoutConfig.layoutEdgeType) continue;
+        const source = endpointId(link.source);
+        const target = endpointId(link.target);
+        if (nodeIdSet.has(source) && nodeIdSet.has(target)) {
+          out.push({ source, target });
+        }
+      }
+      return out;
+    },
+    [flatMode, layoutConfig.layoutEdgeType],
+  );
+
+  // Single effect: handles full init, incremental add-nodes, and same-nodes skip.
+  // Worker lifecycle is managed explicitly (terminate at start of full-init),
+  // NOT via effect cleanup — this avoids React's cleanup-runs-before-next-effect
+  // timing issue that would kill the worker before add-nodes can reuse it.
+  // The unmount effect above (line ~104) handles final cleanup.
   useEffect(() => {
-    // Terminate previous worker
+    const nodeIds = allNodes.map((n) => n.id);
+    const nodeIdSet = new Set(nodeIds);
+    const prevIds = prevNodeIdsRef.current;
+
+    const allPrevPresent =
+      prevIds.size > 0 && [...prevIds].every((id) => nodeIdSet.has(id));
+    const isIncremental =
+      allPrevPresent &&
+      nodeIdSet.size > prevIds.size &&
+      workerRef.current !== null;
+    const isSameNodes = allPrevPresent && nodeIdSet.size === prevIds.size;
+
+    // ── Same nodes (metadata change like communityData) — skip ──
+    if (isSameNodes) return;
+
+    // ── Incremental: send add-nodes to existing worker ──
+    if (isIncremental) {
+      const newNodeIds = nodeIds.filter((id) => !prevIds.has(id));
+      const links = buildLayoutLinks(nodeIdSet, allLinks);
+      const newLinks = links.filter(
+        (l) => !prevIds.has(l.source) || !prevIds.has(l.target),
+      );
+
+      // Update node order: existing + new appended (matches worker's internal order)
+      nodeOrderRef.current = [...nodeOrderRef.current, ...newNodeIds];
+
+      // Seed position map for new nodes near centroid of existing
+      const pos = positionsRef.current;
+      let cx = 0,
+        cy = 0,
+        count = 0;
+      for (const id of prevIds) {
+        const p = pos.get(id);
+        if (p) {
+          cx += p.x;
+          cy += p.y;
+          count++;
+        }
+      }
+      if (count > 0) {
+        cx /= count;
+        cy /= count;
+      }
+      const spread = Math.sqrt(prevIds.size) * 10;
+      for (const id of newNodeIds) {
+        if (!pos.has(id)) {
+          const angle = Math.random() * Math.PI * 2;
+          const r = Math.random() * spread;
+          pos.set(id, {
+            x: cx + Math.cos(angle) * r,
+            y: cy + Math.sin(angle) * r,
+          });
+        }
+      }
+
+      prevNodeIdsRef.current = nodeIdSet;
+
+      workerRef.current!.postMessage({
+        type: 'add-nodes',
+        nodeIds: newNodeIds,
+        links: newLinks,
+        communities: communityData.assignments,
+      } satisfies WorkerInMessage);
+
+      simRunningRef.current = true;
+      setSimRunning(true);
+      return;
+    }
+
+    // ── Full init: terminate old worker, create new one ──
     workerRef.current?.terminate();
     workerRef.current = null;
     setLayoutReady(false);
 
-    if (allNodes.length === 0) return;
+    if (allNodes.length === 0) {
+      prevNodeIdsRef.current = new Set();
+      return;
+    }
 
     const reqId = ++requestIdRef.current;
-
-    // Build node order
-    const nodeIds = allNodes.map((n) => n.id);
     nodeOrderRef.current = nodeIds;
 
-    // Seed position map entries
     const pos = positionsRef.current;
     pos.clear();
     for (const id of nodeIds) {
       pos.set(id, { x: 0, y: 0 });
     }
 
-    // Build layout-only links
-    const nodeIdSet = new Set(nodeIds);
-    const links: { source: string; target: string }[] = [];
-    for (const link of allLinks) {
-      if (!flatMode && link.label !== layoutConfig.layoutEdgeType) continue;
-      const source = endpointId(link.source);
-      const target = endpointId(link.target);
-      if (nodeIdSet.has(source) && nodeIdSet.has(target)) {
-        links.push({ source, target });
-      }
-    }
+    const links = buildLayoutLinks(nodeIdSet, allLinks);
 
-    // Create worker
     const worker = new Worker(
       new URL('../workers/pixiLayoutWorker.ts', import.meta.url),
       { type: 'module' },
@@ -219,13 +302,11 @@ export function usePixiLayout(
 
       switch (e.data.type) {
         case 'ready':
-          // Initial positions from sync ticks
           applyPositionBuffer(e.data.buffer);
           setLayoutReady(true);
           break;
 
         case 'positions':
-          // Streaming position update — in-place map update + pass raw buffer
           applyPositionBuffer(e.data.buffer);
           onTickRef.current(positionsRef.current, e.data.buffer);
           break;
@@ -237,11 +318,9 @@ export function usePixiLayout(
       }
     };
 
-    // Select breakpoint for theta config
     const bp = selectBreakpoint(allNodes.length);
     breakpointRef.current = bp;
 
-    // Send init message
     worker.postMessage({
       type: 'init',
       nodeIds,
@@ -256,15 +335,20 @@ export function usePixiLayout(
       },
     } satisfies WorkerInMessage);
 
+    prevNodeIdsRef.current = nodeIdSet;
     simRunningRef.current = true;
     setSimRunning(true);
-
-    return () => {
-      worker.terminate();
-      if (workerRef.current === worker) workerRef.current = null;
-    };
+    // No cleanup — worker is terminated at the START of the next full-init,
+    // and on unmount via the separate cleanup effect above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allNodes, allLinks, communityData, layoutConfig, applyPositionBuffer]);
+  }, [
+    allNodes,
+    allLinks,
+    communityData,
+    layoutConfig,
+    applyPositionBuffer,
+    buildLayoutLinks,
+  ]);
 
   // ── Control callbacks (all just postMessage to worker) ────────────────
 

--- a/ui/src/components/stories/StreamingGraphPlayground.stories.tsx
+++ b/ui/src/components/stories/StreamingGraphPlayground.stories.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import StreamingGraphPlayground from './StreamingGraphPlayground';
+import { DATASETS } from './datasets';
+
+const meta: Meta<typeof StreamingGraphPlayground> = {
+  title: 'Graph/StreamingGraphPlayground',
+  component: StreamingGraphPlayground,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    dataset: {
+      options: DATASETS.map((d) => d.name),
+      mapping: Object.fromEntries(DATASETS.map((d) => [d.name, d])),
+      control: { type: 'select' },
+    },
+    batchSize: {
+      control: { type: 'range', min: 1, max: 50, step: 1 },
+    },
+    intervalMs: {
+      control: { type: 'range', min: 200, max: 5000, step: 100 },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof StreamingGraphPlayground>;
+
+const ds = (name: string) => DATASETS.find((d) => d.name === name)!;
+
+/** Small dataset — streams 2 nodes every 1s so you can watch each batch arrive. */
+export const WebApp: Story = {
+  name: 'Web App (slow stream)',
+  args: {
+    dataset: ds('Web App'),
+    batchSize: 2,
+    intervalMs: 1000,
+    width: 900,
+    height: 600,
+  },
+};
+
+/** Medium dataset — streams 10 nodes every 1.5s. */
+export const GoMonorepo: Story = {
+  name: 'Go Monorepo',
+  args: {
+    dataset: ds('Go Monorepo'),
+    batchSize: 10,
+    intervalMs: 1500,
+    width: 900,
+    height: 600,
+  },
+};
+
+/** 100 nodes — fast stream (20 nodes/batch, 500ms interval). */
+export const Fast100: Story = {
+  name: '100 nodes (fast)',
+  args: {
+    dataset: ds('100 nodes'),
+    batchSize: 20,
+    intervalMs: 500,
+    width: 900,
+    height: 600,
+  },
+};
+
+/** 500 nodes — moderate stream. */
+export const Nodes500: Story = {
+  name: '500 nodes',
+  args: {
+    dataset: ds('500 nodes'),
+    batchSize: 25,
+    intervalMs: 1000,
+    width: 1000,
+    height: 700,
+  },
+};
+
+/** 2,000 nodes — batch stream simulating a real indexing job. */
+export const Nodes2000: Story = {
+  name: '2,000 nodes',
+  args: {
+    dataset: ds('2,000 nodes'),
+    batchSize: 50,
+    intervalMs: 1500,
+    width: 1000,
+    height: 700,
+  },
+};
+
+/** 20,000 nodes — large stream, 500 nodes per batch every 2s. */
+export const Nodes20000: Story = {
+  name: '20,000 nodes',
+  tags: ['!test'],
+  args: {
+    dataset: ds('20,000 nodes'),
+    batchSize: 500,
+    intervalMs: 2000,
+    width: 1200,
+    height: 800,
+  },
+};
+
+/** 20,000 nodes in 3D mode — streams 500 nodes per batch every 2s with perspective. */
+export const Nodes20000_3D: Story = {
+  name: '20,000 nodes (3D)',
+  tags: ['!test'],
+  args: {
+    dataset: ds('20,000 nodes'),
+    batchSize: 500,
+    intervalMs: 2000,
+    mode3d: true,
+    width: 1200,
+    height: 800,
+  },
+};

--- a/ui/src/components/stories/StreamingGraphPlayground.tsx
+++ b/ui/src/components/stories/StreamingGraphPlayground.tsx
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * StreamingGraph — demonstrates graph updates arriving in batches over time,
+ * simulating the indexing pipeline's incremental data flow.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { GraphNode, GraphLink } from '../types/graph';
+import type { GraphCanvasHandle } from '../types/canvas';
+import PixiGraphCanvas from '../PixiGraphCanvas';
+import GraphLegend from '../panels/GraphLegend';
+import GraphBadge from '../panels/GraphBadge';
+import { getNodeColor } from '../colors/nodeColors';
+import { getLinkColor } from '../colors/linkColors';
+import type { LegendItem } from '../panels/types';
+import type { Dataset } from './datasets';
+import { DATASETS } from './datasets';
+
+export interface StreamingGraphPlaygroundProps {
+  /** Dataset to stream in (nodes/links added incrementally) */
+  dataset?: Dataset;
+  /** Nodes to add per batch */
+  batchSize?: number;
+  /** Milliseconds between batches */
+  intervalMs?: number;
+  /** Enable 3D perspective mode */
+  mode3d?: boolean;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Given the full dataset and a set of visible node IDs, return only the links
+ * whose source AND target are both visible.
+ */
+function visibleLinks(
+  allLinks: GraphLink[],
+  nodeIds: Set<string>,
+): GraphLink[] {
+  return allLinks.filter((l) => nodeIds.has(l.source) && nodeIds.has(l.target));
+}
+
+export default function StreamingGraphPlayground({
+  dataset: initialDataset,
+  batchSize = 5,
+  intervalMs = 1500,
+  mode3d = false,
+  width: widthProp,
+  height: heightProp,
+}: StreamingGraphPlaygroundProps) {
+  const ds = initialDataset ?? DATASETS[0];
+  const width = widthProp ?? 900;
+  const height = heightProp ?? 600;
+
+  const graphRef = useRef<GraphCanvasHandle>(null);
+
+  // How many nodes are currently visible (we reveal them progressively)
+  const [revealedCount, setRevealedCount] = useState(batchSize);
+  const [streaming, setStreaming] = useState(true);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  // Slice the dataset to the current reveal count
+  const currentNodes = ds.nodes.slice(0, revealedCount);
+  const nodeIdSet = new Set(currentNodes.map((n) => n.id));
+  const currentLinks = visibleLinks(ds.links, nodeIdSet);
+
+  const isDone = revealedCount >= ds.nodes.length;
+
+  // Timer-based streaming
+  useEffect(() => {
+    if (!streaming || isDone) return;
+
+    const timer = setInterval(() => {
+      setRevealedCount((prev) => {
+        const next = Math.min(prev + batchSize, ds.nodes.length);
+        if (next >= ds.nodes.length) {
+          setStreaming(false);
+        }
+        return next;
+      });
+    }, intervalMs);
+
+    return () => clearInterval(timer);
+  }, [streaming, isDone, batchSize, intervalMs, ds.nodes.length]);
+
+  // Legend items
+  const legendItems: LegendItem[] = (() => {
+    const counts = new Map<string, number>();
+    for (const n of currentNodes) {
+      counts.set(n.type, (counts.get(n.type) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([type, count]) => ({
+        label: type,
+        count,
+        color: getNodeColor(type),
+      }));
+  })();
+
+  const linkLegendItems: LegendItem[] = (() => {
+    const counts = new Map<string, number>();
+    for (const l of currentLinks) {
+      counts.set(l.label, (counts.get(l.label) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([label, count]) => ({
+        label,
+        count,
+        color: getLinkColor(label),
+      }));
+  })();
+
+  const handleNodeClick = useCallback((node: GraphNode) => {
+    setSelectedNodeId(node.id);
+  }, []);
+
+  const handleStageClick = useCallback(() => {
+    setSelectedNodeId(null);
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    setRevealedCount(batchSize);
+    setStreaming(true);
+    setSelectedNodeId(null);
+  }, [batchSize]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width,
+        fontFamily: 'Inter, system-ui, sans-serif',
+        background: '#0d1117',
+        color: '#e6edf3',
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Controls bar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '8px 12px',
+          borderBottom: '1px solid #21262d',
+          fontSize: 13,
+        }}
+      >
+        <span style={{ fontWeight: 600 }}>Streaming Graph</span>
+        <span style={{ color: '#8b949e', fontSize: 12 }}>
+          {currentNodes.length} / {ds.nodes.length} nodes &middot;{' '}
+          {currentLinks.length} edges
+        </span>
+        <span style={{ flex: 1 }} />
+        {streaming ? (
+          <button
+            onClick={() => setStreaming(false)}
+            style={{
+              background: '#da3633',
+              color: '#fff',
+              border: 'none',
+              borderRadius: 4,
+              padding: '4px 12px',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}
+          >
+            Pause
+          </button>
+        ) : !isDone ? (
+          <button
+            onClick={() => setStreaming(true)}
+            style={{
+              background: '#238636',
+              color: '#fff',
+              border: 'none',
+              borderRadius: 4,
+              padding: '4px 12px',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}
+          >
+            Resume
+          </button>
+        ) : null}
+        <button
+          onClick={handleRestart}
+          style={{
+            background: '#21262d',
+            color: '#e6edf3',
+            border: '1px solid #30363d',
+            borderRadius: 4,
+            padding: '4px 12px',
+            cursor: 'pointer',
+            fontSize: 12,
+          }}
+        >
+          Restart
+        </button>
+        {isDone && (
+          <span
+            style={{
+              color: '#3fb950',
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+          >
+            Complete
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div
+        style={{
+          height: 3,
+          background: '#21262d',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            height: '100%',
+            width: `${(currentNodes.length / ds.nodes.length) * 100}%`,
+            background: streaming ? '#58a6ff' : isDone ? '#3fb950' : '#d29922',
+            transition: 'width 0.3s ease, background 0.3s ease',
+          }}
+        />
+      </div>
+
+      {/* Graph */}
+      <div style={{ position: 'relative' }}>
+        <PixiGraphCanvas
+          ref={graphRef}
+          nodes={currentNodes}
+          links={currentLinks}
+          width={width}
+          height={height}
+          zIndex
+          mode3d={mode3d}
+          selectedNodeId={selectedNodeId}
+          hops={2}
+          onNodeClick={handleNodeClick}
+          onStageClick={handleStageClick}
+        />
+
+        <div style={{ position: 'absolute', bottom: 8, left: 8 }}>
+          <GraphLegend items={legendItems} linkItems={linkLegendItems} />
+        </div>
+
+        <div style={{ position: 'absolute', bottom: 8, right: 8 }}>
+          <GraphBadge
+            nodeCount={currentNodes.length}
+            edgeCount={currentLinks.length}
+            totalNodes={ds.nodes.length}
+            totalEdges={ds.links.length}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/workers/pixiLayoutWorker.ts
+++ b/ui/src/components/workers/pixiLayoutWorker.ts
@@ -76,6 +76,12 @@ export type WorkerInMessage =
       };
     }
   | {
+      type: 'add-nodes';
+      nodeIds: string[];
+      links: { source: string; target: string }[];
+      communities?: Record<string, number>;
+    }
+  | {
       type: 'update-config';
       chargeStrength?: number;
       linkDistance?: number;
@@ -350,6 +356,68 @@ self.onmessage = (e: MessageEvent<WorkerInMessage>) => {
       sim.restart();
       settled = false;
       startStreaming();
+      break;
+    }
+
+    case 'add-nodes': {
+      if (!sim || !cachedConfig) break;
+
+      if (msg.communities) {
+        communities = { ...communities, ...msg.communities };
+      }
+
+      // Compute centroid of existing nodes
+      const existingIds = new Set(simNodes.map((n) => n.id));
+      let cx = 0,
+        cy = 0;
+      for (const n of simNodes) {
+        cx += n.x ?? 0;
+        cy += n.y ?? 0;
+      }
+      if (simNodes.length > 0) {
+        cx /= simNodes.length;
+        cy /= simNodes.length;
+      }
+      const spread = Math.sqrt(simNodes.length) * 10;
+
+      // Add new nodes scattered near centroid
+      let added = 0;
+      for (const id of msg.nodeIds) {
+        if (existingIds.has(id)) continue;
+        const angle = Math.random() * Math.PI * 2;
+        const r = Math.random() * spread;
+        const node: SimNode = {
+          id,
+          x: cx + Math.cos(angle) * r,
+          y: cy + Math.sin(angle) * r,
+        };
+        simNodes.push(node);
+        nodeIdToIndex.set(id, simNodes.length - 1);
+        added++;
+      }
+
+      if (added === 0) break;
+
+      // Add new links
+      const updatedIds = new Set(simNodes.map((n) => n.id));
+      for (const link of msg.links) {
+        if (updatedIds.has(link.source) && updatedIds.has(link.target)) {
+          cachedLinks.push({ source: link.source, target: link.target });
+        }
+      }
+
+      // Rebuild simulation preserving existing positions
+      sim.stop();
+      stopStreaming();
+      sim = buildSimulation(simNodes, cachedLinks, cachedConfig, currentMode);
+
+      // Gentle reheat — existing nodes barely shift, new ones settle in
+      sim.alpha(0.3).restart();
+      settled = false;
+      startStreaming();
+
+      // Send immediate position update for the expanded node set
+      postPositions();
       break;
     }
 


### PR DESCRIPTION
## Add incremental graph streaming support
🆕 **New Feature** · ⚡ **Performance**

Adds an incremental update path so nodes and edges can be appended to the live graph without tearing down and rebuilding the entire Pixi scene or the layout worker's simulation. When data grows monotonically (new node IDs are a strict superset of the previous set), the renderer appends sprites in place and the worker receives an `add-nodes` message to re-heat the simulation gently around the new arrivals.

### Complexity
🟠 High · `6 files changed, 726 insertions(+), 36 deletions(-)`

Three tightly coupled layers change together — the React effect in `PixiGraphCanvas`, the `usePixiLayout` hook, and the layout web worker — and each must agree on what constitutes an "incremental" update vs. a full reset. The worker lifecycle decision (terminate at start of next init rather than in effect cleanup) is subtle and easy to break. Any mismatch in incremental detection between the canvas layer and the layout layer could leave sprites and simulation state out of sync.

### Tests
🧪 No automated tests added; coverage relies on the new Storybook stories that exercise streaming across several dataset sizes (small to 20 k nodes).

### Review focus
Pay particular attention to the following areas:

- **Incremental detection logic** — both `PixiGraphCanvas` and `usePixiLayout` independently decide whether an update is incremental; verify they use identical criteria so the renderer and layout worker never diverge.
- **Worker lifecycle** — cleanup is intentionally moved out of the effect's return value to avoid killing the worker before `add-nodes` is sent; confirm this doesn't leak workers on unmount or rapid dataset switches.
- **Buffer/nodeOrder length guard** — `applyPositionBuffer` now uses `Math.min` to handle the transient mismatch when the worker returns positions for an expanded node set before the React side has updated `nodeOrderRef`; check the bounds are correct in all orderings.
- **Edge deduplication key** — edges are deduplicated using `sourceId-label-targetId`; verify this is consistent with how `setData` constructs the same structure to avoid phantom duplicates or missing edges on full resets.

---

<details>
<summary><strong>Additional details</strong></summary>

### Why worker cleanup moved

React's effect cleanup runs synchronously before the next render's effect. The old pattern (`return () => worker.terminate()`) killed the worker just before `add-nodes` would have been posted to it. The fix moves termination to the **beginning** of a full-init branch, with a separate unmount effect that handles final cleanup. This is a deliberate deviation from the conventional cleanup pattern and is the most non-obvious part of the change.

### Simulation reheat strategy

On `add-nodes`, the worker resets `alpha` to `0.3` (vs. the full `1.0` used on init). This is intentional: existing nodes have already settled, so a low alpha lets the force simulation nudge them minimally while allowing new nodes (seeded near the existing centroid) to converge quickly.

### New nodes seeded in both layers

New node positions are seeded near the centroid with a spread proportional to `√(prevCount) × 10` **twice** — once in `usePixiLayout` (so the Pixi renderer has something to render immediately) and once in the worker (so the simulation starts from a sensible state). They should converge to the same values, but transient renders may show new nodes briefly clustered before the first `positions` message arrives.


</details>
<!-- opentrace:jid=j-670488cc-c259-4655-84ef-89419b4c38b1|sha=23f43675bbcf6d4b79fab16a9c3bd727b1e7c047 -->