### PR TITLE
fix(ui): use theme variables for graph control button active state

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -246,8 +246,9 @@
 }
 
 .graph-control-btn--active {
-  background: rgba(99, 102, 241, 0.3);
-  border-color: rgba(99, 102, 241, 0.6);
+  background: color-mix(in oklch, var(--primary) 20%, transparent);
+  border-color: color-mix(in oklch, var(--primary) 50%, transparent);
+  color: var(--primary);
 }
 
 .panel-header {


### PR DESCRIPTION
## Use theme variables for graph control active state
✨ **Improvement** · 🐛 **Bug Fix**

Replaces hardcoded indigo colors in graph control buttons with the `--primary` theme variable.

This ensures toggled button states (2D/3D, zoom-on-select, physics) match the user's selected theme.

### Complexity
🟢 Trivial · `1 file changed, 3 insertions(+), 2 deletions(-)`

Single-file CSS change replacing hardcoded colors with existing theme variables.
<!-- opentrace:jid=j-553e7cb5-75e1-4516-8588-4ef313fc93be|sha=b4559fa1d1a98570aa096f6103bd7da10a913d47 -->