### PR TITLE
fix(ui): reload page when pixi chunk fails to load after deploy

### DIFF
--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -313,14 +313,27 @@ export class PixiRenderer {
     this.height = height;
 
     const app = new Application();
-    await app.init({
-      width,
-      height,
-      backgroundColor: 0x0d1117,
-      antialias: true,
-      resolution: window.devicePixelRatio || 1,
-      autoDensity: true,
-    });
+    try {
+      await app.init({
+        width,
+        height,
+        backgroundColor: 0x0d1117,
+        antialias: true,
+        resolution: window.devicePixelRatio || 1,
+        autoDensity: true,
+      });
+    } catch (err) {
+      if (
+        err instanceof TypeError &&
+        /dynamically imported module|importing a module script/i.test(
+          err.message,
+        )
+      ) {
+        window.location.reload();
+        return;
+      }
+      throw err;
+    }
 
     // Guard: if destroy() was called while init was pending, don't proceed
     if (this.destroyed) {


### PR DESCRIPTION
## Reload page on Pixi chunk loading failure
🐛 **Bug Fix** · ✨ **Improvement**

Wraps PixiJS initialization in a try-catch block to handle dynamic import failures.

When a "stale chunk" error is detected (common after a new deployment), the app triggers a full page reload to fetch the latest assets.

### Complexity
🟢 Low · `1 file changed, 21 insertions(+), 8 deletions(-)`

Small, localized change to a single initialization function with no impact on existing business logic.

### Review focus
Pay particular attention to the following areas:

- **Error regex** — confirm the regex accurately identifies dynamic import failures across Chrome, Safari, and Firefox.

---

<details>
<summary><strong>Additional details</strong></summary>

PixiJS v8 performs dynamic imports for its internal sub-packages (like `pixi.js/app`) during the `Application.init()` call. In environments with frequent deployments, a user who has the app open might encounter a `TypeError` if a new version of the UI has replaced the old JS chunks on the server.

The regex used (`/dynamically imported module|importing a module script/i`) covers the standard error strings emitted by V8, WebKit, and SpiderMonkey when a dynamic `import()` fails due to network errors or missing files.

By triggering a full page reload, we ensure the browser fetches the latest `index.html` and resource manifest, allowing the application to recover gracefully instead of remaining in a broken state.

</details>
<!-- opentrace:jid=f5de5fe8-b645-486d-b3eb-4a2326b25e13|sha=151d862a10fc3edc67309ef607ea9fa952c50892 -->