### PR TITLE
chore(release): bump to 0.4.0 and derive version from metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,6 @@ jobs:
 
           # Bump agent version
           sed -i "s/^version = .*/version = \"${VERSION}\"/" agent/pyproject.toml
-          sed -i "s/^__version__ = .*/__version__ = \"${VERSION}\"/" agent/src/opentrace_agent/__init__.py
 
           # Bump UI version
           cd ui
@@ -81,7 +80,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout main
-          git add agent/pyproject.toml agent/src/opentrace_agent/__init__.py ui/package.json ui/package-lock.json CHANGELOG.md
+          git add agent/pyproject.toml ui/package.json ui/package-lock.json CHANGELOG.md
           git diff --cached --quiet || git commit -m "chore(release): bump to ${VERSION} and update changelog [skip ci]"
           git push
 
@@ -106,7 +105,6 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
-          sed -i "s/^__version__ = .*/__version__ = \"${VERSION}\"/" src/opentrace_agent/__init__.py
 
       - name: Build package
         working-directory: agent

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opentraceai"
-version = "0.3.0"
+version = "0.4.0"
 description = "OpenTrace Python agent — maps system architecture, code structure, and service relationships into a knowledge graph"
 readme = "README.md"
 license = "Apache-2.0"

--- a/agent/src/opentrace_agent/__init__.py
+++ b/agent/src/opentrace_agent/__init__.py
@@ -14,4 +14,9 @@
 
 """OpenTrace Python Agent."""
 
-__version__ = "0.3.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("opentraceai")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/agent/tests/opentrace_agent/test_init.py
+++ b/agent/tests/opentrace_agent/test_init.py
@@ -16,4 +16,5 @@ from opentrace_agent import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert isinstance(__version__, str)
+    assert __version__ != ""

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrace/opentrace",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "React components for graph visualization — powered by Pixi.js and Graphology",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Bump to 0.4.0 and dynamic Python agent versioning
✨ **Improvement** · ♻️ **Refactor** · 🔧 **Chore**

Bumps the project version to 0.4.0 and implements dynamic version retrieval for the Python agent. This refactors the release pipeline to be more robust and removes redundant source-code modifications during CI.

### Complexity
🟡 Moderate · `4 files changed, 14 insertions(+), 8 deletions(-)`

This PR modifies foundational versioning logic and release infrastructure across both Python and UI components. While the code changes are small, they affect the build/release pipeline and require synchronization between package manifests, source code, and CI scripts.

### Tests
🧪 Existing version tests in the agent are currently out of sync with the new version and dynamic lookup logic.

### Review focus
Pay particular attention to the following areas:

- **`importlib.metadata` fallback** — consider adding a try/except block for cases where the package is run in an uninstalled development environment.
- **Workflow synchronization** — the `publish-preview.yml` and `publish-dev.yml` workflows still contain redundant `sed` commands for `__init__.py` that should be removed.
- **UI lockfile mismatch** — verify and fix the regression in `ui/package-lock.json` which is currently out of sync with `main`.
- **Broken version test** — `agent/tests/opentrace_agent/test_init.py` still asserts a version of `0.1.0` and will fail in CI.

---

<details>
<summary><strong>Additional details</strong></summary>

### Dynamic Versioning
The Python agent now leverages `importlib.metadata` to read its version directly from the package installation. This eliminates the need for the release workflow to perform string replacements on source files, reducing the risk of merge conflicts and build inconsistencies.

### Idempotent Releases
The release workflow has been updated to check for existing GitHub releases before attempting creation. If a release already exists (e.g., created via the UI or a previous partial run), the workflow will now upload assets and update notes instead of failing.

### Note on Branch State
This branch diverged prior to the 0.3.0 release. As a result, `ui/package-lock.json` has regressed to version `0.1.1` in this PR (compared to `0.3.0` on `main`). A rebase or manual synchronization of the lockfile and `CHANGELOG.md` is required before merging.

</details>
<!-- opentrace:jid=j-1bf6b90c-a943-4d3c-bb67-40cbd675b2ef|sha=bce25f4695d160558c1621d26396814841fe86e8 -->