### PR TITLE
feat(plugin): add /index command to run OpenTrace indexer

### DIFF
--- a/claude-code-plugin/commands/index.md
+++ b/claude-code-plugin/commands/index.md
@@ -15,12 +15,12 @@ $ARGUMENTS
 
 1. **Determine the target path**: If the user provided a path in the arguments, use that. Otherwise default to the repository root (find it with `git rev-parse --show-toplevel`).
 
-2. **Run the indexer**:
-   ```
-   uvx opentraceai index <path>
+2. **Run the indexer**: Change directory to the target path and run the indexer. This ensures the `.opentrace/` directory is created in the right place.
+   ```bash
+   cd <path> && uvx opentraceai index .
    ```
    Use `--verbose` if the user asked for verbose/debug output. Pass through any other flags the user specified (e.g. `--db`, `--repo-id`, `--batch-size`).
 
-3. **Report results**: After the command completes, summarize what was indexed. If the command fails, show the error and suggest fixes (e.g. missing dependencies, wrong path).
+3. **Report results**: After the command completes, summarize what was indexed. If the command fails, show the error and suggest fixes (e.g. missing `uv` or dependencies, wrong path).
 
-4. **Verify**: Run `uvx opentraceai stats` to show the updated graph contents so the user can confirm the index looks right.
+4. **Verify**: Run `uvx opentraceai stats` (passing the same `--db` flag if the user provided one) to show the updated graph contents so the user can confirm the index looks right.


### PR DESCRIPTION
## Add /index slash command for project indexing
🆕 **New Feature**

Adds the `/index` slash command to the Claude Code plugin.

This allows users to trigger the OpenTrace indexer directly from the session using the `uvx opentraceai index` CLI.

### Complexity
🟢 Low · `1 file changed, 26 insertions(+)`

Adds a single Markdown instruction file for a new slash command. It leverages existing CLI functionality and follows established patterns in the plugin's commands directory.

### Tests
🧪 Tests are not applicable for this Markdown-based command definition.

### Review focus
Pay particular attention to the following areas:

- **Tool permissions** — Verify that 'Bash' and 'Read' are sufficient for running the indexer and verification steps.
- **Instruction clarity** — Check that the prompt correctly handles optional arguments like `--db` or `--repo-id` passed by the user.
<!-- opentrace:jid=j-7a4c00b2-04c3-4c66-b6d5-99bd59969cd5|sha=854948a62aa2b0f2f9d61a7a2a0107bcff5b7884 -->