### PR TITLE
chore: add /reset command for hard reset to origin/main

### DIFF
--- a/.claude/commands/reset.md
+++ b/.claude/commands/reset.md
@@ -1,0 +1,22 @@
+---
+name: reset
+description: Hard reset to origin/main and clear the chat context.
+allowed-tools: Bash
+---
+
+Reset the current worktree to match origin/main and clear conversation context.
+
+## Instructions
+
+### 1. Fetch latest and hard reset
+
+```bash
+git fetch origin main
+git checkout main
+git reset --hard origin/main
+git clean -fd
+```
+
+### 2. Clear context
+
+After the reset completes, run `/clear` to wipe the conversation context.


### PR DESCRIPTION
## Add /reset slash command for hard-resetting to origin/main
🔧 **Chore**

Adds a `/reset` Claude Code slash command that hard-resets the current worktree to `origin/main` and clears the conversation context. Useful for getting back to a clean state without manually running the git commands.

### Complexity
🟢 Trivial · `1 file changed, 22 insertions(+)`

Single new markdown file defining a slash command. No functional code, no logic, no tests. A reviewer can skim and approve in seconds.

### Review focus
Pay particular attention to the following areas:

- **Destructive git commands** — the command runs `git reset --hard` and `git clean -fd`, which discard all uncommitted changes and untracked files with no recovery path; verify the description makes this risk clear enough to users.
<!-- opentrace:jid=ab428f03-7e11-46e3-8f59-fca486a76963|sha=36cf6d270cb494e99abc715144e92e54ea9fb745 -->