### PR TITLE
fix(ui): correct style.css export path in package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
       "import": "./dist/lib/chat.js",
       "require": "./dist/lib/chat.cjs"
     },
-    "./style.css": "./dist/lib/components.css"
+    "./style.css": "./dist/lib/opentrace.css"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary
- Fix broken `./style.css` export in `package.json` — pointed to non-existent `components.css`, now points to actual build output `opentrace.css`
- Unblocks consumers importing `@opentrace/opentrace/style.css`

## Test plan
- [x] Verified `npm run build:lib` produces `dist/lib/opentrace.css` (not `components.css`)
- [ ] Confirm downstream consumers can resolve `@opentrace/opentrace/style.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)