### PR TITLE
fix(ui): wrap library CSS in @layer opentrace

### DIFF
--- a/ui/vite.config.lib.ts
+++ b/ui/vite.config.lib.ts
@@ -24,13 +24,48 @@
  *   dist/lib/opentrace-components.cjs  (CJS)
  *   dist/lib/components.css            (extracted CSS)
  */
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import wasm from 'vite-plugin-wasm';
 import { resolve } from 'path';
 
+/**
+ * Rollup plugin that wraps all emitted CSS assets in `@layer opentrace { … }`.
+ *
+ * This prevents Tailwind (in consuming apps) from rewriting `color-mix()` rules
+ * with `@supports` fallbacks that produce opaque backgrounds instead of the
+ * intended translucent ones.  Layered CSS also ensures library styles never
+ * accidentally override consumer styles.
+ */
+function cssLayerPlugin(): Plugin {
+  return {
+    name: 'opentrace-css-layer',
+    enforce: 'post',
+    generateBundle(_options, bundle) {
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        if (fileName.endsWith('.css') && chunk.type === 'asset') {
+          const css =
+            typeof chunk.source === 'string'
+              ? chunk.source
+              : new TextDecoder().decode(chunk.source);
+          // Pull @import rules out of the layer block — CSS requires
+          // @import to appear before any other rules, including @layer.
+          const imports: string[] = [];
+          const rest = css.replace(/@import\s+url\([^)]*\)\s*;?/g, (m) => {
+            imports.push(m.trimEnd().replace(/;?$/, ';'));
+            return '';
+          });
+          chunk.source =
+            (imports.length ? imports.join('\n') + '\n' : '') +
+            `@layer opentrace {\n${rest}\n}\n`;
+        }
+      }
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), wasm()],
+  plugins: [react(), wasm(), cssLayerPlugin()],
   publicDir: false,
   resolve: {
     alias: {


### PR DESCRIPTION
## Export OpenTraceApp component for embedding the full application
🆕 **New Feature** · ✨ **Improvement** · ♻️ **Refactor** · 🔧 **Chore**

Adds an exportable `<OpenTraceApp>` component that allows mounting the entire UI (graph, chat, settings) within other React apps. Updates the build system to support this new entry point and introduces CSS isolation to prevent style conflicts in consuming applications.

### Complexity
🟡 Moderate · `9 files changed, 228 insertions(+), 21 deletions(-)`

The PR touches multiple layers including build configuration, global styles, and core component structure. It introduces a significant new way to consume the project (as an embedded app) which requires foundational changes to how the app handles its environment, such as switching from window-based sizing to container-based responsiveness.

### Tests
🧪 Existing tests for components and hooks remain valid; logic changes are primarily structural or build-related.

### Review focus
Pay particular attention to the following areas:

- **CSS Layering** — check the Vite plugin logic in `vite.config.lib.ts` that wraps styles in `@layer opentrace` to ensure it correctly handles `@import` rules.
- **Container Sizing** — verify the transition from `window.innerWidth` to `ResizeObserver` in `App.tsx` correctly handles layout updates for the graph canvas.
- **URL Parameter Cleanup** — ensure the selective removal of the `repo` parameter doesn't inadvertently strip other necessary query strings in the `useEffect` hook.

---

<details>
<summary><strong>Additional details</strong></summary>

### Component Strategy
The new `<OpenTraceApp>` component acts as a wrapper that bundles the `StoreProvider`, `JobServiceProvider`, and the main `App` logic into a single export. This allows consumers to integrate the full OpenTrace experience with minimal boilerplate.

### Responsiveness & Layout
Previously, the app assumed it owned the entire viewport (`100vw`/`100dvh`). To support embedding in smaller containers (e.g., a tab or a sidebar), several changes were made:
- Switched from `window` resize events to a `ResizeObserver` on the root `.app` container.
- Updated CSS dimensions from viewport units to percentages.
- The version footer is now conditionally rendered based on props or the presence of Vite globals.

### CSS Isolation
When this library is used in apps with Tailwind CSS, Tailwind's build pipeline often detects `color-mix()` usage and injects `@supports` fallbacks. These fallbacks use opaque variables that override the intended translucent backgrounds. 

Wrapping the entire library CSS in `@layer opentrace` ensures:
1. Library styles have lower priority than the consumer's unlayered styles.
2. Tailwind treats the CSS as a distinct layer, preventing the conflicting fallback injection.

### Build System
The build process now includes a separate `tsc` pass for the app export (`tsconfig.lib-app.json`). This was necessary because the standard library build only emitted declarations for the components sub-directory, whereas the full app export requires declarations for the entire source tree.

</details>
<!-- opentrace:jid=e8745262-178d-431a-a182-29ed2a16787a|sha=8a0ce1d63d5c2038dff78c7fba8de718b6a7cd2f -->