### PR TITLE
chore(ci): unify preview label names to `preview-*` prefix

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -9,8 +9,8 @@ jobs:
     name: Cleanup Preview
     runs-on: ubuntu-latest
     if: |
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy-preview')) ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-preview')
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview-deploy')) ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview-deploy')
     steps:
       - name: Trigger preview cleanup
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,7 +8,7 @@ jobs:
   trigger-deploy:
     name: Deploy Preview
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+    if: contains(github.event.pull_request.labels.*.name, 'preview-deploy')
     steps:
       - name: Trigger preview deployment
         run: |

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-preview:
     name: Publish preview to PyPI
-    if: contains(github.event.pull_request.labels.*.name, 'publish-preview')
+    if: contains(github.event.pull_request.labels.*.name, 'preview-publish')
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

- Standardize all preview-related label names to use a `preview-` prefix
- `deploy-preview` → `preview-deploy` (in deploy-preview.yml, cleanup-preview.yml)
- `publish-preview` → `preview-publish` (in publish-preview.yml)
- `preview-npm` was already correct — no change needed

## Test plan

- [ ] Rename labels in GitHub repo settings to match
- [ ] Verify deploy-preview triggers with new `preview-deploy` label
- [ ] Verify cleanup-preview triggers on PR close/unlabel with `preview-deploy`
- [ ] Verify publish-preview triggers with new `preview-publish` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)