### PR TITLE
feat(ui): persist chat graph highlights with conversation history

### DIFF
--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -112,6 +112,7 @@ export default function ChatPanel({
     deleteConversation,
     persistMessages,
     loadingConversation,
+    foundNodeIds: restoredFoundNodeIds,
   } = useConversation(repoUrl, historyEnabled);
 
   const [showSettings, setShowSettings] = useState(false);
@@ -170,6 +171,19 @@ export default function ChatPanel({
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages]);
+
+  // Restore chat graph highlights when switching conversations
+  useEffect(() => {
+    chatFoundNodesRef.current = new Set(restoredFoundNodeIds);
+    const hasNodes = restoredFoundNodeIds.length > 0;
+    setHasFoundNodes(hasNodes);
+    if (highlightEnabled && hasNodes) {
+      onChatHighlight?.(new Set(restoredFoundNodeIds), []);
+    } else {
+      onChatHighlight?.(new Set(), []);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only fire when restored node IDs change
+  }, [restoredFoundNodeIds]);
 
   // Sync highlight state when toggle changes
   useEffect(() => {
@@ -549,7 +563,12 @@ export default function ChatPanel({
       setStreaming(false);
       // Persist conversation after each completed turn (skip if user aborted)
       if (!controller.signal.aborted) {
-        persistMessages(messagesRef.current, providerId, modelId);
+        persistMessages(
+          messagesRef.current,
+          providerId,
+          modelId,
+          Array.from(chatFoundNodesRef.current),
+        );
       }
     }
   };

--- a/ui/src/chat/chatHistoryStore.ts
+++ b/ui/src/chat/chatHistoryStore.ts
@@ -26,6 +26,8 @@ export interface Conversation {
   /** Scopes the conversation to a project (typically the repo URL) */
   projectKey: string;
   messages: ChatMessage[];
+  /** Node IDs discovered by chat tool results (the "chat graph") */
+  foundNodeIds?: string[];
 }
 
 export type ConversationSummary = Omit<Conversation, 'messages'>;

--- a/ui/src/chat/useConversation.ts
+++ b/ui/src/chat/useConversation.ts
@@ -32,6 +32,8 @@ export interface UseConversationReturn {
   conversations: ConversationSummary[];
   messages: ChatMessage[];
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+  /** Node IDs found by chat tools, restored when switching conversations */
+  foundNodeIds: string[];
   startNewConversation: () => void;
   switchConversation: (id: string) => Promise<void>;
   deleteConversation: (id: string) => Promise<void>;
@@ -40,6 +42,7 @@ export interface UseConversationReturn {
     msgs: ChatMessage[],
     provider: string,
     model: string,
+    foundNodeIds?: string[],
   ) => Promise<void>;
   loadingConversation: boolean;
 }
@@ -51,6 +54,7 @@ export function useConversation(
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [foundNodeIds, setFoundNodeIds] = useState<string[]>([]);
   const [loadingConversation, setLoadingConversation] = useState(false);
 
   // Ref to track the live conversation ID — avoids stale closures in callbacks
@@ -66,6 +70,7 @@ export function useConversation(
     setConversationId(null);
     conversationIdRef.current = null;
     setMessages([]);
+    setFoundNodeIds([]);
 
     (async () => {
       const list = await listConversations(projectKey);
@@ -88,6 +93,7 @@ export function useConversation(
     setConversationId(null);
     conversationIdRef.current = null;
     setMessages([]);
+    setFoundNodeIds([]);
   }, []);
 
   const switchConversation = useCallback(async (id: string) => {
@@ -101,6 +107,7 @@ export function useConversation(
         setConversationId(conv.id);
         conversationIdRef.current = conv.id;
         setMessages(conv.messages);
+        setFoundNodeIds(conv.foundNodeIds ?? []);
       }
     } finally {
       if (token === switchTokenRef.current) {
@@ -116,6 +123,7 @@ export function useConversation(
         setConversationId(null);
         conversationIdRef.current = null;
         setMessages([]);
+        setFoundNodeIds([]);
       }
       await refreshList();
     },
@@ -123,7 +131,12 @@ export function useConversation(
   );
 
   const persistMessages = useCallback(
-    async (msgs: ChatMessage[], provider: string, model: string) => {
+    async (
+      msgs: ChatMessage[],
+      provider: string,
+      model: string,
+      nodeIds?: string[],
+    ) => {
       if (!enabled || msgs.length === 0) return;
 
       // Use the ref to get the live ID, not the stale closure value
@@ -145,6 +158,7 @@ export function useConversation(
         model,
         projectKey: projectKey ?? '',
         messages: msgs,
+        foundNodeIds: nodeIds,
       };
 
       // Preserve original createdAt if conversation already exists
@@ -164,6 +178,7 @@ export function useConversation(
     conversations,
     messages,
     setMessages,
+    foundNodeIds,
     startNewConversation,
     switchConversation,
     deleteConversation,


### PR DESCRIPTION
## Persist chat graph highlights with conversation history
🆕 **New Feature**

This PR saves discovered node IDs in IndexedDB alongside chat messages. 

Switching between conversations now restores the correct graph highlights instead of showing the state of the last active chat. 

- Adds `foundNodeIds` to the `Conversation` persistence model.
- Updates the `useConversation` hook to track and load highlighted nodes.
- Synchronizes the graph viewer when switching history items.

### Complexity
🟢 Low · `3 files changed, 38 insertions(+), 2 deletions(-)`

The changes are narrow in scope and follow existing patterns for chat history persistence. The logic is contained within the chat UI and the `useConversation` hook, with no impact on core graph rendering or LLM processing.

### Tests
🧪 This change adds persistence logic to the chat hook and UI without accompanying unit tests.

### Review focus
Pay particular attention to the following areas:

- **State synchronization** — verify that the restoration `useEffect` in `ChatPanel` correctly applies stored IDs to the graph without side effects.
- **Persistence timing** — ensure `persistMessages` correctly captures node IDs from the ref at the end of the streaming loop.

---

<details>
<summary><strong>Additional details</strong></summary>

### Approach
The "chat graph" state (nodes discovered by tool calls) was previously stored in a `Set` within `ChatPanel` and lost on page refresh or conversation switch. This PR extends the persistence layer to treat these IDs as part of the conversation's state.

1.  **Storage**: The `Conversation` interface is extended with an optional `foundNodeIds` array. Because the storage implementation uses IndexedDB, this extra field is handled automatically without manual schema migrations.
2.  **Hook Logic**: `useConversation` is updated to manage `foundNodeIds` state. It ensures that when a conversation is loaded or cleared, the associated highlights are updated.
3.  **UI Sync**: `ChatPanel` now monitors `restoredFoundNodeIds` from the hook. When it changes (e.g., during a switch), an effect triggers the `onChatHighlight` callback to update the global graph viewer.

### Handling LLM Turns
To ensure highlights are saved accurately, the `persistMessages` call at the end of an LLM stream now captures the contents of `chatFoundNodesRef`. Using the ref ensures we save all nodes discovered during the current turn, avoiding stale closure issues.

</details>
<!-- opentrace:jid=j-825cd16a-4336-4ee0-bf89-41ebdd6d29c5|sha=e79c4b606100c2def1f5d5279b20b30a086c8fb5 -->