### PR TITLE
feat(ui): make StoreProvider accept a required store prop

### DIFF
--- a/ui/src/OpenTraceApp.tsx
+++ b/ui/src/OpenTraceApp.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { StoreProvider } from './store';
+import { StoreProvider, createLadybugStore } from './store';
 import { JobServiceProvider } from './job';
 import App from './App';
 import './styles/index.css';
@@ -28,6 +28,8 @@ export interface OpenTraceAppProps {
   /** Initial repository URL to index or open. */
   repoUrl?: string;
 }
+
+const store = createLadybugStore();
 
 /**
  * Drop-in full OpenTrace application component.
@@ -50,7 +52,7 @@ export function OpenTraceApp({
   repoUrl,
 }: OpenTraceAppProps = {}) {
   return (
-    <StoreProvider>
+    <StoreProvider store={store}>
       <JobServiceProvider>
         <App version={version} buildTime={buildTime} initialRepoUrl={repoUrl} />
       </JobServiceProvider>

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -18,12 +18,14 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles/index.css';
 import App from './App.tsx';
-import { StoreProvider } from './store';
+import { StoreProvider, createLadybugStore } from './store';
 import { JobServiceProvider } from './job';
+
+const store = createLadybugStore();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <StoreProvider>
+    <StoreProvider store={store}>
       <JobServiceProvider>
         <App version={__APP_VERSION__} buildTime={__BUILD_TIME__} />
       </JobServiceProvider>

--- a/ui/src/store/__tests__/context.test.tsx
+++ b/ui/src/store/__tests__/context.test.tsx
@@ -15,13 +15,15 @@
  */
 
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import React from 'react';
+import { StoreProvider, useStore } from '../context';
+import type { GraphStore } from '../types';
 
-// Mock LadybugGraphStore and crossOriginIsolated
-vi.mock('../ladybugStore', () => ({
-  LadybugGraphStore: vi.fn().mockImplementation(() => ({
+function createMockStore(): GraphStore {
+  return {
+    hasData: () => false,
     fetchGraph: vi.fn().mockResolvedValue({ nodes: [], links: [] }),
     fetchStats: vi.fn().mockResolvedValue({
       total_nodes: 0,
@@ -33,38 +35,29 @@ vi.mock('../ladybugStore', () => ({
       nodes_created: 0,
       relationships_created: 0,
     }),
+    flush: vi.fn().mockResolvedValue(undefined),
     storeSource: vi.fn(),
     fetchSource: vi.fn().mockResolvedValue(null),
     searchNodes: vi.fn().mockResolvedValue([]),
     listNodes: vi.fn().mockResolvedValue([]),
     getNode: vi.fn().mockResolvedValue(null),
     traverse: vi.fn().mockResolvedValue([]),
-  })),
-}));
-
-// Must mock crossOriginIsolated before importing context
-vi.stubGlobal('crossOriginIsolated', true);
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
+  };
+}
 
 describe('StoreContext', () => {
-  it('useStore outside provider throws', async () => {
-    // Dynamic import after mocks are set up
-    const { useStore } = await import('../context');
+  it('useStore outside provider throws', () => {
     expect(() => {
       renderHook(() => useStore());
     }).toThrow('useStore() must be used within <StoreProvider>');
   });
 
-  it('useStore inside provider returns store', async () => {
-    const { useStore, StoreProvider } = await import('../context');
+  it('useStore inside provider returns the provided store', () => {
+    const mockStore = createMockStore();
     const wrapper = ({ children }: { children: React.ReactNode }) =>
-      React.createElement(StoreProvider, null, children);
+      React.createElement(StoreProvider, { store: mockStore }, children);
 
     const { result } = renderHook(() => useStore(), { wrapper });
-    expect(result.current.store).toBeDefined();
-    expect(typeof result.current.store.fetchGraph).toBe('function');
+    expect(result.current.store).toBe(mockStore);
   });
 });

--- a/ui/src/store/context.tsx
+++ b/ui/src/store/context.tsx
@@ -15,7 +15,6 @@
  */
 
 import { createContext, use, type ReactNode } from 'react';
-import { LadybugGraphStore } from './ladybugStore';
 import type { GraphStore } from './types';
 
 interface StoreContextValue {
@@ -24,26 +23,12 @@ interface StoreContextValue {
 
 const StoreContext = createContext<StoreContextValue | null>(null);
 
-// Module-level singleton — survives React StrictMode double-invocation.
-// Without this, StrictMode creates two LadybugGraphStore instances (two workers,
-// two independent in-memory databases), so imports go to one and reads to the other.
-let singletonStore: LadybugGraphStore | null = null;
-function getStore(): LadybugGraphStore {
-  if (!singletonStore) {
-    if (!crossOriginIsolated) {
-      throw new Error(
-        'Cross-Origin Isolation (COOP/COEP headers) is required ' +
-          'for in-browser LadybugDB. Serve with appropriate headers.',
-      );
-    }
-    singletonStore = new LadybugGraphStore();
-  }
-  return singletonStore;
+interface StoreProviderProps {
+  store: GraphStore;
+  children: ReactNode;
 }
 
-export function StoreProvider({ children }: { children: ReactNode }) {
-  const store = getStore();
-
+export function StoreProvider({ store, children }: StoreProviderProps) {
   return <StoreContext value={{ store }}>{children}</StoreContext>;
 }
 
@@ -54,12 +39,4 @@ export function useStore(): StoreContextValue {
     throw new Error('useStore() must be used within <StoreProvider>');
   }
   return ctx;
-}
-
-// Clean up WASM resources on Vite HMR to prevent memory leaks.
-if (import.meta.hot) {
-  import.meta.hot.dispose(() => {
-    singletonStore?.dispose();
-    singletonStore = null;
-  });
 }

--- a/ui/src/store/createLadybugStore.ts
+++ b/ui/src/store/createLadybugStore.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LadybugGraphStore } from './ladybugStore';
+
+// Module-level singleton — survives React StrictMode double-invocation.
+// Without this, StrictMode creates two LadybugGraphStore instances (two workers,
+// two independent in-memory databases), so imports go to one and reads to the other.
+let singletonStore: LadybugGraphStore | null = null;
+
+/**
+ * Returns a singleton LadybugGraphStore backed by the in-browser WASM engine.
+ *
+ * Requires Cross-Origin Isolation (COOP/COEP headers).
+ */
+export function createLadybugStore(): LadybugGraphStore {
+  if (!singletonStore) {
+    if (!crossOriginIsolated) {
+      throw new Error(
+        'Cross-Origin Isolation (COOP/COEP headers) is required ' +
+          'for in-browser LadybugDB. Serve with appropriate headers.',
+      );
+    }
+    singletonStore = new LadybugGraphStore();
+  }
+  return singletonStore;
+}
+
+// Clean up WASM resources on Vite HMR to prevent memory leaks.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    singletonStore?.dispose();
+    singletonStore = null;
+  });
+}

--- a/ui/src/store/index.ts
+++ b/ui/src/store/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { StoreProvider, useStore } from './context';
+export { createLadybugStore } from './createLadybugStore';
 export type { GraphStore } from './types';


### PR DESCRIPTION
## Flexible store injection for StoreProvider
♻️ **Refactor** · ✨ **Improvement** · 🧪 **Tests**

Extracts WASM store creation into a factory and updates `StoreProvider` to accept an explicit `store` prop. 

This enables the UI to run with alternative `GraphStore` implementations, supporting embedded panels and simpler testing without the WASM engine.

### Complexity
🟡 Moderate · `6 files changed, 75 insertions(+), 52 deletions(-)`

This PR refactors the core data injection layer of the UI. While the code changes are relatively small, they modify foundational patterns for how the application accesses its storage engine, moving from a hardcoded singleton to a dependency injection model.

### Tests
🧪 Refactored store context tests to use explicit mock stores, eliminating fragile module-level mocking and global state stubs.

### Review focus
Pay particular attention to the following areas:

- **Singleton persistence** — verify that `createLadybugStore` correctly maintains the singleton across React re-renders and Vite HMR to prevent multiple WASM worker instances.
- **WASM requirements** — ensure the `crossOriginIsolated` check remains effective now that it is moved from the provider to the factory function.

---

<details>
<summary><strong>Additional details</strong></summary>

### The Problem
The UI was previously hardcoded to use the WASM-backed `LadybugGraphStore`. This forced a dependency on Cross-Origin Isolation (COOP/COEP) headers across the entire app, even for simple embedded panels or tests that could run with a lighter in-memory store.

### The Solution
We've decoupled the storage engine from the React context:
- `StoreProvider` is now a pure "dumb" provider that distributes a `GraphStore` instance.
- `createLadybugStore()` handles the specialized logic for the WASM engine, including singleton management and HMR cleanup.
- This allows consumers to swap in the `InMemoryGraphStore` or a mock store easily.

The singleton pattern in the factory is critical. Without it, React's `StrictMode` would instantiate the WASM worker twice during development, leading to independent databases where writes and reads would go to different instances.

</details>
<!-- opentrace:jid=cdcebacc-f2bc-4281-97fb-97b85c9debe7|sha=3f35447ae9cb1547cba05e3f59d120ff78932056 -->