### PR TITLE
fix(ui): truncate graph labels and strip control characters

### DIFF
--- a/ui/src/components/config/graphLayout.ts
+++ b/ui/src/components/config/graphLayout.ts
@@ -104,6 +104,7 @@ export const NOVERLAP_COMMUNITY_ITERATIONS = 20; // per-community push-apart pas
 export const EDGE_PROGRAM_THRESHOLD = 50000;
 
 export const LABEL_RENDERED_SIZE_THRESHOLD = 8;
+export const LABEL_MAX_LENGTH = 64;
 export const LABEL_SIZE = 12;
 export const LABEL_FONT = 'Inter, system-ui, sans-serif';
 export const LABEL_COLOR = '#e2e8f0';

--- a/ui/src/components/graph/useGraphInstance.ts
+++ b/ui/src/components/graph/useGraphInstance.ts
@@ -26,6 +26,7 @@ import type { LayoutRequest, LayoutResponse } from '../workers/d3LayoutWorker';
 import {
   EDGE_SIZE_DEFAULT,
   EDGE_SIZE_DEFAULT_LINE,
+  LABEL_MAX_LENGTH,
 } from '../config/graphLayout';
 import {
   nodeSize,
@@ -33,6 +34,13 @@ import {
   applySpacing,
   applyNoverlap,
 } from './layoutHelpers';
+
+function cleanLabel(raw: string): string {
+  const stripped = raw.replace(/[\n\r\t]+/g, ' ').trim();
+  return stripped.length > LABEL_MAX_LENGTH
+    ? stripped.slice(0, LABEL_MAX_LENGTH) + '…'
+    : stripped;
+}
 
 // ─── Hook ───────────────────────────────────────────────────────────────
 
@@ -109,8 +117,8 @@ export function useGraphInstance({
       return {
         key: node.id,
         attributes: {
-          label: node.name || node.id,
-          _originalLabel: node.name || node.id,
+          label: cleanLabel(node.name || node.id),
+          _originalLabel: cleanLabel(node.name || node.id),
           x: 0,
           y: 0,
           size,

--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -64,10 +64,19 @@ import {
   EDGE_OPACITY_DEFAULT,
   EDGE_OPACITY_HIGHLIGHTED,
   EDGE_OPACITY_DIMMED,
+  LABEL_MAX_LENGTH,
   LABEL_SIZE,
   LABEL_FONT,
   LABEL_COLOR,
 } from '../config/graphLayout';
+
+/** Strip control characters and truncate to MAX_LABEL_LENGTH. */
+function cleanLabel(raw: string): string {
+  const stripped = raw.replace(/[\n\r\t]+/g, ' ').trim();
+  return stripped.length > LABEL_MAX_LENGTH
+    ? stripped.slice(0, LABEL_MAX_LENGTH) + '…'
+    : stripped;
+}
 
 // ─── Types ──────────────────────────────────────────────────────────────
 
@@ -960,7 +969,7 @@ export class PixiRenderer {
 
       const sx = (nx + gap) * this.vp.scale + this.vp.x;
       const sy = ny * this.vp.scale + this.vp.y - labelH / 2;
-      const textLen = (node.graphNode.name || node.id).length;
+      const textLen = cleanLabel(node.graphNode.name || node.id).length;
       const sw = textLen * LABEL_SIZE * 0.6 * screenLabelScale;
       const sh = labelH;
 
@@ -1276,7 +1285,7 @@ export class PixiRenderer {
   private createLabel(node: PixiNode): Text {
     const lblInv = this.labelInvScale();
     const label = new Text({
-      text: node.graphNode.name || node.id,
+      text: cleanLabel(node.graphNode.name || node.id),
       style: new TextStyle({
         fontSize: LABEL_SIZE,
         fontFamily: LABEL_FONT,


### PR DESCRIPTION
## Truncate graph labels and strip control characters
🐛 **Bug Fix** · ✨ **Improvement**

This PR improves graph label rendering by stripping control characters (newlines, tabs) and truncating long names to 64 characters. 

It ensures that the labels used for Pixi renderer culling and the labels stored in the graph state are perfectly in sync to prevent visual flickering.

### Complexity
🟢 Low · `3 files changed, 22 insertions(+), 4 deletions(-)`

The changes are localized to string manipulation within the graph UI. They do not alter the underlying data structures or core application logic.

### Review focus
Pay particular attention to the following areas:

- **Label Consistency** — verify that the cleaning logic is applied identically in both the graph state and the renderer to maintain layout accuracy.
- **Truncation Limit** — confirm that 64 characters is an appropriate length for node labels in the graph view.
<!-- opentrace:jid=j-43223ea6-538d-4c1f-95ee-2807997af239|sha=964993c8bb9cbd524dbbd8c04e66201b0c7dd692 -->