### PR TITLE
docs: add MCP quickstart and update db path to .opentrace/index.db

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,28 @@ A knowledge graph that maps your codebase structure, service architecture, and s
 
 **[Docs](https://opentrace.github.io/opentrace/reference/chat-providers/)** - for help and support
 
-## Quick Start
+## Quick Start MCP in Local Project
+
+Chat with AI about your local project, using the knowledge graph, integrated with your local tooling.
+
+~~~bash
+cd $PROJECT_DIR
+uvx opentraceai index .
+
+# Claude users: install plugin
+claude plugin marketplace add https://github.com/opentrace/opentrace
+claude plugin install opentrace-oss@opentrace-oss
+
+# Gemini user: configure MCP
+# - change scope from 'project' to 'user' to add it for all projects
+gemini mcp add --scope project opentraceai uvx opentraceai mcp
+~~~
+
+The next time claude or gemini is started, it will have opentrace configured.
+
+See [agent/README.md](agent/README.md) for more information on using the `opentraceai` agent, and [claude-code-plugin/README.md](claude-code-plugin/README.md) for more on configuring it as an MCP plugin.
+
+## Quick Start the Web UI
 
 ```bash
 git clone https://github.com/opentrace/opentrace.git
@@ -46,7 +67,7 @@ OpenTrace indexes source code directly in your browser — no server required. P
 │                                  │  WASM parsers   │ │
 │                                  └─────────────────┘ │
 │                                  ┌─────────────────┐ │
-│                                  │  LadybugDB WASM    │ │
+│                                  │  LadybugDB WASM │ │
 │                                  │  graph store    │ │
 │                                  └─────────────────┘ │
 └──────────────────────────────────────────────────────┘

--- a/agent/README.md
+++ b/agent/README.md
@@ -29,12 +29,12 @@ Requires Python 3.12+.
 opentraceai index /path/to/repo
 ```
 
-This parses every supported file, extracts symbols and relationships, and writes the graph to `./otindex.db`.
+This parses every supported file, extracts symbols and relationships, and writes the graph to `.opentrace/index.db`.
 
 ```
-$ opentraceai index ~/projects/myapp
-Opening LadybugDB at ./otindex.db ...
-Indexing /home/user/projects/myapp ...
+$ opentraceai index /path/to/repo
+Opening LadybugDB at /path/to/repo/.opentrace/index.db ...
+Indexing /path/to/repo ...
   1284 nodes, 3421 relationships, 187 files, 95 classes, 412 functions
 Done in 4.2s.
 ```
@@ -44,7 +44,7 @@ Done in 4.2s.
 Start a stdio MCP server against the indexed database:
 
 ```bash
-opentraceai mcp --db ./otindex.db
+opentraceai mcp --db ./opentrace/index.db
 ```
 
 This exposes graph query tools over stdin/stdout for any MCP-compatible client.
@@ -59,7 +59,7 @@ Add OpenTrace to Claude Code as a plugin, or configure it manually in your proje
     "opentrace": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["opentraceai", "mcp", "--db", "./otindex.db"]
+      "args": ["opentraceai", "mcp", "--db", "./opentrace/index.db"]
     }
   }
 }
@@ -92,7 +92,7 @@ opentraceai index [PATH] [OPTIONS]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `PATH` | `.` | Directory to index |
-| `--db` | `./otindex.db` | Database path |
+| `--db` | `./opentrace/index.db` | Database path |
 | `--repo-id` | directory name | Repository identifier |
 | `--batch-size` | 200 | Items per write batch |
 | `-v, --verbose` | off | Debug logging |
@@ -103,7 +103,7 @@ opentraceai mcp [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--db` | `./otindex.db` | Database path |
+| `--db` | `./opentrace/index.db` | Database path |
 | `-v, --verbose` | off | Debug logging |
 
 ## Part of OpenTrace

--- a/agent/README.md
+++ b/agent/README.md
@@ -44,7 +44,7 @@ Done in 4.2s.
 Start a stdio MCP server against the indexed database:
 
 ```bash
-opentraceai mcp --db ./opentrace/index.db
+opentraceai mcp --db .opentrace/index.db
 ```
 
 This exposes graph query tools over stdin/stdout for any MCP-compatible client.
@@ -59,7 +59,7 @@ Add OpenTrace to Claude Code as a plugin, or configure it manually in your proje
     "opentrace": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["opentraceai", "mcp", "--db", "./opentrace/index.db"]
+      "args": ["opentraceai", "mcp", "--db", ".opentrace/index.db"]
     }
   }
 }
@@ -92,7 +92,7 @@ opentraceai index [PATH] [OPTIONS]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `PATH` | `.` | Directory to index |
-| `--db` | `./opentrace/index.db` | Database path |
+| `--db` | `.opentrace/index.db` | Database path |
 | `--repo-id` | directory name | Repository identifier |
 | `--batch-size` | 200 | Items per write batch |
 | `-v, --verbose` | off | Debug logging |
@@ -103,7 +103,7 @@ opentraceai mcp [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--db` | `./opentrace/index.db` | Database path |
+| `--db` | `.opentrace/index.db` | Database path |
 | `-v, --verbose` | off | Debug logging |
 
 ## Part of OpenTrace

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -28,7 +28,7 @@ claude plugin install opentrace-oss@opentrace-oss
 #### Gemini
 
 ```bash
-gemini mcp add --scope project opentrace-oss uvx opentraceai mcp
+gemini mcp add --scope project opentraceai uvx opentraceai mcp
 ```
 
 #### GitHub Copilot (VS Code)

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -4,18 +4,60 @@ Gives Claude Code access to an indexed codebase knowledge graph via MCP.
 
 ## Setup
 
-### 1. Index a codebase
+### 1. Index your codebase
+
+From your project directory:
 
 ```bash
-uvx opentraceai index /path/to/repo
+uvx opentraceai index
 ```
 
-This creates an `otindex.db` database in the current directory.
+This creates a `.opentrace/index.db` knowledge graph in your project root. You can also pass a path explicitly: `uvx opentraceai index /path/to/repo`.
 
 ### 2. Install the plugin
 
-The `.mcp.json` is configured to run `uvx opentraceai mcp --db ./otindex.db`.
-Update the `--db` path to point at your indexed database.
+#### Claude Code
+
+Add the OpenTrace marketplace and install the plugin:
+
+```bash
+claude plugin marketplace add https://github.com/opentrace/opentrace
+claude plugin install opentrace-oss@opentrace-oss
+```
+
+#### Gemini
+
+```bash
+gemini mcp add --scope project opentrace-oss uvx opentraceai mcp
+```
+
+#### GitHub Copilot (VS Code)
+
+Add to `.vscode/mcp.json` in your project root (create it if it doesn't exist):
+
+```json
+{
+  "servers": {
+    "opentrace-oss": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["opentraceai", "mcp"]
+    }
+  }
+}
+```
+
+The MCP server auto-discovers `.opentrace/index.db` by walking up from the current directory.
+
+#### Other MCP clients (local LLMs, custom tooling)
+
+Configure your MCP client to run the stdio server directly:
+
+```bash
+uvx opentraceai mcp --db /path/to/repo/.opentrace/index.db
+```
+
+If your client launches the server from the project directory, the `--db` flag can be omitted and the database will be auto-discovered.
 
 ## Dev mode
 
@@ -32,7 +74,7 @@ To run against a local checkout of the agent (e.g. when developing new MCP tools
         "run",
         "--directory", "/path/to/opentrace/agent",
         "opentrace", "mcp",
-        "--db", "/path/to/otindex.db"
+        "--db", "/path/to/repo/.opentrace/index.db"
       ],
       "description": "OpenTrace knowledge graph tools (dev)."
     }


### PR DESCRIPTION
## Update default database path and add MCP quickstart docs
📝 **Docs** · ✨ **Improvement**

Updates all documentation to reflect the new default database path at `.opentrace/index.db`. Adds a comprehensive MCP quickstart section covering Claude Code, Gemini, and GitHub Copilot.

### Complexity
🟢 Low · `3 files changed, 79 insertions(+), 16 deletions(-)`

Documentation-only change updating paths and adding setup instructions with no impact on functional code.

### Review focus
Pay particular attention to the following areas:

- **Database path typos** — ensure the new path consistently uses the dot-prefix (`.opentrace/`) across all examples, as some instances in `agent/README.md` appear to be missing it.
- **Server naming** — verify consistency between `opentraceai` and `opentrace-oss` labels in the Gemini/Copilot configuration examples.
- **MCP config keys** — check that the GitHub Copilot JSON example uses the correct key (`mcpServers` vs `servers`) required by the client.
<!-- opentrace:jid=de1e79ac-e0c5-49e1-9eb1-f496b533d90f|sha=01a0c48dbfc4cfbc3ee7eed7593eac3965350d78 -->