### PR TITLE
chore: fix ingores and package lock build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ ui/node_modules/
 ui/dist/
 functions/node_modules/
 functions/lib/
+components/node_modules/
 
 # IDE
 .idea/

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,6 @@
         "@langchain/google-genai": "^2.1.26",
         "@langchain/langgraph": "^1.2.2",
         "@langchain/openai": "^1.3.0",
-        "@opentrace/opentrace": "^0.1.1-pr.214.244",
         "apache-arrow": "^21.1.0",
         "d3-force": "^3.0.0",
         "d3-quadtree": "^3.0.1",
@@ -31,14 +30,14 @@
         "parquet-wasm": "^0.7.1",
         "pixi.js": "^8.17.1",
         "prism-react-renderer": "^2.4.1",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "react-markdown": "^10.1.0",
         "react-window": "^2.2.7",
         "remark-gfm": "^4.0.1",
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.6.0",
-        "web-tree-sitter": "^0.26.6",
+        "web-tree-sitter": ">=0.24.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -2234,63 +2233,6 @@
       "license": "MIT",
       "dependencies": {
         "langium": "^4.0.0"
-      }
-    },
-    "node_modules/@opentrace/opentrace": {
-      "version": "0.1.1-pr.214.244",
-      "resolved": "https://registry.npmjs.org/@opentrace/opentrace/-/opentrace-0.1.1-pr.214.244.tgz",
-      "integrity": "sha512-r1m9KZQOKJfNVWyTyobqpgAbvObOKswXgHfsqhRDF8RlMKxBr0lwcZicrM19W6mbA4+P2z4DMAxDjJSaTDnSew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@huggingface/transformers": "^3.0.0",
-        "@ladybugdb/wasm-core": "0.15.2",
-        "@langchain/anthropic": "^1.3.23",
-        "@langchain/core": "^1.1.32",
-        "@langchain/google-genai": "^2.1.26",
-        "@langchain/langgraph": "^1.2.2",
-        "@langchain/openai": "^1.3.0",
-        "apache-arrow": "^21.1.0",
-        "d3-force": "^3.0.0",
-        "d3-quadtree": "^3.0.1",
-        "fflate": "^0.8.2",
-        "graphology": "^0.26.0",
-        "graphology-communities-louvain": "^2.0.2",
-        "graphology-layout-forceatlas2": "^0.10.1",
-        "graphology-layout-noverlap": "^0.4.2",
-        "graphology-types": "^0.24.8",
-        "idb": "^8.0.3",
-        "mermaid": "^11.6.0",
-        "parquet-wasm": "^0.7.1",
-        "pixi.js": "^8.17.1",
-        "prism-react-renderer": "^2.4.1",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
-        "react-markdown": "^10.1.0",
-        "react-window": "^2.2.7",
-        "remark-gfm": "^4.0.1",
-        "vite-plugin-top-level-await": "^1.6.0",
-        "vite-plugin-wasm": "^3.6.0",
-        "web-tree-sitter": "^0.26.6",
-        "zod": "^4.3.6"
-      },
-      "bin": {
-        "opentrace-copy-wasm": "bin/copy-wasm.js"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "web-tree-sitter": ">=0.24.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "web-tree-sitter": {
-          "optional": true
-        }
       }
     },
     "node_modules/@pixi/colord": {


### PR DESCRIPTION
## Fix package-lock inconsistencies and update gitignore
🔧 **Chore**

Synchronises `ui/package-lock.json` with existing `package.json` constraints and removes a redundant self-dependency. Also updates `.gitignore` to include `components/node_modules/`.

### Complexity
🟢 Trivial · `2 files changed, 4 insertions(+), 61 deletions(-)`

Single-file lockfile cleanup and a .gitignore addition with no impact on functional code or resolved dependency versions.
<!-- opentrace:jid=c12727f2-a703-4e39-80e7-59321c7a40d7|sha=76d1ac812fbc856c24c584e3990376ae122aa75e -->