### PR TITLE
docs: use uv tool install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The plugin gives Claude Code 5 agents, 4 slash commands, and graph query tools â
 ### CLI Agent (standalone)
 
 ```bash
-pip install opentraceai     # or: uvx opentraceai index .
+uv tool install opentraceai --upgrade   # install or upgrade the CLI
 opentraceai index /path/to/repo
 opentraceai mcp             # start MCP server for any compatible client
 ```


### PR DESCRIPTION
## Summary
- Replace `pip install opentraceai` with `uv tool install opentraceai --upgrade` in the CLI Agent quick start section of the README.

## Test plan
- [x] README renders correctly with the new install command

🤖 Generated with [Claude Code](https://claude.com/claude-code)