### PR TITLE
docs: fix stale content and add missing reference pages

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,7 +10,7 @@
 │                                  │  WASM parsers   │ │
 │                                  └─────────────────┘ │
 │                                  ┌─────────────────┐ │
-│                                  │  LadybugDB WASM    │ │
+│                                  │  LadybugDB WASM │ │
 │                                  │  graph store    │ │
 │                                  └─────────────────┘ │
 └──────────────────────────────────────────────────────┘
@@ -27,10 +27,14 @@ React/TypeScript frontend that runs entirely in the browser. Includes:
 - **LadybugDB WASM** — embedded graph database for storing and querying the knowledge graph
 - **Chat Agent** — in-app AI agent with access to graph tools via MCP
 
+### Agent (`agent/`)
+
+Python agent that loads data into the knowledge graph. Managed with [uv](https://docs.astral.sh/uv/), it runs as an MCP server and handles data ingestion from external sources.
+
 ### Protobuf Definitions (`proto/`)
 
 Shared API contracts used across components.
 
 ### Claude Code Plugin (`claude-code-plugin/`)
 
-MCP server configuration that connects Claude Code to OpenTrace.
+MCP server configuration that connects Claude Code to OpenTrace. See the [Claude Code Plugin reference](../reference/claude-code-plugin.md) for details.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,3 +1,10 @@
 # Contributing
 
-See the [CONTRIBUTING.md](https://github.com/opentrace/opentrace/blob/main/CONTRIBUTING.md) file in the repository root for full guidelines.
+We welcome contributions! The full guide is in [CONTRIBUTING.md](https://github.com/opentrace/opentrace/blob/main/CONTRIBUTING.md) — here's the short version:
+
+1. Fork the repo, create a feature branch, and run `make install`
+2. Make your changes — run `make fmt` before committing and `make test` + `make lint` to verify
+3. Open a focused PR (one feature or fix per PR) with tests for new functionality
+4. All source files need Apache 2.0 license headers — run `make license-fix` to add them automatically
+
+Commit messages follow the conventional format: `fix:`, `feat:`, `chore:`, `docs:`, etc.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -4,6 +4,7 @@
 
 - Node.js 22+ (see `ui/.nvmrc`)
 - npm
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/) (for the agent)
 
 ## Getting Started
 
@@ -38,6 +39,8 @@ npm run lint          # ESLint + Prettier check
 
 ```
 ui/                   — React/TypeScript frontend (graph explorer + browser indexer)
+agent/                — Python agent (loads data into the graph)
 proto/                — Protobuf definitions (shared API contracts)
 claude-code-plugin/   — Claude Code plugin (MCP server config)
+benchmark/            — Performance benchmarks
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,6 +4,7 @@
 
 - Node.js 22+ (see `ui/.nvmrc`)
 - npm
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/) (for the agent)
 
 ## Installation
 

--- a/docs/reference/chat-providers.md
+++ b/docs/reference/chat-providers.md
@@ -8,9 +8,9 @@ All API keys are stored locally in your browser — they are never sent to OpenT
 
 Provides access to the Claude model family.
 
-**Available models:** Claude Opus 4, Claude Sonnet 4.5, Claude Sonnet 4, Claude Haiku 3.5
+**Available models:** Claude Opus 4.6, Claude Opus 4.5, Claude Sonnet 4.6, Claude Sonnet 4.5, Claude Haiku 4.5
 
-To get an API key, visit the [Anthropic Console](https://console.anthropic.com/).
+To get an API key, visit the [Anthropic Console](https://platform.claude.com/settings/keys).
 
 See the [Anthropic API documentation](https://docs.anthropic.com/en/api/getting-started) for details on plans, pricing, and usage.
 
@@ -18,7 +18,7 @@ See the [Anthropic API documentation](https://docs.anthropic.com/en/api/getting-
 
 Provides access to GPT and reasoning models.
 
-**Available models:** o3, o4-mini, GPT-4.1, GPT-4.1 Mini, GPT-4.1 Nano, GPT-4o, GPT-4o Mini
+**Available models:** o3, o4-mini, GPT-4.1, GPT-4.1 Mini, GPT-4o, GPT-4o Mini
 
 To get an API key, visit the [OpenAI Platform](https://platform.openai.com/api-keys).
 

--- a/docs/reference/claude-code-plugin.md
+++ b/docs/reference/claude-code-plugin.md
@@ -1,0 +1,59 @@
+# Claude Code Plugin
+
+OpenTrace ships a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins) that connects Claude to the OpenTrace knowledge graph. Once installed, Claude can explore your indexed codebase — find components, trace dependencies, and answer architecture questions.
+
+## Installation
+
+```bash
+claude plugin install opentrace-oss@opentrace-oss
+```
+
+The plugin requires the `opentraceai` CLI. Install it with:
+
+```bash
+uvx opentraceai --help
+```
+
+## How It Works
+
+The plugin runs an MCP server (via `opentraceai mcp`) that gives Claude access to the knowledge graph stored in `.opentrace/index.db`. The database is auto-discovered by walking up from the current directory to the git root.
+
+## Agents
+
+Agents are specialized assistants you can invoke with `@agent-name` in Claude Code.
+
+| Agent | Description |
+|-------|-------------|
+| `@opentrace` | General-purpose — any codebase question (default) |
+| `@code-explorer` | Explore code structure, files, directories, and their relationships |
+| `@dependency-analyzer` | Analyze dependencies and blast radius for code changes |
+| `@explain-service` | Top-down explanation of a service or major component |
+| `@find-usages` | Find all callers, references, and usages of a component |
+
+## Commands
+
+Commands are slash-invoked actions available in Claude Code.
+
+| Command | Description |
+|---------|-------------|
+| `/explore <name>` | Quick exploration of a named component in the graph |
+| `/graph-status` | Show overview of indexed nodes by type |
+| `/index` | Index or re-index the current project |
+| `/interrogate` | Answer a question about the codebase (read-only) |
+| `/update` | Check for and install CLI updates |
+
+## Graph Tools
+
+The plugin exposes these MCP tools to Claude:
+
+| Tool | Description |
+|------|-------------|
+| `search_graph` | Full-text search across nodes by name or properties |
+| `list_nodes` | List nodes by type with optional property filters |
+| `get_node` | Get full details of a single node by ID |
+| `traverse_graph` | BFS traversal to discover connected nodes |
+| `get_stats` | Node and edge counts by type |
+
+## Configuration
+
+The plugin source lives in `claude-code-plugin/` in the repository root. See the `CLAUDE.md` file in that directory for details on plugin structure, versioning, and agent development.

--- a/docs/reference/graph-tools.md
+++ b/docs/reference/graph-tools.md
@@ -1,0 +1,26 @@
+# Graph Tools
+
+The OpenTrace knowledge graph can be queried through MCP tools, available to both the built-in chat agent and the Claude Code plugin.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_graph` | Full-text search across nodes by name or properties |
+| `list_nodes` | List nodes by type with optional property filters |
+| `get_node` | Get full details of a single node by ID |
+| `traverse_graph` | BFS traversal to discover connected nodes |
+| `load_source` | Fetch source code for an indexed file or symbol |
+| `get_stats` | Node and edge counts by type |
+
+## Node Types
+
+The knowledge graph contains the following node types:
+
+| Category | Types |
+|----------|-------|
+| Code | Class, Module, Function, File, Directory |
+| Infrastructure | Service, Cluster, Namespace, Deployment |
+| Observability | InstrumentedService, Span, Log, Metric |
+| Data | Database, DBTable, Endpoint |
+| Organization | Repo, Repository |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,4 +53,6 @@ nav:
   - Reference:
       - Browser Requirements: reference/browser-requirements.md
       - Chat Providers: reference/chat-providers.md
+      - Claude Code Plugin: reference/claude-code-plugin.md
+      - Graph Tools: reference/graph-tools.md
       - Supported Languages: reference/languages.md


### PR DESCRIPTION
## Sync documentation with Python agent and Claude plugin features
📝 **Docs**

Updates the documentation suite to include the Python agent and Claude Code plugin. 

Adds new reference pages for graph tools and plugin usage while correcting stale model lists and external API links.

### Complexity
🟢 Low · `9 files changed, 109 insertions(+), 7 deletions(-)`

Pure documentation update with no functional code changes. The scope is limited to Markdown files and MkDocs navigation configuration.

### Review focus
Pay particular attention to the following areas:

- **Python Requirements** — verify if the documentation should specify Python 3.12+ (as seen in `agent/pyproject.toml`) instead of 3.11+.
- **Tool Availability** — confirm that the tools listed in `graph-tools.md` (specifically `load_source`) are available in the Python MCP server and not just the browser-based UI agent.
<!-- opentrace:jid=j-151044b8-a163-4988-a9ce-1c73a8d523ce|sha=9d90273960ecdaa37fa4a69daa9817f72a787118 -->