### PR TITLE
fix(ui): mobile side panel overlay and zoom-to-node scaling

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1464,24 +1464,29 @@
     display: none;
   }
 
-  /* Show as full-width overlay when opened from burger menu */
+  /* Show as bottom 70% overlay (on top of chat) when opened from burger menu */
   .side-panel.side-panel--mobile-open {
     display: flex;
     position: fixed;
-    top: 0;
+    top: 30%;
     left: 0;
     right: 0;
     bottom: 0;
     width: 100% !important;
     z-index: 50;
-    padding-top: max(0px, env(safe-area-inset-top));
+    padding-top: 0;
     background: var(--background);
     border-right: none;
+    border-top: 1px solid var(--border);
     backdrop-filter: none;
   }
 
   .side-panel--mobile-open .side-panel-tabs {
-    padding-top: 8px;
+    padding-top: 0;
+  }
+
+  .side-panel--mobile-open .side-panel-drag-handle {
+    display: none;
   }
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -226,10 +226,10 @@ function App({
     : dimensions.height;
   const handleToggleGraphFullscreen = useCallback(() => {
     setGraphFullscreen((v) => !v);
-    // Wait a frame for the canvas to resize, then fit the graph
-    requestAnimationFrame(() => {
+    // Wait for React to re-render with new dimensions and the canvas to resize
+    setTimeout(() => {
       graphViewerRef.current?.resetCamera();
-    });
+    }, 150);
   }, []);
   const handleToggleSettings = useCallback(() => {
     setShowSettings((v) => {

--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -931,10 +931,15 @@ const GraphViewer = memo(
             canvasRef.current?.triggerPing?.(nodeIds);
           },
           resetCamera: () => {
-            canvasRef.current?.resetCamera();
+            const sel = selectedNode?.id;
+            if (sel) {
+              canvasRef.current?.zoomToNodes([sel], 300);
+            } else {
+              canvasRef.current?.resetCamera();
+            }
           },
         }),
-        [graphData, loadGraph, onNodeClick],
+        [graphData, loadGraph, onNodeClick, selectedNode],
       );
 
       const onLinkClick = useCallback((edge: SelectedEdge) => {

--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -1607,7 +1607,9 @@ export class PixiRenderer {
     }
     if (positions.length === 0) return;
     const bounds = computeBounds(positions);
-    const target = fitBounds(bounds, this.width, this.height, 120);
+    // Use proportional padding (15% of smallest dimension, min 40, max 120)
+    const padding = Math.max(40, Math.min(120, Math.min(this.width, this.height) * 0.15));
+    const target = fitBounds(bounds, this.width, this.height, padding);
 
     this.cancelAnimation?.();
     this.cancelAnimation = animateViewport(


### PR DESCRIPTION
## Mobile layout and graph camera improvements
✨ **Improvement** · 🐛 **Bug Fix**

This PR improves the mobile experience by converting the side panel into a 70% bottom overlay and refining graph camera behaviors. It also introduces proportional padding for node-level zooming to ensure nodes remain legible on small viewports.

### Complexity
🟢 Low · `4 files changed, 22 insertions(+), 10 deletions(-)`

Narrow scope focused on UI/styling adjustments and minor camera logic. The changes are localized to the frontend and do not affect core data flow or external contracts.

### Review focus
Pay particular attention to the following areas:

- **Layout Consistency** — verify that the `30%` top offset in `App.css` correctly aligns with the `0.3` height ratio defined in `App.tsx`.
- **Camera Reset UX** — confirm the new behavior where the reset button focuses on the selected node (if any) instead of the full graph.
- **Transition Timing** — ensure the `150ms` delay in `App.tsx` provides enough time for the canvas to resize before the camera re-centers.
<!-- opentrace:jid=j-4f35a961-e2b3-4532-95c2-e8ab75ee1581|sha=1fc76570b065fe9aa32891c7c2a47729b26478cd -->