### PR TITLE
docs: restructure install paths into per-audience guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git clone https://github.com/opentrace/opentrace.git && cd opentrace
 make install && make ui
 ```
 
-> **Prerequisites:** plugin and CLI need [`uv`](https://docs.astral.sh/uv/). Source build also needs Node 22+ and Python 3.11+. See [Troubleshooting](https://opentrace.github.io/opentrace/getting-started/troubleshooting/) if anything fails.
+> **Prerequisites:** plugin and CLI need [`uv`](https://docs.astral.sh/uv/). Source build also needs Node 22+ and Python 3.12+. See [Troubleshooting](https://opentrace.github.io/opentrace/getting-started/troubleshooting/) if anything fails.
 
 ## What It Does
 

--- a/README.md
+++ b/README.md
@@ -13,67 +13,52 @@ A knowledge graph that maps your codebase structure, service architecture, and s
 
 ## Try Now
 
-**[oss.opentrace.ai](https://oss.opentrace.ai)** — no install required, runs entirely in your browser.
+**[oss.opentrace.ai](https://oss.opentrace.ai)** — no install, runs in your browser.
 
-**[Docs](https://opentrace.github.io/opentrace/)** — getting started, architecture, and reference guides
+## Documentation
 
-## Quick Start
+**[opentrace.github.io/opentrace](https://opentrace.github.io/opentrace/)** — install guides, architecture, and reference.
 
-### Browser (no install)
+## Install
 
-Visit **[oss.opentrace.ai](https://oss.opentrace.ai)**, add a GitHub repo, and explore the graph.
+Pick the path that matches what you want to do. Every row links to a full guide.
 
-### Claude Code Plugin
+| You want to…                          | Use                              | Guide |
+|---------------------------------------|----------------------------------|-------|
+| See what OpenTrace is                 | Browser                          | [Browser](https://opentrace.github.io/opentrace/getting-started/install-browser/) |
+| Give Claude Code codebase awareness   | Claude Code plugin               | [Plugin](https://opentrace.github.io/opentrace/getting-started/install-plugin/) |
+| Index repos from a terminal           | CLI (`uvx` / `uv tool`)          | [CLI](https://opentrace.github.io/opentrace/getting-started/install-cli/) |
+| Hack on OpenTrace itself              | Source build                     | [Source](https://opentrace.github.io/opentrace/development/setup/) |
+
+### One-liner per path
 
 ```bash
-claude plugin marketplace add https://github.com/opentrace/opentrace 
+# Claude Code plugin — auto-indexes on session start
+claude plugin marketplace add https://github.com/opentrace/opentrace
 claude plugin install opentrace-oss@opentrace-oss
+
+# CLI — try without installing, or install permanently
+uvx opentraceai index .
+uv tool install opentraceai --upgrade
+
+# Source
+git clone https://github.com/opentrace/opentrace.git && cd opentrace
+make install && make ui
 ```
 
-> We will automatically start an index in the background on session start.
-
-Then index your codebase and start exploring:
-
-```bash
-uvx opentraceai index        # index the current repo
-```
-
-The plugin gives Claude Code 5 agents, 4 slash commands, and graph query tools — see [Claude Code Plugin](#claude-code-plugin) for details.
-
-### CLI Agent (standalone)
-
-```bash
-uv tool install opentraceai --upgrade   # install or upgrade the CLI
-opentraceai index /path/to/repo
-opentraceai mcp             # start MCP server for any compatible client
-```
-
-The database is stored at `.opentrace/index.db` and auto-discovered by all commands.
-
-### Run from Source
-
-```bash
-git clone https://github.com/opentrace/opentrace.git
-cd opentrace
-make install
-make ui
-```
-
-Open [http://localhost:5173](http://localhost:5173), add a GitHub repo, and explore the graph.
+> **Prerequisites:** plugin and CLI need [`uv`](https://docs.astral.sh/uv/). Source build also needs Node 22+ and Python 3.11+. See [Troubleshooting](https://opentrace.github.io/opentrace/getting-started/troubleshooting/) if anything fails.
 
 ## What It Does
 
-OpenTrace indexes source code directly in your browser — no server required. Point it at a GitHub or GitLab repo and it will:
+OpenTrace indexes source code and builds a queryable knowledge graph. Point it at a repo and it will:
 
 1. **Parse** every file using tree-sitter WASM grammars (12 languages)
 2. **Extract** classes, functions, imports, and call relationships
-3. **Build** a knowledge graph stored in LadybugDB WASM (embedded graph database)
+3. **Build** a knowledge graph stored in LadybugDB (embedded graph database)
 4. **Summarize** every node using template-based identifier analysis
-5. **Expose** the graph to an in-app chat agent via MCP tools
+5. **Expose** the graph via MCP tools to any compatible AI client
 
 ## Architecture
-
-Everything runs in the browser — no server required.
 
 ```
 ┌───────────────────────────────────────────────────────────┐
@@ -95,37 +80,36 @@ Everything runs in the browser — no server required.
 └───────────────────────────────────────────────────────────┘
 ```
 
+See [Architecture Overview](https://opentrace.github.io/opentrace/architecture/overview/) for details.
+
+## Claude Code Plugin
+
+The plugin gives Claude Code 5 agents, 4 slash commands, and MCP graph tools.
+
+| Agent                  | Description                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| `@opentrace`           | Default catch-all — any codebase question routed to the knowledge graph              |
+| `@code-explorer`       | Explore indexed code structure — find classes, functions, files, and relationships   |
+| `@dependency-analyzer` | Analyze dependencies and blast radius for code changes                               |
+| `@find-usages`         | Find all callers, references, and usages of a component                              |
+| `@explain-service`     | Top-down walkthrough of how a service or module works                                |
+
+| Command             | Description                                                      |
+| ------------------- | ---------------------------------------------------------------- |
+| `/index`            | Index (or re-index) the current project into the knowledge graph |
+| `/graph-status`     | Show overview of indexed nodes by type                           |
+| `/explore <name>`   | Quick exploration of a named component in the graph              |
+| `/interrogate`      | Answer a question about the codebase without making changes     |
+
+Full details: [Claude Code Plugin reference](https://opentrace.github.io/opentrace/reference/claude-code-plugin/).
+
 ## Supported Languages
 
-| Full Extraction (symbols + calls + imports) | Structural Extraction (symbols only) |
-|---|---|
-| Python, TypeScript/JavaScript, Go | Rust, Java, Kotlin, C#, C/C++, Ruby, Swift |
+**Full extraction** (symbols + calls + imports): Python, TypeScript/JavaScript, Go
+**Structural extraction** (symbols only): Rust, Java, Kotlin, C#, C/C++, Ruby, Swift
+**Indexed as file nodes**: JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash
 
-Config and data files (JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash) are indexed as file nodes.
-
-## Graph Tools
-
-### Browser Chat Agent
-
-| Tool | Description |
-|------|-------------|
-| `search_graph` | Full-text search across nodes by name, properties, and file content |
-| `list_nodes` | List nodes by type with optional property filters |
-| `get_node` | Get full details of a single node by ID |
-| `traverse_graph` | BFS traversal to discover connected nodes and relationships |
-| `load_source` | Fetch source code for an indexed file or symbol |
-| `explore_node` | Deep inspection — node details + relationships + source in one call |
-| `grep` | Regex search across all indexed source files |
-
-### Claude Code Plugin (MCP)
-
-| Tool | Description |
-|------|-------------|
-| `search_graph` | Full-text search across nodes by name or properties |
-| `list_nodes` | List nodes of a specific type |
-| `get_node` | Get full details of a single node by ID |
-| `traverse_graph` | BFS traversal with direction and relationship filters |
-| `get_stats` | Graph statistics — total nodes, edges, and breakdown by type |
+Full language matrix: [Supported Languages](https://opentrace.github.io/opentrace/reference/languages/).
 
 ## Repository Structure
 
@@ -141,76 +125,7 @@ benchmark/            — Accuracy benchmarks
 
 ## Development
 
-### Prerequisites
-
-- Node.js 22+ (see `ui/.nvmrc`)
-- npm
-
-### Commands
-
-```bash
-make install          # Install dependencies (agent + ui)
-make agent            # Run Python agent
-make ui               # Start dev server (localhost:5173)
-make build            # Production build
-make test             # Run all tests (agent + ui)
-make fmt              # Format all code
-make lint             # Lint all code
-make proto            # Generate protobuf types
-make ui-build-static  # Static build (browser-only, no API dependency)
-make license-check    # Verify Apache 2.0 headers on all source files
-make plugin-reload    # Reinstall the Claude Code plugin locally
-```
-
-### Agent
-
-```bash
-cd agent
-uv sync          # Install dependencies
-uv run pytest    # Run tests
-```
-
-### Running Tests
-
-```bash
-cd ui
-npm test              # Run all tests
-npm run lint          # ESLint + Prettier check
-```
-
-## Agents
-
-| Agent                  | Description                                                                                |
-| ---------------------- | ------------------------------------------------------------------------------------------ |
-| `@opentrace`           | Default catch-all — any codebase question routed to the knowledge graph                   |
-| `@code-explorer`       | Explore indexed code structure — find classes, functions, files, and their relationships   |
-| `@dependency-analyzer` | Analyze dependencies and blast radius for code changes                                     |
-| `@find-usages`         | Find all callers, references, and usages of a component                                    |
-| `@explain-service`     | Top-down walkthrough of how a service or module works                                      |
-
-## Commands
-
-| Command             | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `/graph-status`     | Show overview of indexed nodes by type, list repos and services |
-| `/explore <name>`   | Quick exploration of a named component in the graph             |
-| `/index`            | Index (or re-index) the current project into the knowledge graph |
-| `/interrogate`      | Answer a question about the codebase without making changes      |
-
-## Graph Node Types
-
-Repository, Directory, File, Class, Function, Variable, Dependency, PullRequest, IndexMetadata
-
-## Claude Code Plugin
-
-OpenTrace ships a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins) that connects Claude to an OpenTrace MCP server.
-
-```bash
-claude plugin marketplace add https://github.com/opentrace/opentrace
-claude plugin install opentrace-oss@opentrace-oss
-```
-
-The plugin provides 5 agents, 4 slash commands, and MCP graph tools. See `claude-code-plugin/` for full documentation.
+See [Development Setup](https://opentrace.github.io/opentrace/development/setup/) for prerequisites, commands, and the full dev workflow.
 
 ## Contributing
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -4,7 +4,7 @@
 
 - Node.js 22+ (see `ui/.nvmrc`)
 - npm
-- Python 3.11+ and [uv](https://docs.astral.sh/uv/) (for the agent)
+- Python 3.12+ and [uv](https://docs.astral.sh/uv/) (for the agent)
 
 ## Getting Started
 

--- a/docs/getting-started/install-browser.md
+++ b/docs/getting-started/install-browser.md
@@ -1,0 +1,32 @@
+# Browser (No Install)
+
+The fastest way to try OpenTrace. Everything runs in your browser — no account, no download, no server.
+
+**[oss.opentrace.ai](https://oss.opentrace.ai)**
+
+## How It Works
+
+1. Open [oss.opentrace.ai](https://oss.opentrace.ai).
+2. Paste a GitHub or GitLab repo URL (public repos work with no auth; private repos need a token).
+3. Watch it index — tree-sitter parses every file directly in a Web Worker, and the knowledge graph is stored in an embedded LadybugDB WASM instance.
+4. Explore the graph, or chat with the built-in agent.
+
+Nothing is uploaded. Your code, the parser, and the database all live in your browser tab.
+
+## Requirements
+
+OpenTrace needs **Cross-Origin Isolation** (for `SharedArrayBuffer`), so you need a reasonably modern browser:
+
+- Chrome / Edge 91+
+- Firefox 119+
+- Safari **does not currently work** — see [Browser Requirements](../reference/browser-requirements.md) for the WebKit limitation.
+
+## What Next
+
+- **Want this inside Claude Code?** → [Claude Code Plugin](install-plugin.md)
+- **Want a CLI on your machine?** → [CLI](install-cli.md)
+- **Hitting an unsupported-browser screen?** → [Browser Requirements](../reference/browser-requirements.md)
+
+---
+
+*Other install paths: [Browser](install-browser.md) · [CLI](install-cli.md) · [Plugin](install-plugin.md) · [Source](../development/setup.md)*

--- a/docs/getting-started/install-cli.md
+++ b/docs/getting-started/install-cli.md
@@ -1,0 +1,79 @@
+# CLI
+
+Install the `opentraceai` command-line tool to index repositories and run an MCP server from your terminal.
+
+## Prerequisites
+
+- **Python 3.11+**
+- **[`uv`](https://docs.astral.sh/uv/)** recommended — makes `uvx` and isolated installs trivial. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
+## Install
+
+=== "uvx (try without installing)"
+
+    Run OpenTrace without installing it globally — `uvx` downloads and caches it on first use.
+
+    ```bash
+    uvx opentraceai index .
+    ```
+
+    Best for: kicking the tires, or using it from a CI job.
+
+=== "uv tool (recommended)"
+
+    Install globally in an isolated environment managed by `uv`. Re-running the command upgrades it in place.
+
+    ```bash
+    uv tool install opentraceai --upgrade
+    opentraceai index .
+    ```
+
+    Best for: daily use from any shell. This is the recommended permanent install.
+
+=== "pip"
+
+    Install into your current Python environment (ideally a venv).
+
+    ```bash
+    pip install opentraceai
+    opentraceai index .
+    ```
+
+    Best for: an environment you already manage with pip.
+
+=== "pipx"
+
+    Install globally in an isolated environment. Similar to `uv tool install` but via `pipx`.
+
+    ```bash
+    pipx install opentraceai
+    opentraceai index .
+    ```
+
+    Best for: if you already use `pipx` and don't want to install `uv`.
+
+## Using It
+
+```bash
+opentraceai index /path/to/repo   # index a repo into a knowledge graph
+opentraceai mcp                   # start an MCP server over stdio
+opentraceai --help                # see all commands
+```
+
+The graph is stored at `.opentrace/index.db` at the repo root. Every `opentraceai` command walks up from your current directory to find it, so you can run commands from any subdirectory.
+
+## MCP Server
+
+`opentraceai mcp` starts a Model Context Protocol server over stdio. Any MCP-compatible client (Claude Code, Cursor, etc.) can connect to it to query the graph.
+
+If you're using Claude Code, the [plugin](install-plugin.md) handles this for you.
+
+## What Next
+
+- **Run it inside Claude Code?** → [Claude Code Plugin](install-plugin.md) (installs the CLI automatically)
+- **Something not working?** → [Troubleshooting](troubleshooting.md)
+- **See what the graph exposes** → [Graph Tools](../reference/graph-tools.md)
+
+---
+
+*Other install paths: [Browser](install-browser.md) · [CLI](install-cli.md) · [Plugin](install-plugin.md) · [Source](../development/setup.md)*

--- a/docs/getting-started/install-cli.md
+++ b/docs/getting-started/install-cli.md
@@ -5,7 +5,7 @@ Install the `opentraceai` command-line tool to index repositories and run an MCP
 ## Prerequisites
 
 - **Python 3.12+**
-- **[`uv`](https://docs.astral.sh/uv/)** recommended — makes `uvx` and isolated installs trivial. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- **[`uv`](https://docs.astral.sh/uv/)** recommended — makes `uvx` and isolated installs trivial. See the [`uv` install guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 ## Install
 
@@ -25,7 +25,7 @@ Install the `opentraceai` command-line tool to index repositories and run an MCP
 
     ```bash
     uv tool install opentraceai --upgrade
-    opentraceai index .
+    opentrace index .
     ```
 
     Best for: daily use from any shell. This is the recommended permanent install.
@@ -36,7 +36,7 @@ Install the `opentraceai` command-line tool to index repositories and run an MCP
 
     ```bash
     pip install opentraceai
-    opentraceai index .
+    opentrace index .
     ```
 
     Best for: an environment you already manage with pip.
@@ -47,24 +47,26 @@ Install the `opentraceai` command-line tool to index repositories and run an MCP
 
     ```bash
     pipx install opentraceai
-    opentraceai index .
+    opentrace index .
     ```
 
     Best for: if you already use `pipx` and don't want to install `uv`.
 
 ## Using It
 
+The package installs as `opentraceai`, but the CLI binary is `opentrace` (shorter alias — `opentraceai` also works).
+
 ```bash
-opentraceai index /path/to/repo   # index a repo into a knowledge graph
-opentraceai mcp                   # start an MCP server over stdio
-opentraceai --help                # see all commands
+opentrace index /path/to/repo   # index a repo into a knowledge graph
+opentrace mcp                   # start an MCP server over stdio
+opentrace --help                # see all commands
 ```
 
-The graph is stored at `.opentrace/index.db` at the repo root. Every `opentraceai` command walks up from your current directory to find it, so you can run commands from any subdirectory.
+The graph is stored at `.opentrace/index.db` at the repo root. Every `opentrace` command walks up from your current directory to find it, so you can run commands from any subdirectory.
 
 ## MCP Server
 
-`opentraceai mcp` starts a Model Context Protocol server over stdio. Any MCP-compatible client (Claude Code, Cursor, etc.) can connect to it to query the graph.
+`opentrace mcp` starts a Model Context Protocol server over stdio. Any MCP-compatible client (Claude Code, Cursor, etc.) can connect to it to query the graph.
 
 If you're using Claude Code, the [plugin](install-plugin.md) handles this for you.
 

--- a/docs/getting-started/install-cli.md
+++ b/docs/getting-started/install-cli.md
@@ -4,7 +4,7 @@ Install the `opentraceai` command-line tool to index repositories and run an MCP
 
 ## Prerequisites
 
-- **Python 3.11+**
+- **Python 3.12+**
 - **[`uv`](https://docs.astral.sh/uv/)** recommended — makes `uvx` and isolated installs trivial. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
 
 ## Install

--- a/docs/getting-started/install-plugin.md
+++ b/docs/getting-started/install-plugin.md
@@ -1,0 +1,57 @@
+# Claude Code Plugin
+
+The OpenTrace plugin gives [Claude Code](https://docs.anthropic.com/en/docs/claude-code) real codebase awareness — Claude can search the graph, trace dependencies, and explain services without you feeding it files by hand.
+
+## Prerequisites
+
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** installed and working (`claude --version`).
+- **[`uv`](https://docs.astral.sh/uv/)** installed — the plugin uses `uvx` to run the `opentraceai` MCP server. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
+!!! tip "Why `uv`?"
+    The plugin doesn't bundle a Python environment. Instead it invokes `uvx opentraceai mcp`, which lets `uv` handle Python version, dependencies, and caching automatically. If `uv` isn't installed, the MCP server can't start and Claude won't see any graph tools.
+
+## Install
+
+```bash
+claude plugin marketplace add https://github.com/opentrace/opentrace
+claude plugin install opentrace-oss@opentrace-oss
+```
+
+That's the whole install. Restart Claude Code (or start a new session) and the plugin is active.
+
+## First Session
+
+When you start a Claude Code session inside a git repo, the plugin **automatically kicks off a background index**. You don't need to run anything manually — by the time you ask your first question, the graph is usually ready.
+
+If you want explicit control:
+
+```text
+/index           # index (or re-index) the current repo
+/graph-status    # see what's in the graph
+/interrogate     # ask a codebase question without making changes
+/explore <name>  # quick exploration of a named component
+```
+
+## What You Get
+
+- **5 agents** — `@opentrace` (default), `@code-explorer`, `@dependency-analyzer`, `@find-usages`, `@explain-service`
+- **4 slash commands** — `/index`, `/graph-status`, `/explore`, `/interrogate`
+- **5 MCP tools** — `search_graph`, `list_nodes`, `get_node`, `traverse_graph`, `get_stats`
+
+For the full list with descriptions, see the [Claude Code Plugin reference](../reference/claude-code-plugin.md).
+
+## Where the Graph Lives
+
+The plugin stores the graph at `.opentrace/index.db` in your repo. It's auto-discovered by walking up from your current directory to the git root, so any subdirectory works.
+
+You can safely `.gitignore` the `.opentrace/` directory — it's rebuildable from source.
+
+## What Next
+
+- **Full plugin reference** → [Claude Code Plugin](../reference/claude-code-plugin.md)
+- **CLI (same tool, without Claude)** → [CLI](install-cli.md)
+- **Plugin installed but tools missing?** → [Troubleshooting](troubleshooting.md)
+
+---
+
+*Other install paths: [Browser](install-browser.md) · [CLI](install-cli.md) · [Plugin](install-plugin.md) · [Source](../development/setup.md)*

--- a/docs/getting-started/install-plugin.md
+++ b/docs/getting-started/install-plugin.md
@@ -5,17 +5,26 @@ The OpenTrace plugin gives [Claude Code](https://docs.anthropic.com/en/docs/clau
 ## Prerequisites
 
 - **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** installed and working (`claude --version`).
-- **[`uv`](https://docs.astral.sh/uv/)** installed — the plugin uses `uvx` to run the `opentraceai` MCP server. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- **[`uv`](https://docs.astral.sh/uv/)** installed — the plugin uses `uvx` to run the `opentraceai` MCP server. See the [`uv` install guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 !!! tip "Why `uv`?"
     The plugin doesn't bundle a Python environment. Instead it invokes `uvx opentraceai mcp`, which lets `uv` handle Python version, dependencies, and caching automatically. If `uv` isn't installed, the MCP server can't start and Claude won't see any graph tools.
 
 ## Install
 
-```bash
-claude plugin marketplace add https://github.com/opentrace/opentrace
-claude plugin install opentrace-oss@opentrace-oss
-```
+=== "Shell (`claude plugin`)"
+
+    ```bash
+    claude plugin marketplace add https://github.com/opentrace/opentrace
+    claude plugin install opentrace-oss@opentrace-oss
+    ```
+
+=== "Inside Claude Code (`/plugin`)"
+
+    ```text
+    /plugin marketplace add https://github.com/opentrace/opentrace
+    /plugin install opentrace-oss@opentrace-oss
+    ```
 
 That's the whole install. Restart Claude Code (or start a new session) and the plugin is active.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,28 +1,62 @@
-# Quick Start
+# Pick Your Path
 
-## Prerequisites
+OpenTrace has four ways in. Pick the one that matches what you want to do.
 
-- Node.js 22+ (see `ui/.nvmrc`)
-- npm
-- Python 3.11+ and [uv](https://docs.astral.sh/uv/) (for the agent)
+| You want to…                          | Use                              | Time       | Guide |
+|---------------------------------------|----------------------------------|------------|-------|
+| See what OpenTrace is                 | Browser                          | 30 seconds | [Browser](install-browser.md) |
+| Give Claude Code codebase awareness   | Claude Code plugin               | 2 minutes  | [Plugin](install-plugin.md) |
+| Index repos from a terminal           | CLI (`uvx` / `pip` / `pipx`)     | 2 minutes  | [CLI](install-cli.md) |
+| Hack on OpenTrace itself              | Source build                     | 5 minutes  | [Development Setup](../development/setup.md) |
 
-## Installation
+## One-Liners
 
-```bash
-git clone https://github.com/opentrace/opentrace.git
-cd opentrace
-make install
-make ui
-```
+If you already know which path you want:
 
-Open [http://localhost:5173](http://localhost:5173), add a GitHub repo, and explore the graph.
+=== "Browser"
 
-## What Happens
+    Open [**oss.opentrace.ai**](https://oss.opentrace.ai) and paste a repo URL. Done.
 
-When you add a repository, OpenTrace will:
+=== "Claude Code Plugin"
 
-1. Fetch the source code via the GitHub/GitLab API
-2. Parse every file using tree-sitter WASM grammars
-3. Extract symbols (classes, functions, imports) and relationships
-4. Build a knowledge graph in an embedded LadybugDB instance
-5. Make the graph available for exploration and querying
+    ```bash
+    claude plugin marketplace add https://github.com/opentrace/opentrace
+    claude plugin install opentrace-oss@opentrace-oss
+    ```
+
+    Requires [`uv`](https://docs.astral.sh/uv/). The plugin auto-indexes your repo on session start.
+
+=== "CLI"
+
+    ```bash
+    uvx opentraceai index .          # try without installing
+    # or
+    pip install opentraceai
+    ```
+
+    Requires Python 3.11+.
+
+=== "Source"
+
+    ```bash
+    git clone https://github.com/opentrace/opentrace.git
+    cd opentrace
+    make install
+    make ui
+    ```
+
+    Requires Node 22+ and Python 3.11+ with `uv`.
+
+## What Happens When You Index
+
+Regardless of path, when OpenTrace indexes a repo it will:
+
+1. Fetch or read the source code.
+2. Parse every file using tree-sitter WASM grammars.
+3. Extract symbols (classes, functions, imports) and call relationships.
+4. Build a knowledge graph in an embedded LadybugDB instance.
+5. Make the graph available for exploration and querying.
+
+## Something Not Working?
+
+See [Troubleshooting](troubleshooting.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -34,7 +34,7 @@ If you already know which path you want:
     pip install opentraceai
     ```
 
-    Requires Python 3.11+.
+    Requires Python 3.12+.
 
 === "Source"
 
@@ -45,7 +45,7 @@ If you already know which path you want:
     make ui
     ```
 
-    Requires Node 22+ and Python 3.11+ with `uv`.
+    Requires Node 22+ and Python 3.12+ with `uv`.
 
 ## What Happens When You Index
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -29,12 +29,14 @@ If you already know which path you want:
 === "CLI"
 
     ```bash
-    uvx opentraceai index .          # try without installing
-    # or
+    uvx opentraceai index .                  # try without installing
+    # or — permanent install (pick one):
+    uv tool install opentraceai --upgrade    # recommended
+    pipx install opentraceai
     pip install opentraceai
     ```
 
-    Requires Python 3.12+.
+    Requires Python 3.12+. See the [CLI guide](install-cli.md) for when to pick each.
 
 === "Source"
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -48,7 +48,7 @@ See [Configuration](configuration.md) for details.
 ## `make install` fails
 
 - **Node version.** OpenTrace needs Node.js 22+. Check with `node --version`; see `ui/.nvmrc`.
-- **Python version.** The agent needs Python 3.11+. Check with `python --version`.
+- **Python version.** The agent needs Python 3.12+. Check with `python --version`.
 - **Missing `uv`.** The agent install uses `uv sync`. Install `uv` as above.
 
 ## Something else

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -6,11 +6,7 @@ Common install issues and how to fix them.
 
 The plugin and the "try without installing" CLI path both need [`uv`](https://docs.astral.sh/uv/) (which provides `uvx`).
 
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-Then open a new shell (or `source` your profile) so `uvx` is on `PATH`.
+See the [`uv` install guide](https://docs.astral.sh/uv/getting-started/installation/). After installing, open a new shell so `uvx` is on `PATH`.
 
 ## `command not found: claude`
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -1,0 +1,60 @@
+# Troubleshooting
+
+Common install issues and how to fix them.
+
+## `command not found: uvx`
+
+The plugin and the "try without installing" CLI path both need [`uv`](https://docs.astral.sh/uv/) (which provides `uvx`).
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Then open a new shell (or `source` your profile) so `uvx` is on `PATH`.
+
+## `command not found: claude`
+
+Claude Code isn't installed. See the [Claude Code install guide](https://docs.anthropic.com/en/docs/claude-code) — then come back and install the plugin.
+
+## Plugin installed but Claude has no graph tools
+
+1. **Restart Claude Code.** Plugins are loaded at session start; an existing session won't pick one up.
+2. **Check `uv` is installed.** The plugin runs `uvx opentraceai mcp` — without `uv`, the MCP server silently fails to start. See the first entry above.
+3. **Verify the plugin is listed.** Run `claude plugin list` and make sure `opentrace-oss` is present.
+4. **Check plugin logs.** Look in `~/.claude/logs/` for MCP startup errors.
+
+## `opentraceai index` hangs or fails
+
+- **No write permissions on `.opentrace/`.** The database is written to `.opentrace/index.db` at the repo root. If the directory exists but isn't writable, indexing hangs on the first save. Fix: `chmod -R u+w .opentrace/` or delete the directory and re-index.
+- **Not in a git repo.** `opentraceai` walks up from your current directory looking for the git root. If there isn't one, it falls back to the current directory — make sure that's what you want.
+
+## Browser shows "unsupported browser"
+
+OpenTrace needs Cross-Origin Isolation, which means:
+
+- Chrome / Edge 91+, Firefox 119+.
+- **Safari does not currently work** — see [Browser Requirements](../reference/browser-requirements.md).
+- Link-preview embedded browsers (Slack, Discord, iMessage) don't support it either. Open the URL in a real browser tab.
+
+## Port 5173 already in use (source build)
+
+```bash
+cd ui
+PORT=5174 npm run dev
+```
+
+See [Configuration](configuration.md) for details.
+
+## `make install` fails
+
+- **Node version.** OpenTrace needs Node.js 22+. Check with `node --version`; see `ui/.nvmrc`.
+- **Python version.** The agent needs Python 3.11+. Check with `python --version`.
+- **Missing `uv`.** The agent install uses `uv sync`. Install `uv` as above.
+
+## Something else
+
+Open an issue: [github.com/opentrace/opentrace/issues](https://github.com/opentrace/opentrace/issues).
+
+---
+
+*Install paths: [Browser](install-browser.md) · [CLI](install-cli.md) · [Plugin](install-plugin.md) · [Source](../development/setup.md)*

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,27 +4,37 @@ A knowledge graph that maps your codebase structure, service architecture, and s
 
 **[Try it now at oss.opentrace.ai](https://oss.opentrace.ai)** — no install required, runs entirely in your browser.
 
+## Where to Start
+
+| Goal                                  | Start here |
+|---------------------------------------|------------|
+| See what OpenTrace is                 | [Browser (no install)](getting-started/install-browser.md) |
+| Give Claude Code codebase awareness   | [Claude Code Plugin](getting-started/install-plugin.md) |
+| Index repos from a terminal           | [CLI](getting-started/install-cli.md) |
+| Hack on OpenTrace itself              | [Development Setup](development/setup.md) |
+
+Not sure? → [Pick Your Path](getting-started/quickstart.md)
+
 ## What It Does
 
-OpenTrace indexes source code directly in your browser — no server required. Point it at a GitHub or GitLab repo and it will:
+OpenTrace indexes source code and builds a queryable knowledge graph. Point it at a repo and it will:
 
 1. **Parse** every file using tree-sitter WASM grammars (12 languages)
 2. **Extract** classes, functions, imports, and call relationships
-3. **Build** a knowledge graph stored in LadybugDB WASM (embedded graph database)
+3. **Build** a knowledge graph stored in LadybugDB (embedded graph database)
 4. **Summarize** every node using template-based identifier analysis
-5. **Expose** the graph to an in-app chat agent via MCP tools
+5. **Expose** the graph via MCP tools to any compatible AI client
 
-## Quick Start
+See [Architecture Overview](architecture/overview.md) for how the pieces fit together.
 
-```bash
-git clone https://github.com/opentrace/opentrace.git
-cd opentrace
-make install
-make ui
-```
+## Learn More
 
-Open [http://localhost:5173](http://localhost:5173), add a GitHub repo, and explore the graph.
+- **[Graph Tools](reference/graph-tools.md)** — the MCP tools exposed to AI agents
+- **[Supported Languages](reference/languages.md)** — full vs. structural extraction
+- **[Claude Code Plugin](reference/claude-code-plugin.md)** — agents, commands, and tools
+- **[Browser Requirements](reference/browser-requirements.md)** — why Safari doesn't work
+- **[Contributing](development/contributing.md)** — help improve OpenTrace
 
-## License
+## Source
 
-Apache License 2.0 — see [LICENSE](https://github.com/opentrace/opentrace/blob/main/LICENSE) for details.
+OpenTrace is open source under Apache 2.0 — [github.com/opentrace/opentrace](https://github.com/opentrace/opentrace).

--- a/docs/reference/claude-code-plugin.md
+++ b/docs/reference/claude-code-plugin.md
@@ -2,17 +2,8 @@
 
 OpenTrace ships a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins) that connects Claude to the OpenTrace knowledge graph. Once installed, Claude can explore your indexed codebase — find components, trace dependencies, and answer architecture questions.
 
-## Installation
-
-```bash
-claude plugin install opentrace-oss@opentrace-oss
-```
-
-The plugin requires the `opentraceai` CLI. Install it with:
-
-```bash
-uvx opentraceai --help
-```
+!!! info "New here?"
+    This page is the **reference** for what's inside the plugin. For install instructions, see [Claude Code Plugin install](../getting-started/install-plugin.md).
 
 ## How It Works
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,12 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started:
-      - Quick Start: getting-started/quickstart.md
+      - Pick Your Path: getting-started/quickstart.md
+      - Browser: getting-started/install-browser.md
+      - CLI: getting-started/install-cli.md
+      - Claude Code Plugin: getting-started/install-plugin.md
       - Configuration: getting-started/configuration.md
+      - Troubleshooting: getting-started/troubleshooting.md
   - Architecture:
       - Overview: architecture/overview.md
   - Development:


### PR DESCRIPTION
## Audience-specific installation guides and documentation restructure
📝 **Docs** · ✨ **Improvement**

This PR replaces the monolithic Quick Start section in the README with a decision table routing users to four specialized installation guides. 

It introduces dedicated pages for Browser, CLI, Claude Code Plugin, and Source builds to provide scoped prerequisites and targeted troubleshooting for each audience.

### Complexity
🟢 Low · `9 files changed, 350 insertions(+), 179 deletions(-)`

Documentation-only restructure with moderate scope but no functional code changes. Review effort is primarily focused on information layout and link validity.

### Review focus
Pay particular attention to the following areas:

- **Internal link integrity** — verify that relative paths between the root README and the new `/docs` subdirectories resolve correctly.
- **Prerequisite visibility** — check that the `uv` requirement is clearly highlighted for both CLI and Plugin users.
- **Compatibility notice** — confirm the Safari limitation is clearly documented in the Browser guide and troubleshooting page.
<!-- opentrace:jid=a7b51ccc-6d8f-4fc8-a3c0-3d58184c91f6|sha=fcb06ab80368f8ef6860f34628c4ef3506e40427 -->