### PR TITLE
fix(ci): handle pre-existing GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,14 @@ jobs:
       - name: Generate release notes
         run: git-cliff --latest --strip header -o RELEASE_NOTES.md
 
-      - name: Create Release
-        run: gh release create ${{ github.ref_name }} opentrace-ui-${{ github.ref_name }}.zip --notes-file RELEASE_NOTES.md
+      - name: Create or update Release
+        run: |
+          if gh release view "${{ github.ref_name }}" &>/dev/null; then
+            gh release upload "${{ github.ref_name }}" opentrace-ui-${{ github.ref_name }}.zip --clobber
+            gh release edit "${{ github.ref_name }}" --notes-file RELEASE_NOTES.md
+          else
+            gh release create "${{ github.ref_name }}" opentrace-ui-${{ github.ref_name }}.zip --notes-file RELEASE_NOTES.md
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- Makes the release workflow idempotent when a GitHub release already exists (e.g. created via the UI)
- Uses `gh release view` to check, then `upload --clobber` + `edit` instead of failing on `create`

## Test plan
- [ ] Create a release via the GitHub UI, then push a matching `v*` tag — workflow should succeed
- [ ] Push a `v*` tag with no pre-existing release — workflow should create as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)