### PR TITLE
fix(ui): filter panel sub-type toggle ignored after hide-all

### DIFF
--- a/ui/src/components/graph/__tests__/useGraphFilters.test.ts
+++ b/ui/src/components/graph/__tests__/useGraphFilters.test.ts
@@ -145,7 +145,7 @@ describe('shouldHideNode', () => {
     ).toBe(false);
   });
 
-  it('hides by type even when sub-type does not match', () => {
+  it('ignores hiddenNodeTypes when the type has sub-types', () => {
     const node: GraphNode = { id: 'n1', name: 'foo.go', type: 'File' };
     const availableSubTypes = new Map([
       [
@@ -160,7 +160,62 @@ describe('shouldHideNode', () => {
       hiddenNodeTypes: new Set(['File']),
       hiddenSubTypes: new Set(['File:ts']), // different sub-type
     });
-    // Type filter catches it even though sub-type doesn't match
+    // Sub-type filters take precedence — File:go is not hidden
+    expect(
+      shouldHideNode(
+        node,
+        filterState,
+        noAssignments,
+        availableSubTypes,
+        defaultGetSubType,
+      ),
+    ).toBe(false);
+  });
+
+  it('shows node after hide-all then unhiding its sub-type', () => {
+    const node: GraphNode = { id: 'n1', name: 'data.json', type: 'File' };
+    const availableSubTypes = new Map([
+      [
+        'File',
+        [
+          { subType: 'json', count: 2 },
+          { subType: 'ts', count: 5 },
+          { subType: 'go', count: 3 },
+        ],
+      ],
+    ]);
+    // Simulates: hide-all sets both hiddenNodeTypes and hiddenSubTypes,
+    // then user un-hides .json only
+    const filterState = makeFilterState({
+      hiddenNodeTypes: new Set(['File', 'Function', 'Class']),
+      hiddenSubTypes: new Set(['File:ts', 'File:go']), // .json removed
+    });
+    expect(
+      shouldHideNode(
+        node,
+        filterState,
+        noAssignments,
+        availableSubTypes,
+        defaultGetSubType,
+      ),
+    ).toBe(false);
+  });
+
+  it('hides node without sub-type when all sub-types are hidden', () => {
+    // A file with no extension
+    const node: GraphNode = { id: 'n1', name: 'Makefile', type: 'File' };
+    const availableSubTypes = new Map([
+      [
+        'File',
+        [
+          { subType: 'ts', count: 5 },
+          { subType: 'go', count: 3 },
+        ],
+      ],
+    ]);
+    const filterState = makeFilterState({
+      hiddenSubTypes: new Set(['File:ts', 'File:go']),
+    });
     expect(
       shouldHideNode(
         node,

--- a/ui/src/components/graph/useGraphFilters.ts
+++ b/ui/src/components/graph/useGraphFilters.ts
@@ -40,16 +40,21 @@ export function shouldHideNode(
     return true;
   }
 
-  // Sub-type filter: only applies when the node type has sub-types
+  // Sub-type filter: when the node type has sub-types, sub-type visibility
+  // takes precedence over the top-level type filter (matching filteredGraphData).
   const subTypes = availableSubTypes.get(node.type);
   if (subTypes && subTypes.length > 0) {
     const subType = getSubType(node);
-    if (subType && filterState.hiddenSubTypes.has(`${node.type}:${subType}`)) {
-      return true;
+    if (subType) {
+      return filterState.hiddenSubTypes.has(`${node.type}:${subType}`);
     }
+    // Node has no sub-type — hide only if ALL sub-types are hidden
+    return subTypes.every((s) =>
+      filterState.hiddenSubTypes.has(`${node.type}:${s.subType}`),
+    );
   }
 
-  // Type filter
+  // Type filter (only for types without sub-types)
   if (filterState.hiddenNodeTypes.has(node.type)) {
     return true;
   }


### PR DESCRIPTION
## Fix filter sub-type visibility after "Hide all" action
🐛 **Bug Fix** · 🧪 **Tests**

Fixes a bug where un-hiding a node sub-type (e.g., `.json`) had no effect if the parent type (e.g., `File`) was still hidden.

Sub-type visibility now takes precedence over the top-level type filter when sub-types are available. This matches the behavior of the data-filtering logic and ensures the UI state correctly reflects the rendered graph.

### Complexity
🟢 Low · `2 files changed, 66 insertions(+), 6 deletions(-)`

Localised logic fix in a single utility function. The change synchronises the graph's visibility hook with existing filtering logic used elsewhere in the UI.

### Tests
🧪 Includes unit tests covering the precedence fix, "Hide all" recovery scenarios, and edge cases for nodes without sub-types.

### Review focus
Pay particular attention to the following areas:

- **Filter Precedence** — Verify that the logic correctly falls back to the top-level type filter only when no sub-types are defined for that node type.
- **Sub-type-less nodes** — Check the "hide only if ALL sub-types are hidden" logic for nodes that belong to a typed group but lack a specific sub-type (e.g., a Makefile in a file list).
<!-- opentrace:jid=cdb5e8bd-dc0c-4e44-9b54-09e5fb9fbe5f|sha=63ec6909e28011033b4341b574895ace4b9860c6 -->