### PR TITLE
feat(auth): add user-scoped tokens and per-org token resolution

### DIFF
--- a/agent/src/opentrace_agent/cli/auth.py
+++ b/agent/src/opentrace_agent/cli/auth.py
@@ -45,7 +45,16 @@ from opentrace_agent.cli.credentials import (
 )
 
 # Re-export for convenience — callers can ``from opentrace_agent.cli.auth import load_tokens``.
-__all__ = ["clear_tokens", "discover", "load_tokens", "login", "refresh", "save_tokens"]
+__all__ = [
+    "clear_tokens",
+    "discover",
+    "get_api_token",
+    "load_tokens",
+    "login",
+    "refresh",
+    "resolve_org_token",
+    "save_tokens",
+]
 
 ISSUER = "https://api.opentrace.ai"
 DISCOVERY_PATH = "/.well-known/oauth-authorization-server"
@@ -408,6 +417,7 @@ def login() -> dict[str, Any]:
             "state": state,
             "code_challenge": challenge,
             "code_challenge_method": "S256",
+            "prompt": "none",  # Skip org selector — CLI controls org via config
         }
     )
     authorize_url = f"{disco['authorization_endpoint']}?{params}"
@@ -444,3 +454,109 @@ def login() -> dict[str, Any]:
     finally:
         server.shutdown()
         server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Org-token resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_org_token(org_id: str) -> dict[str, Any]:
+    """Get an org-scoped ``otoat_`` token, exchanging the ``otuat_`` if needed.
+
+    1. Check cache in ``~/.opentrace/org_tokens/{org_id}.json``
+    2. If missing/expired, exchange ``otuat_`` + org via API
+    3. Cache and return
+
+    Raises :class:`RuntimeError` if not logged in or exchange fails.
+    """
+    from opentrace_agent.cli.credentials import load_org_token, save_org_token
+
+    # Check cache
+    cached = load_org_token(org_id)
+    if cached is not None:
+        return cached
+
+    # Load user token
+    user_tokens = load_tokens()
+    if not user_tokens or not user_tokens.get("access_token"):
+        raise RuntimeError("Not logged in. Run 'opentraceai login' first.")
+
+    user_token = user_tokens["access_token"]
+
+    # Handle legacy: if user has an old otoat_ token from before this change
+    if user_token.startswith("otoat_"):
+        raise RuntimeError(
+            "Your login token is org-scoped (legacy format). "
+            "Run 'opentraceai logout' then 'opentraceai login' to get a user token."
+        )
+
+    # Exchange otuat_ for org-scoped otoat_
+    disco = discover()
+    issuer = disco.get("issuer", ISSUER)
+    exchange_url = f"{issuer}/oauth/exchange-org-token"
+
+    body = json.dumps({"org": org_id}).encode()
+    req = urllib.request.Request(
+        exchange_url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {user_token}",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        if exc.code == 404:
+            raise RuntimeError(
+                f"Organization '{org_id}' not found. "
+                f"Check your .opentrace/config.yaml org value."
+            ) from exc
+        if exc.code == 401:
+            raise RuntimeError(
+                "User token expired or invalid. "
+                "Run 'opentraceai login' to re-authenticate."
+            ) from exc
+        raise RuntimeError(
+            f"Org token exchange failed ({exc.code}): {error_body}"
+        ) from exc
+
+    # Add local expiry timestamp for cache checking
+    expires_in = result.get("expires_in", 259200)  # default 3 days
+    result["expires_at"] = int(time.time()) + expires_in
+
+    save_org_token(org_id, result)
+    return result
+
+
+def get_api_token() -> str:
+    """Get the appropriate access token for the current project context.
+
+    If a project config with org exists, returns an org-scoped ``otoat_``.
+    Otherwise returns the user-level ``otuat_``.
+
+    Raises :class:`RuntimeError` if not logged in.
+    """
+    from opentrace_agent.cli.config import find_config, load_config
+    from opentrace_agent.cli.main import _find_opentrace_dir
+
+    ot_dir = _find_opentrace_dir()
+    config_path = find_config(ot_dir)
+
+    if config_path is not None:
+        config = load_config(config_path)
+        org = config.get("org")
+        if org:
+            org_tokens = resolve_org_token(org)
+            return org_tokens["access_token"]
+
+    # No org config — return user token directly
+    tokens = load_tokens()
+    if not tokens or not tokens.get("access_token"):
+        raise RuntimeError("Not logged in. Run 'opentraceai login' first.")
+    return tokens["access_token"]

--- a/agent/src/opentrace_agent/cli/auth.py
+++ b/agent/src/opentrace_agent/cli/auth.py
@@ -514,17 +514,11 @@ def resolve_org_token(org_id: str) -> dict[str, Any]:
         error_body = exc.read().decode("utf-8", errors="replace")
         if exc.code == 404:
             raise RuntimeError(
-                f"Organization '{org_id}' not found. "
-                f"Check your .opentrace/config.yaml org value."
+                f"Organization '{org_id}' not found. Check your .opentrace/config.yaml org value."
             ) from exc
         if exc.code == 401:
-            raise RuntimeError(
-                "User token expired or invalid. "
-                "Run 'opentraceai login' to re-authenticate."
-            ) from exc
-        raise RuntimeError(
-            f"Org token exchange failed ({exc.code}): {error_body}"
-        ) from exc
+            raise RuntimeError("User token expired or invalid. Run 'opentraceai login' to re-authenticate.") from exc
+        raise RuntimeError(f"Org token exchange failed ({exc.code}): {error_body}") from exc
 
     # Add local expiry timestamp for cache checking
     expires_in = result.get("expires_in", 259200)  # default 3 days

--- a/agent/src/opentrace_agent/cli/credentials.py
+++ b/agent/src/opentrace_agent/cli/credentials.py
@@ -35,6 +35,7 @@ import os
 import platform
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -242,6 +243,50 @@ def clear_tokens() -> bool:
         path.unlink()
         return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# Per-org tokens  (org_tokens/{org_id}.json) — encrypted
+# ---------------------------------------------------------------------------
+
+
+def _org_tokens_dir() -> Path:
+    """Return ``~/.opentrace/org_tokens/``, creating with secure permissions if needed."""
+    d = _base_dir() / "org_tokens"
+    if not d.exists():
+        d.mkdir(parents=True, exist_ok=True)
+        _secure_path(d)
+    return d
+
+
+def load_org_token(org_id: str) -> dict[str, Any] | None:
+    """Load a cached org-scoped access token, or ``None`` if missing/expired."""
+    path = _org_tokens_dir() / f"{org_id}.json"
+    data = _read_encrypted(path)
+    if data and "access_token" in data:
+        expires_at = data.get("expires_at")
+        if expires_at and time.time() > expires_at:
+            path.unlink(missing_ok=True)
+            return None
+        return data
+    return None
+
+
+def save_org_token(org_id: str, tokens: dict[str, Any]) -> None:
+    """Persist an org-scoped access token (encrypted)."""
+    _write_encrypted(_org_tokens_dir() / f"{org_id}.json", tokens)
+
+
+def clear_org_tokens() -> int:
+    """Remove all cached org tokens. Returns count removed."""
+    d = _org_tokens_dir()
+    if not d.exists():
+        return 0
+    count = 0
+    for f in d.glob("*.json"):
+        f.unlink()
+        count += 1
+    return count
 
 
 # ---------------------------------------------------------------------------

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -714,11 +714,7 @@ def whoami() -> None:
     issuer = tokens.get("issuer", "unknown")
     scope = tokens.get("scope", "none")
     access_token = tokens.get("access_token", "")
-    token_type = (
-        "user (otuat)"
-        if access_token.startswith("otuat_")
-        else "org-scoped (legacy)"
-    )
+    token_type = "user (otuat)" if access_token.startswith("otuat_") else "org-scoped (legacy)"
     created = tokens.get("created_at")
 
     click.echo(f"Issuer:  {issuer}")

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -658,7 +658,8 @@ def config_path() -> None:
 
 
 @app.command()
-def login() -> None:
+@click.option("--resolve", is_flag=True, help="Also resolve an org-scoped token from project config.")
+def login(resolve: bool) -> None:
     """Log in to api.opentrace.ai via your browser."""
     from opentrace_agent.cli.auth import load_tokens
     from opentrace_agent.cli.auth import login as do_login
@@ -678,6 +679,26 @@ def login() -> None:
 
     scope = payload.get("scope", "")
     click.echo(f"Logged in to {payload.get('issuer', 'OpenTrace')} (scope: {scope}).")
+
+    if resolve:
+        from opentrace_agent.cli.auth import resolve_org_token
+        from opentrace_agent.cli.config import find_config, load_config
+
+        ot_dir = _find_opentrace_dir()
+        config_path = find_config(ot_dir)
+        if config_path is None:
+            click.echo("No .opentrace/config.yaml found — skipping org token resolution.")
+            return
+        config = load_config(config_path)
+        org = config.get("org")
+        if not org:
+            click.echo("No org set in config — skipping org token resolution.")
+            return
+        try:
+            resolve_org_token(org)
+            click.echo(f"Org token resolved for '{org}'.")
+        except RuntimeError as exc:
+            raise click.ClickException(f"Org token resolution failed: {exc}")
 
 
 @app.command()
@@ -737,7 +758,13 @@ def whoami() -> None:
             if org_token:
                 click.echo(f"Org:     {org} (token cached)")
             else:
-                click.echo(f"Org:     {org} (not yet authenticated)")
+                try:
+                    from opentrace_agent.cli.auth import resolve_org_token
+
+                    resolve_org_token(org)
+                    click.echo(f"Org:     {org} (token resolved)")
+                except RuntimeError as exc:
+                    click.echo(f"Org:     {org} (exchange failed: {exc})")
 
 
 @app.command()

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -684,9 +684,17 @@ def login() -> None:
 def logout() -> None:
     """Log out and remove saved credentials."""
     from opentrace_agent.cli.auth import clear_tokens
+    from opentrace_agent.cli.credentials import clear_org_tokens
 
-    if clear_tokens():
-        click.echo("Logged out.")
+    cleared_user = clear_tokens()
+    org_count = clear_org_tokens()
+    if cleared_user or org_count:
+        parts = []
+        if cleared_user:
+            parts.append("user credentials")
+        if org_count:
+            parts.append(f"{org_count} org token(s)")
+        click.echo(f"Logged out. Removed {', '.join(parts)}.")
     else:
         click.echo("Not logged in.")
 
@@ -695,6 +703,8 @@ def logout() -> None:
 def whoami() -> None:
     """Show the current authentication status."""
     from opentrace_agent.cli.auth import load_tokens
+    from opentrace_agent.cli.config import find_config, load_config
+    from opentrace_agent.cli.credentials import load_org_token
 
     tokens = load_tokens()
     if not tokens:
@@ -703,7 +713,12 @@ def whoami() -> None:
 
     issuer = tokens.get("issuer", "unknown")
     scope = tokens.get("scope", "none")
-    token_type = tokens.get("token_type", "bearer")
+    access_token = tokens.get("access_token", "")
+    token_type = (
+        "user (otuat)"
+        if access_token.startswith("otuat_")
+        else "org-scoped (legacy)"
+    )
     created = tokens.get("created_at")
 
     click.echo(f"Issuer:  {issuer}")
@@ -714,6 +729,19 @@ def whoami() -> None:
 
         dt = datetime.fromtimestamp(created, tz=timezone.utc)
         click.echo(f"Issued:  {dt:%Y-%m-%d %H:%M:%S UTC}")
+
+    # Show project org context
+    ot_dir = _find_opentrace_dir()
+    config_path = find_config(ot_dir)
+    if config_path is not None:
+        config = load_config(config_path)
+        org = config.get("org")
+        if org:
+            org_token = load_org_token(org)
+            if org_token:
+                click.echo(f"Org:     {org} (token cached)")
+            else:
+                click.echo(f"Org:     {org} (not yet authenticated)")
 
 
 @app.command()

--- a/agent/tests/opentrace_agent/cli/test_auth.py
+++ b/agent/tests/opentrace_agent/cli/test_auth.py
@@ -1,0 +1,316 @@
+# Copyright 2026 OpenTrace Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for auth functions and auth-related CLI commands."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from opentrace_agent.cli import auth, credentials
+from opentrace_agent.cli.config import save_config
+from opentrace_agent.cli.credentials import (
+    load_org_token,
+    save_org_token,
+    save_tokens,
+)
+from opentrace_agent.cli.main import app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+runner = CliRunner()
+
+FAKE_DISCOVERY = {
+    "issuer": "https://api.opentrace.ai",
+    "authorization_endpoint": "https://api.opentrace.ai/oauth/authorize",
+    "token_endpoint": "https://api.opentrace.ai/oauth/token",
+    "registration_endpoint": "https://api.opentrace.ai/oauth/register",
+}
+
+
+def _patch_base_dir(monkeypatch: object, tmp_path: Path, subdir: str = ".opentrace") -> Path:
+    """Redirect credentials storage to a test-local directory."""
+    base = tmp_path / subdir
+    base.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(credentials, "_base_dir", lambda: base)
+    return base
+
+
+def _make_repo(base: Path) -> Path:
+    """Create a fake git repo root so directory walk stays bounded."""
+    (base / ".git").mkdir(exist_ok=True)
+    return base
+
+
+def _fake_urlopen_response(data: dict) -> MagicMock:
+    """Return a context-manager mock that acts like urlopen(...)."""
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(data).encode()
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — resolve_org_token
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_cached(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_org_token("org_cached", {"access_token": "otoat_cached", "expires_at": int(time.time()) + 3600})
+    result = auth.resolve_org_token("org_cached")
+    assert result["access_token"] == "otoat_cached"
+
+
+def test_resolve_exchanges_on_miss(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_tokens({"access_token": "otuat_usertoken"})
+    monkeypatch.setattr(auth, "_discovery_cache", None)
+
+    exchange_resp = {"access_token": "otoat_new", "expires_in": 3600}
+    with (
+        patch.object(auth, "discover", return_value=FAKE_DISCOVERY),
+        patch("urllib.request.urlopen", return_value=_fake_urlopen_response(exchange_resp)) as mock_urlopen,
+    ):
+        result = auth.resolve_org_token("org_miss")
+
+    assert result["access_token"] == "otoat_new"
+    assert "expires_at" in result
+
+    # Verify it was cached
+    assert load_org_token("org_miss") is not None
+
+    # Verify correct request
+    req = mock_urlopen.call_args[0][0]
+    assert req.full_url == "https://api.opentrace.ai/oauth/exchange-org-token"
+    assert req.get_header("Authorization") == "Bearer otuat_usertoken"
+
+
+def test_resolve_not_logged_in(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    with pytest.raises(RuntimeError, match="Not logged in"):
+        auth.resolve_org_token("org_x")
+
+
+def test_resolve_legacy_otoat(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_tokens({"access_token": "otoat_legacytoken"})
+    monkeypatch.setattr(auth, "_discovery_cache", None)
+    with pytest.raises(RuntimeError, match="legacy format"):
+        auth.resolve_org_token("org_x")
+
+
+def test_resolve_http_401(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_tokens({"access_token": "otuat_valid"})
+    monkeypatch.setattr(auth, "_discovery_cache", None)
+
+    err = urllib.error.HTTPError("url", 401, "Unauthorized", {}, BytesIO(b"unauth"))
+    with (
+        patch.object(auth, "discover", return_value=FAKE_DISCOVERY),
+        patch("urllib.request.urlopen", side_effect=err),
+    ):
+        with pytest.raises(RuntimeError, match="expired or invalid"):
+            auth.resolve_org_token("org_x")
+
+
+def test_resolve_http_404(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_tokens({"access_token": "otuat_valid"})
+    monkeypatch.setattr(auth, "_discovery_cache", None)
+
+    err = urllib.error.HTTPError("url", 404, "Not Found", {}, BytesIO(b"not found"))
+    with (
+        patch.object(auth, "discover", return_value=FAKE_DISCOVERY),
+        patch("urllib.request.urlopen", side_effect=err),
+    ):
+        with pytest.raises(RuntimeError, match="not found"):
+            auth.resolve_org_token("org_x")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — get_api_token
+# ---------------------------------------------------------------------------
+
+
+def test_get_api_token_with_org(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    # Set up project config
+    ot_dir = tmp_path / ".opentrace"
+    ot_dir.mkdir(exist_ok=True)
+    save_config(ot_dir / "config.yaml", {"org": "org_test"})
+
+    # Save org token
+    save_org_token("org_test", {"access_token": "otoat_orgtoken", "expires_at": int(time.time()) + 3600})
+
+    assert auth.get_api_token() == "otoat_orgtoken"
+
+
+def test_get_api_token_no_org(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    save_tokens({"access_token": "otuat_direct"})
+
+    assert auth.get_api_token() == "otuat_direct"
+
+
+def test_get_api_token_not_logged_in(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    with pytest.raises(RuntimeError, match="Not logged in"):
+        auth.get_api_token()
+
+
+# ---------------------------------------------------------------------------
+# Unit test — login includes prompt=none
+# ---------------------------------------------------------------------------
+
+
+def test_login_includes_prompt_none(monkeypatch: object) -> None:
+    monkeypatch.setattr(auth, "_discovery_cache", None)
+    captured_url = {}
+
+    def capture_url(url: str) -> None:
+        captured_url["url"] = url
+
+    # Create a fake _OAuthResult whose ready.wait() returns False immediately
+    fake_result = MagicMock()
+    fake_result.ready.wait.return_value = False
+
+    with (
+        patch.object(auth, "discover", return_value=FAKE_DISCOVERY),
+        patch.object(auth, "_find_open_port", return_value=9876),
+        patch.object(auth, "_ensure_client", return_value={"client_id": "test_client"}),
+        patch.object(auth, "webbrowser") as mock_wb,
+        patch.object(auth, "_ThreadedHTTPServer"),
+        patch.object(auth, "_OAuthResult", return_value=fake_result),
+    ):
+        mock_wb.open.side_effect = capture_url
+
+        with pytest.raises(TimeoutError):
+            auth.login()
+
+    assert "url" in captured_url
+    assert "prompt=none" in captured_url["url"]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — logout
+# ---------------------------------------------------------------------------
+
+
+def test_logout_with_org_tokens(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_tokens({"access_token": "otuat_user"})
+    save_org_token("org_1", {"access_token": "otoat_1", "expires_at": int(time.time()) + 3600})
+    save_org_token("org_2", {"access_token": "otoat_2", "expires_at": int(time.time()) + 3600})
+
+    result = runner.invoke(app, ["logout"])
+    assert result.exit_code == 0
+    assert "user credentials" in result.output
+    assert "2 org token(s)" in result.output
+
+
+def test_logout_not_logged_in(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    result = runner.invoke(app, ["logout"])
+    assert result.exit_code == 0
+    assert "Not logged in" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — whoami
+# ---------------------------------------------------------------------------
+
+
+def test_whoami_not_logged_in(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0
+    assert "Not logged in" in result.output
+
+
+def test_whoami_otuat_token(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_tokens({"access_token": "otuat_abc", "issuer": "https://api.opentrace.ai", "scope": "read write"})
+
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0
+    assert "user (otuat)" in result.output
+
+
+def test_whoami_legacy_otoat(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_tokens({"access_token": "otoat_legacy123", "issuer": "https://api.opentrace.ai", "scope": "read write"})
+
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0
+    assert "org-scoped (legacy)" in result.output
+
+
+def test_whoami_org_cached(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    # Set up project config
+    ot_dir = tmp_path / ".opentrace"
+    ot_dir.mkdir(exist_ok=True)
+    save_config(ot_dir / "config.yaml", {"org": "org_cached"})
+
+    # Save tokens
+    save_tokens({"access_token": "otuat_user", "issuer": "https://api.opentrace.ai", "scope": "read write"})
+    save_org_token("org_cached", {"access_token": "otoat_org", "expires_at": int(time.time()) + 3600})
+
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0
+    assert "org_cached" in result.output
+    assert "(token cached)" in result.output
+
+
+def test_whoami_org_not_cached(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    # Set up project config
+    ot_dir = tmp_path / ".opentrace"
+    ot_dir.mkdir(exist_ok=True)
+    save_config(ot_dir / "config.yaml", {"org": "org_nocache"})
+
+    # Only user token, no org token
+    save_tokens({"access_token": "otuat_user", "issuer": "https://api.opentrace.ai", "scope": "read write"})
+
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0
+    assert "org_nocache" in result.output
+    assert "(not yet authenticated)" in result.output

--- a/agent/tests/opentrace_agent/cli/test_auth.py
+++ b/agent/tests/opentrace_agent/cli/test_auth.py
@@ -297,7 +297,7 @@ def test_whoami_org_cached(tmp_path: Path, monkeypatch: object) -> None:
     assert "(token cached)" in result.output
 
 
-def test_whoami_org_not_cached(tmp_path: Path, monkeypatch: object) -> None:
+def test_whoami_org_not_cached_resolve_fails(tmp_path: Path, monkeypatch: object) -> None:
     _make_repo(tmp_path)
     monkeypatch.chdir(tmp_path)
     _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
@@ -310,7 +310,108 @@ def test_whoami_org_not_cached(tmp_path: Path, monkeypatch: object) -> None:
     # Only user token, no org token
     save_tokens({"access_token": "otuat_user", "issuer": "https://api.opentrace.ai", "scope": "read write"})
 
-    result = runner.invoke(app, ["whoami"])
+    with patch.object(auth, "resolve_org_token", side_effect=RuntimeError("token expired")):
+        result = runner.invoke(app, ["whoami"])
     assert result.exit_code == 0
     assert "org_nocache" in result.output
-    assert "(not yet authenticated)" in result.output
+    assert "(exchange failed:" in result.output
+
+
+def test_whoami_org_auto_resolves(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    ot_dir = tmp_path / ".opentrace"
+    ot_dir.mkdir(exist_ok=True)
+    save_config(ot_dir / "config.yaml", {"org": "org_resolved"})
+
+    save_tokens({"access_token": "otuat_user", "issuer": "https://api.opentrace.ai", "scope": "read write"})
+
+    with patch.object(auth, "resolve_org_token", return_value={"access_token": "otoat_new"}):
+        result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0
+    assert "org_resolved" in result.output
+    assert "(token resolved)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — login --resolve
+# ---------------------------------------------------------------------------
+
+
+def test_login_resolve_exchanges_org_token(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    ot_dir = tmp_path / ".opentrace"
+    ot_dir.mkdir(exist_ok=True)
+    save_config(ot_dir / "config.yaml", {"org": "org_test"})
+
+    fake_payload = {"issuer": "https://api.opentrace.ai", "scope": "read write", "access_token": "otuat_new"}
+
+    with (
+        patch.object(auth, "login", return_value=fake_payload),
+        patch.object(auth, "resolve_org_token", return_value={"access_token": "otoat_org"}) as mock_resolve,
+    ):
+        result = runner.invoke(app, ["login", "--resolve"])
+
+    assert result.exit_code == 0
+    assert "Org token resolved for 'org_test'" in result.output
+    mock_resolve.assert_called_once_with("org_test")
+
+
+def test_login_resolve_no_config(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    # No .opentrace/config.yaml
+
+    fake_payload = {"issuer": "https://api.opentrace.ai", "scope": "read write", "access_token": "otuat_new"}
+
+    with patch.object(auth, "login", return_value=fake_payload):
+        result = runner.invoke(app, ["login", "--resolve"])
+
+    assert result.exit_code == 0
+    assert "No .opentrace/config.yaml found" in result.output
+
+
+def test_login_resolve_no_org(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    ot_dir = tmp_path / ".opentrace"
+    ot_dir.mkdir(exist_ok=True)
+    save_config(ot_dir / "config.yaml", {})
+
+    fake_payload = {"issuer": "https://api.opentrace.ai", "scope": "read write", "access_token": "otuat_new"}
+
+    with patch.object(auth, "login", return_value=fake_payload):
+        result = runner.invoke(app, ["login", "--resolve"])
+
+    assert result.exit_code == 0
+    assert "No org set in config" in result.output
+
+
+def test_login_resolve_exchange_fails(tmp_path: Path, monkeypatch: object) -> None:
+    _make_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_base_dir(monkeypatch, tmp_path, subdir="home_opentrace")
+
+    ot_dir = tmp_path / ".opentrace"
+    ot_dir.mkdir(exist_ok=True)
+    save_config(ot_dir / "config.yaml", {"org": "org_fail"})
+
+    fake_payload = {"issuer": "https://api.opentrace.ai", "scope": "read write", "access_token": "otuat_new"}
+
+    with (
+        patch.object(auth, "login", return_value=fake_payload),
+        patch.object(auth, "resolve_org_token", side_effect=RuntimeError("token expired")),
+    ):
+        result = runner.invoke(app, ["login", "--resolve"])
+
+    assert result.exit_code != 0
+    assert "Org token resolution failed" in result.output

--- a/agent/tests/opentrace_agent/cli/test_credentials.py
+++ b/agent/tests/opentrace_agent/cli/test_credentials.py
@@ -1,0 +1,89 @@
+# Copyright 2026 OpenTrace Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for per-org token storage in credentials.py."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from opentrace_agent.cli import credentials
+from opentrace_agent.cli.credentials import (
+    clear_org_tokens,
+    load_org_token,
+    save_org_token,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_base_dir(monkeypatch: object, tmp_path: Path) -> Path:
+    """Redirect credentials storage to a test-local directory."""
+    base = tmp_path / ".opentrace"
+    base.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(credentials, "_base_dir", lambda: base)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — org token storage
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_org_token_roundtrip(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    token_data = {"access_token": "otoat_roundtrip", "expires_at": int(time.time()) + 3600}
+    save_org_token("org_abc", token_data)
+    loaded = load_org_token("org_abc")
+    assert loaded is not None
+    assert loaded["access_token"] == "otoat_roundtrip"
+
+
+def test_load_org_token_missing(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    assert load_org_token("org_nonexistent") is None
+
+
+def test_load_org_token_expired(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    save_org_token("org_exp", {"access_token": "otoat_expired", "expires_at": 1000})
+    with patch.object(credentials.time, "time", return_value=2000):
+        assert load_org_token("org_exp") is None
+
+
+def test_load_org_token_expired_deletes_file(tmp_path: Path, monkeypatch: object) -> None:
+    base = _patch_base_dir(monkeypatch, tmp_path)
+    save_org_token("org_exp", {"access_token": "otoat_expired", "expires_at": 1000})
+    token_file = base / "org_tokens" / "org_exp.json"
+    assert token_file.exists()
+    with patch.object(credentials.time, "time", return_value=2000):
+        load_org_token("org_exp")
+    assert not token_file.exists()
+
+
+def test_clear_org_tokens_removes_all(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    for i in range(3):
+        save_org_token(f"org_{i}", {"access_token": f"otoat_{i}", "expires_at": int(time.time()) + 3600})
+    assert clear_org_tokens() == 3
+    assert load_org_token("org_0") is None
+
+
+def test_clear_org_tokens_empty(tmp_path: Path, monkeypatch: object) -> None:
+    _patch_base_dir(monkeypatch, tmp_path)
+    assert clear_org_tokens() == 0


### PR DESCRIPTION
## Summary

- Add user-scoped OAuth login flow — `opentrace login` now gets an `otuat_` token (no org) instead of `otoat_` (org-scoped)
- Add per-org token resolution — CLI reads org from `.opentrace/config.yaml` and exchanges `otuat_` for org-scoped `otoat_` via `POST /oauth/exchange-org-token`
- Add per-org token cache in `~/.opentrace/org_tokens/{org}.json` (encrypted, same Fernet scheme)
- Update `logout` to clear org tokens, `whoami` to show org context

## Motivation

Previously, `opentrace login` forced org selection in the browser. Switching orgs required re-login. Now the CLI authenticates the user once, and org scoping is controlled by the project config file.

## How it works

```
opentrace login
  → OAuth PKCE flow with prompt=none (skips org selector in UI)
  → Gets otuat_ token (user-level, 30-day TTL)
  → Stored in ~/.opentrace/auth.json

opentrace <command>  (in project with .opentrace/config.yaml org: edwin)
  → resolve_org_token(\"edwin\")
  → Checks ~/.opentrace/org_tokens/edwin.json cache
  → If missing/expired: POST /oauth/exchange-org-token with otuat_ + org
  → Gets otoat_ (org-scoped, 3-day TTL)
  → Cached and used for API calls
```

## Files changed

| File | Change |
|------|--------|
| `agent/src/opentrace_agent/cli/auth.py` | `prompt=none` on authorize URL, `resolve_org_token()`, `get_api_token()` |
| `agent/src/opentrace_agent/cli/credentials.py` | `load_org_token()`, `save_org_token()`, `clear_org_tokens()` |
| `agent/src/opentrace_agent/cli/main.py` | Updated `logout`, `whoami` |

## Companion PRs

- **API**: opentrace/insight-api#1186
- **UI**: pending — `prompt=none` handling on `/oauth/authorize`

## Test plan

- [x] `opentraceai login` gets `otuat_` token
- [x] `opentraceai whoami` shows user type and org context
- [x] `opentraceai config set org edwin` sets org
- [x] API command triggers `resolve_org_token()` and exchanges for `otoat_`
- [x] `opentraceai logout` clears user + org tokens
- [x] Legacy `otoat_` tokens show clear migration message

🤖 Generated with [Claude Code](https://claude.com/claude-code)