### PR TITLE
feat: show dev server port and PR number in statusline

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -36,17 +36,18 @@ pr_number=""
 if [ -n "$branch" ] && [ -n "$cwd" ] && command -v gh &>/dev/null; then
   cache_dir="/tmp/statusline-pr-cache"
   mkdir -p "$cache_dir" 2>/dev/null
-  cache_key=$(echo "$cwd:$branch" | md5sum | cut -d' ' -f1)
+  cache_key=$(echo "$cwd:$branch" | (md5sum 2>/dev/null || md5 2>/dev/null || echo "default") | cut -d' ' -f1)
   cache_file="$cache_dir/$cache_key"
   now=$(date +%s)
   if [ -f "$cache_file" ]; then
-    cache_age=$(( now - $(stat -c %Y "$cache_file" 2>/dev/null || echo 0) ))
+    cache_age=$(( now - $(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0) ))
     if [ "$cache_age" -lt 300 ]; then
       pr_number=$(cat "$cache_file")
+      pr_cached=1
     fi
   fi
-  if [ -z "$pr_number" ] || [ ! -f "$cache_file" ] || [ "$cache_age" -ge 300 ]; then
-    pr_number=$(GIT_DIR="$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse --git-dir 2>/dev/null)" gh pr view "$branch" --json number -q '.number' 2>/dev/null || echo "")
+  if [ -z "$pr_cached" ]; then
+    pr_number=$(cd "$cwd" && GIT_OPTIONAL_LOCKS=0 gh pr view "$branch" --json number -q '.number' 2>/dev/null || echo "")
     echo "$pr_number" > "$cache_file" 2>/dev/null
   fi
 fi


### PR DESCRIPTION
## Display PR number and Vite port in status line
🆕 **New Feature** · ✨ **Improvement**

Adds the current branch's PR number and the active Vite dev server port to the Claude status line.

Uses a 5-minute file-based cache for GitHub CLI results to avoid rate limiting. Port detection matches the process working directory to the project root while excluding worktrees.

### Complexity
🟢 Low · `1 file changed, 43 insertions(+)`

Single-file update to a developer utility script with narrow scope and no impact on core application logic.

### Review focus
Pay particular attention to the following areas:

- **GitHub API caching** — check if the script avoids repeated `gh` calls when no PR exists; an empty string in the cache file might trigger a refresh on every execution.
- **Platform compatibility** — ensure the Linux-specific port detection (using `ss` and `/proc`) fails gracefully on macOS or Windows systems.
<!-- opentrace:jid=j-4ec04a38-79f3-4f17-ac03-2ffc36ae4761|sha=0765ca5e8f5dab9cc35bbee7db20fc3302055852 -->