### PR TITLE
fix(ui): display edge type labels in uppercase in filter panel

### DIFF
--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -1455,7 +1455,7 @@ const GraphViewer = memo(
       const linkFilterItems: FilterItem[] = availableLinkTypes.map(
         ({ type, count }) => ({
           key: type,
-          label: type.toLowerCase(),
+          label: type.toUpperCase(),
           count,
           color: getLinkColor(type),
           hidden: hiddenLinkTypes.has(type),


### PR DESCRIPTION
## Fix edge type label casing in filter panel
✨ **Improvement** · 🐛 **Bug Fix**

Updates edge type labels in the graph filter panel to display in uppercase.

This ensures consistency with the project's naming convention for relationship types (e.g., CALLS, IMPORTS).

### Complexity
🟢 Trivial · `1 file changed, 1 insertion(+), 1 deletion(-)`

Single-line UI change to a display label with no functional impact.
<!-- opentrace:jid=j-7e2ca6e9-d538-457f-90ef-d870be0076d5|sha=69a9e95e4e18312b37e4909c5becdd90ca43d8ae -->