### PR TITLE
feat(ui): add help menu and Getting Started drawer

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -365,6 +365,98 @@
   border-color: var(--primary);
 }
 
+.help-toggle-btn {
+  pointer-events: auto;
+  background: color-mix(in oklch, var(--card) 80%, transparent);
+  border: 1px solid color-mix(in oklch, var(--border) 30%, transparent);
+  color: var(--muted-foreground);
+  width: 36px;
+  height: 36px;
+  border-radius: calc(var(--radius) + 2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.help-toggle-btn:hover {
+  background: color-mix(in oklch, var(--primary) 10%, transparent);
+  color: var(--primary);
+  border-color: color-mix(in oklch, var(--primary) 30%, transparent);
+}
+
+.help-toggle-btn.active {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-color: var(--primary);
+}
+
+/* Help dropdown menu */
+.help-menu-container {
+  position: relative;
+  pointer-events: auto;
+}
+
+.help-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 50;
+  min-width: 200px;
+  background: var(--popover, var(--card));
+  border: 1px solid color-mix(in oklch, var(--border) 60%, transparent);
+  border-radius: calc(var(--radius) + 2px);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.15),
+    0 1px 3px rgba(0, 0, 0, 0.1);
+  padding: 4px 0;
+  animation: helpDropdownIn 0.15s ease-out;
+}
+
+@keyframes helpDropdownIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.help-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 14px;
+  background: none;
+  border: none;
+  color: var(--foreground);
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.1s;
+  white-space: nowrap;
+}
+
+.help-dropdown-item:hover {
+  background: color-mix(in oklch, var(--accent) 60%, transparent);
+}
+
+.help-external-icon {
+  margin-left: auto;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+
+.help-dropdown-divider {
+  height: 1px;
+  background: color-mix(in oklch, var(--border) 40%, transparent);
+  margin: 4px 0;
+}
+
 /* GitHub Star Button */
 .github-star-btn {
   pointer-events: auto;
@@ -1190,6 +1282,7 @@
   .ot-toolbar-nav .add-repo-btn,
   .ot-toolbar-nav .chat-toggle-btn,
   .ot-toolbar-nav .settings-toggle-btn,
+  .ot-toolbar-nav .help-toggle-btn,
   .ot-toolbar-nav .theme-toggle-btn {
     width: auto;
     height: auto;
@@ -1207,6 +1300,7 @@
   .ot-toolbar-nav .add-repo-btn:hover,
   .ot-toolbar-nav .chat-toggle-btn:hover,
   .ot-toolbar-nav .settings-toggle-btn:hover,
+  .ot-toolbar-nav .help-toggle-btn:hover,
   .ot-toolbar-nav .theme-toggle-btn:hover {
     background: var(--accent);
     color: var(--foreground);
@@ -1215,6 +1309,7 @@
 
   .ot-toolbar-nav .chat-toggle-btn.active,
   .ot-toolbar-nav .settings-toggle-btn.active,
+  .ot-toolbar-nav .help-toggle-btn.active,
   .ot-toolbar-nav .theme-toggle-btn.active {
     background: color-mix(in oklch, var(--primary) 15%, transparent);
     color: var(--primary);
@@ -1236,6 +1331,27 @@
 
   .ot-toolbar-nav .add-repo-btn {
     margin-left: 0;
+  }
+
+  /* Help menu: make container full-width and dropdown static in burger */
+  .ot-toolbar-nav .help-menu-container {
+    width: 100%;
+  }
+
+  .ot-toolbar-nav .help-dropdown {
+    position: static;
+    box-shadow: none;
+    border: none;
+    border-top: 1px solid var(--border);
+    border-radius: 0;
+    margin-top: 4px;
+    min-width: 0;
+    animation: none;
+  }
+
+  .ot-toolbar-nav .help-dropdown-item {
+    padding: 10px 16px 10px 28px;
+    font-size: 14px;
   }
 
   /* Job minimized bar as menu row */

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,6 +21,7 @@ import GraphViewer from './appComponents/GraphViewer';
 import type { GraphViewerHandle } from './appComponents/GraphViewer';
 import ChatPanel from './appComponents/ChatPanel';
 import SettingsDrawer from './appComponents/SettingsDrawer';
+import HelpDrawer from './appComponents/HelpDrawer';
 import type { GraphNode, GraphLink } from '@opentrace/components/utils';
 import { loadAnimationSettings } from './config/animation';
 import { normalizeRepoUrl, detectProvider } from '@opentrace/components';
@@ -66,9 +67,11 @@ function App({
     new URLSearchParams(window.location.search).has('repo'),
   );
 
-  const [showChat, setShowChat] = useState(true);
+  const isNewUser = !localStorage.getItem('ot:hasVisited');
+  const [showChat, setShowChat] = useState(!isNewUser);
   const [chatWidth, setChatWidth] = useState(480);
   const [showSettings, setShowSettings] = useState(false);
+  const [showHelp, setShowHelp] = useState(isNewUser);
   const [animationSettings, setAnimationSettings] = useState<AnimationSettings>(
     loadAnimationSettings,
   );
@@ -200,12 +203,38 @@ function App({
     setShowAddRepo(true);
   }, []);
   const handleAddRepoClose = useCallback(() => setShowAddRepo(false), []);
-  const handleToggleChat = useCallback(() => setShowChat((v) => !v), []);
+  const handleToggleChat = useCallback(() => {
+    setShowChat((v) => {
+      if (!v) {
+        setShowSettings(false);
+        setShowHelp(false);
+        localStorage.setItem('ot:hasVisited', '1');
+      }
+      return !v;
+    });
+  }, []);
   const handleChatWidthChange = useCallback((w: number) => setChatWidth(w), []);
-  const handleToggleSettings = useCallback(
-    () => setShowSettings((v) => !v),
-    [],
-  );
+  const handleToggleSettings = useCallback(() => {
+    setShowSettings((v) => {
+      if (!v) {
+        setShowChat(false);
+        setShowHelp(false);
+        localStorage.setItem('ot:hasVisited', '1');
+      }
+      return !v;
+    });
+  }, []);
+  const handleToggleHelp = useCallback(() => {
+    setShowHelp((v) => {
+      if (!v) {
+        setShowChat(false);
+        setShowSettings(false);
+      } else {
+        localStorage.setItem('ot:hasVisited', '1');
+      }
+      return !v;
+    });
+  }, []);
 
   return (
     <div className="app" ref={containerRef}>
@@ -230,6 +259,8 @@ function App({
           onToggleChat={handleToggleChat}
           showSettings={showSettings}
           onToggleSettings={handleToggleSettings}
+          showHelp={showHelp}
+          onToggleHelp={handleToggleHelp}
           onGraphDataChange={setChatGraphData}
           chatHighlightNodes={chatHighlightNodes}
           animationSettings={animationSettings}
@@ -263,6 +294,18 @@ function App({
           />
         )}
       </div>
+
+      {showHelp && (
+        <HelpDrawer
+          onClose={() => setShowHelp(false)}
+          onOpenAddRepo={() => {
+            setShowHelp(false);
+            handleAddRepoOpen();
+          }}
+          onOpenChat={handleToggleChat}
+          onOpenSettings={handleToggleSettings}
+        />
+      )}
 
       {showSettings && (
         <SettingsDrawer

--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -155,6 +155,199 @@ function linkId(endpoint: string | number | GraphNode | undefined): string {
 
 // GraphLegend is now imported from @opentrace/components
 
+/** Dropdown help menu that appears on the toolbar. */
+function HelpMenuButton({
+  showHelp,
+  onToggleHelp,
+}: {
+  showHelp: boolean;
+  onToggleHelp: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (ref.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    const onEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    document.addEventListener('keydown', onEscape);
+    return () => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('keydown', onEscape);
+    };
+  }, [open]);
+
+  return (
+    <div className="help-menu-container" ref={ref}>
+      <button
+        className={`help-toggle-btn ${showHelp ? 'active' : ''}`}
+        onClick={() => setOpen((v) => !v)}
+        title="Help"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <span className="ot-menu-label">Help</span>
+      </button>
+      {open && (
+        <div className="help-dropdown">
+          <button
+            className="help-dropdown-item"
+            onClick={() => {
+              setOpen(false);
+              onToggleHelp();
+            }}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+            Getting Started
+          </button>
+          <a
+            className="help-dropdown-item"
+            href="https://opentrace.github.io/opentrace/"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />
+            </svg>
+            Documentation
+            <svg
+              className="help-external-icon"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </a>
+          <a
+            className="help-dropdown-item"
+            href="https://github.com/opentrace/opentrace"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+            </svg>
+            GitHub
+            <svg
+              className="help-external-icon"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </a>
+          <div className="help-dropdown-divider" />
+          <a
+            className="help-dropdown-item"
+            href="https://github.com/opentrace/opentrace/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setOpen(false)}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            Report an Issue
+            <svg
+              className="help-external-icon"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export interface GraphViewerHandle {
   graphData: { nodes: GraphNode[]; links: GraphLink[] };
   selectNode: (nodeId: string, hops?: number) => void;
@@ -184,6 +377,8 @@ export interface GraphViewerProps {
   onToggleChat: () => void;
   showSettings: boolean;
   onToggleSettings: () => void;
+  showHelp: boolean;
+  onToggleHelp: () => void;
   /** Called when graphData changes so parent can pass it reactively to siblings */
   onGraphDataChange?: (data: {
     nodes: GraphNode[];
@@ -220,6 +415,8 @@ const GraphViewer = memo(
         onToggleChat,
         showSettings,
         onToggleSettings,
+        showHelp,
+        onToggleHelp,
         onGraphDataChange,
         chatHighlightNodes,
         animationSettings,
@@ -1542,6 +1739,10 @@ const GraphViewer = memo(
                   </svg>
                   <span className="ot-menu-label">AI Chat</span>
                 </button>
+                <HelpMenuButton
+                  showHelp={showHelp}
+                  onToggleHelp={onToggleHelp}
+                />
                 <button
                   className={`settings-toggle-btn ${showSettings ? 'active' : ''}`}
                   onClick={onToggleSettings}

--- a/ui/src/appComponents/HelpDrawer.css
+++ b/ui/src/appComponents/HelpDrawer.css
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.help-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 380px;
+  padding-top: 68px;
+  background: var(--background);
+  border-left: 1px solid color-mix(in oklch, var(--border) 40%, transparent);
+  display: flex;
+  flex-direction: column;
+  z-index: 15;
+  box-shadow: -4px 0 24px -4px hsl(0 0% 0% / 0.3);
+  animation: slideInRight 0.25s ease-out;
+}
+
+.help-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.help-section + .help-section {
+  margin-top: 24px;
+  padding-top: 24px;
+  border-top: 1px solid color-mix(in oklch, var(--border) 25%, transparent);
+}
+
+.help-section h4 {
+  margin: 0 0 12px 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted-foreground);
+}
+
+/* Definition list for shortcut/help items */
+.help-shortcuts {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 16px;
+  align-items: baseline;
+}
+
+.help-shortcuts dt {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--foreground);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.help-shortcuts dd {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+  line-height: 1.4;
+}
+
+/* Action buttons (Add Repo, AI Chat, Settings) */
+.help-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.help-action-btn {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 12px;
+  background: none;
+  border: 1px solid color-mix(in oklch, var(--border) 40%, transparent);
+  border-radius: calc(var(--radius) + 2px);
+  color: var(--foreground);
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.15s;
+}
+
+.help-action-btn:hover {
+  background: color-mix(in oklch, var(--accent) 60%, transparent);
+  border-color: color-mix(in oklch, var(--primary) 30%, transparent);
+}
+
+.help-action-btn svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--primary);
+}
+
+.help-action-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.help-action-text strong {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.help-action-text span {
+  font-size: 0.78rem;
+  color: var(--muted-foreground);
+  line-height: 1.4;
+}
+
+@media (max-width: 1024px) {
+  .help-drawer {
+    width: 100%;
+    padding-top: 0;
+    z-index: 100;
+    border-left: none;
+    padding-top: max(0px, env(safe-area-inset-top));
+    padding-bottom: max(0px, env(safe-area-inset-bottom));
+  }
+}
+
+@media (max-width: 640px) {
+  .help-content {
+    padding: 16px;
+  }
+}

--- a/ui/src/appComponents/HelpDrawer.tsx
+++ b/ui/src/appComponents/HelpDrawer.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './HelpDrawer.css';
+
+interface HelpDrawerProps {
+  onClose: () => void;
+  onOpenAddRepo: () => void;
+  onOpenChat: () => void;
+  onOpenSettings: () => void;
+}
+
+export default function HelpDrawer({
+  onClose,
+  onOpenAddRepo,
+  onOpenChat,
+  onOpenSettings,
+}: HelpDrawerProps) {
+  return (
+    <div className="help-drawer">
+      <div className="panel-header">
+        <h3>Getting Started</h3>
+        <button className="close-btn" onClick={onClose}>
+          &times;
+        </button>
+      </div>
+
+      <div className="help-content">
+        <section className="help-section">
+          <h4>Graph Navigation</h4>
+          <dl className="help-shortcuts">
+            <dt>Pan</dt>
+            <dd>Click &amp; drag on the canvas</dd>
+            <dt>Zoom</dt>
+            <dd>Scroll wheel or pinch</dd>
+            <dt>Select node</dt>
+            <dd>Click a node</dd>
+            <dt>Deselect</dt>
+            <dd>Click empty canvas</dd>
+          </dl>
+        </section>
+
+        <section className="help-section">
+          <h4>Search &amp; Filtering</h4>
+          <dl className="help-shortcuts">
+            <dt>Search</dt>
+            <dd>Type a node name and press Enter</dd>
+            <dt>Hops</dt>
+            <dd>Control how many connections deep to traverse</dd>
+            <dt>Show All</dt>
+            <dd>Reset search to show the full graph</dd>
+            <dt>Filters</dt>
+            <dd>Toggle node types and communities in the side panels</dd>
+          </dl>
+        </section>
+
+        <section className="help-section">
+          <h4>Toolbar</h4>
+          <div className="help-actions">
+            <button className="help-action-btn" onClick={onOpenAddRepo}>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              <div className="help-action-text">
+                <strong>Add Repository</strong>
+                <span>Index a GitHub repo or local directory</span>
+              </div>
+            </button>
+            <button className="help-action-btn" onClick={onOpenChat}>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z" />
+              </svg>
+              <div className="help-action-text">
+                <strong>AI Chat</strong>
+                <span>Ask questions about the codebase using AI</span>
+              </div>
+            </button>
+            <button className="help-action-btn" onClick={onOpenSettings}>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+              </svg>
+              <div className="help-action-text">
+                <strong>Settings</strong>
+                <span>
+                  Configure visualization limits, AI summarization, and
+                  animation
+                </span>
+              </div>
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/appComponents/SettingsDrawer.css
+++ b/ui/src/appComponents/SettingsDrawer.css
@@ -20,11 +20,12 @@
   right: 0;
   bottom: 0;
   width: 420px;
+  padding-top: 68px;
   background: var(--background);
   border-left: 1px solid color-mix(in oklch, var(--border) 40%, transparent);
   display: flex;
   flex-direction: column;
-  z-index: 100;
+  z-index: 15;
   box-shadow: -4px 0 24px -4px hsl(0 0% 0% / 0.3);
   animation: slideInRight 0.25s ease-out;
 }
@@ -273,6 +274,8 @@
   .settings-drawer {
     width: 100%;
     max-width: 100vw;
+    padding-top: 0;
+    z-index: 100;
     border-left: none;
     padding-top: max(0px, env(safe-area-inset-top));
     padding-bottom: max(0px, env(safe-area-inset-bottom));


### PR DESCRIPTION
## Add help menu and Getting Started onboarding drawer
🆕 **New Feature** · ✨ **Improvement**

Adds a help menu to the toolbar and a "Getting Started" onboarding drawer for new users. It also updates the side panel layout to be mutually exclusive and sit below the toolbar.

### Complexity
🟡 Moderate · `6 files changed, 651 insertions(+), 7 deletions(-)`

The PR introduces a new onboarding flow and refactors the interaction logic for primary UI panels (Chat, Settings, Help) to be mutually exclusive. While it uses existing patterns, it modifies the layout hierarchy (z-index and offsets) and introduces state management for persistent user onboarding.

### Tests
🧪 Adds new UI components and state logic without new unit tests, though existing tests for similar drawers are present in the repo.

### Review focus
Pay particular attention to the following areas:

- **Onboarding Persistence** — Verify that `ot:hasVisited` is set correctly in all dismissal scenarios. Currently, closing the Help drawer via the "X" button or the "Add Repository" action does not seem to trigger the localStorage update.
- **Panel Alignment** — Check that the new 68px top padding on drawers aligns correctly with the toolbar. There is a slight inconsistency as `ChatPanel` currently uses 64px in `App.css`.
- **Dropdown Behavior** — Ensure the help dropdown's "click outside" and "Escape key" listeners in `HelpMenuButton` work as expected without interfering with other toolbar interactions.

---

<details>
<summary><strong>Additional details</strong></summary>

### Interaction Logic
- **Mutually Exclusive Panels**: The application state now ensures only one of AI Chat, Settings, or Getting Started panels is open at once. Toggling any panel explicitly closes the others to prevent layout overlap.
- **First-visit Onboarding**: The "Getting Started" drawer is triggered by the absence of an `ot:hasVisited` key in `localStorage`. This flow also suppresses the AI Chat panel on first load to focus the user on basic navigation.

### Layout and Responsive Design
- **Z-Index Layering**: Drawers have been moved to `z-index: 15` so they appear behind the toolbar (`z-index: 20`). 
- **Toolbar Offsets**: Panels now use `padding-top: 68px` to align correctly under the fixed toolbar.
- **Mobile Menu**: On smaller screens, the help options are flattened and integrated into the toolbar's navigation burger menu instead of using a hover-based dropdown.

</details>
<!-- opentrace:jid=ad919b9b-8fd2-4d76-acf8-31f5f0351aed|sha=98310c5cb50df0ec5bb8dcaf527b2d71d492efdf -->