### PR TITLE
fix(agent): allow concurrent index while MCP server is running

### DIFF
--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -382,14 +382,15 @@ def stats(db_path: str | None, output_format: str) -> None:
 
 
 class _ReloadableStore:
-    """Mutable GraphStore handle that reopens when the DB file is replaced.
+    """Transparent proxy for GraphStore that reopens when the DB file is replaced.
 
     LadybugDB uses exclusive file locking, so a long-running reader (MCP)
     blocks writers (``opentrace index``).  The indexer works around this by
     writing to a staging file and atomically renaming it over the original.
 
-    This class detects the rename (via inode change) and transparently
-    reopens the database on the next access.
+    This proxy detects the rename (via inode change) and transparently
+    reopens the database.  Attribute access is delegated to the inner
+    store, so callers treat this as a regular ``GraphStore``.
     """
 
     def __init__(self, db_path: str | None, store: object | None) -> None:
@@ -399,6 +400,8 @@ class _ReloadableStore:
         self._lock = threading.Lock()
         self._log = logging.getLogger("opentrace_agent.mcp.reload")
 
+    # -- inode helpers -------------------------------------------------------
+
     def _stat_inode(self) -> int | None:
         if self._db_path is None:
             return None
@@ -407,20 +410,18 @@ class _ReloadableStore:
         except OSError:
             return None
 
-    def get(self) -> object | None:
-        """Return the current store, reopening if the DB file changed.
+    def _maybe_reload(self) -> None:
+        """Reopen the database if the file's inode has changed.
 
-        Thread-safe: FastMCP may dispatch tool calls from a thread pool,
-        so we serialize the inode check + reopen with a lock.
+        Thread-safe: FastMCP may dispatch tool calls from a thread pool.
         """
         if self._db_path is None:
-            return self._store
+            return
 
         with self._lock:
-            # Re-check inode under the lock (double-checked).
             current_inode = self._stat_inode()
             if current_inode == self._inode:
-                return self._store
+                return
 
             self._log.info(
                 "Database file changed (inode %s → %s), reopening",
@@ -449,7 +450,18 @@ class _ReloadableStore:
                 except Exception as e:
                     self._log.warning("Failed to reopen database: %s", e)
 
-            return self._store
+    # -- proxy protocol ------------------------------------------------------
+
+    def __bool__(self) -> bool:
+        self._maybe_reload()
+        return self._store is not None
+
+    def __getattr__(self, name: str) -> object:
+        self._maybe_reload()
+        store = self._store
+        if store is None:
+            raise AttributeError(name)
+        return getattr(store, name)
 
     def close(self) -> None:
         with self._lock:
@@ -511,7 +523,7 @@ def mcp_cmd(db_path: str | None, verbose: bool) -> None:
     signal.signal(signal.SIGTERM, _shutdown)
 
     try:
-        server = create_mcp_server(reloadable.get)
+        server = create_mcp_server(reloadable)
         log.debug("MCP server running on stdio")
         server.run(transport="stdio")
     except KeyboardInterrupt:

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import time
 from pathlib import Path
@@ -184,28 +185,42 @@ def index(
     db_dir.mkdir(parents=True, exist_ok=True)
     _ensure_gitignore(db_dir)
 
+    # Write to a staging file so we don't contend with readers (MCP)
+    # that hold an exclusive lock on the live database.
+    staging_db = resolved_db + ".staging"
+
     click.echo(f"Opening database at {resolved_db} ...")
-    graph_store = GraphStore(resolved_db)
-    store = GraphStoreAdapter(graph_store, batch_size=batch_size)
+    try:
+        graph_store = GraphStore(staging_db)
+        store = GraphStoreAdapter(graph_store, batch_size=batch_size)
 
-    click.echo(f"Indexing {root} ...")
-    t0 = time.monotonic()
+        click.echo(f"Indexing {root} ...")
+        t0 = time.monotonic()
 
-    inp = PipelineInput(path=str(root), repo_id=repo_id)
+        inp = PipelineInput(path=str(root), repo_id=repo_id)
 
-    last_result = None
-    for event in run_pipeline(inp, store=store):
-        _print_event(event, verbose)
-        if getattr(event, "result", None) is not None:
-            last_result = event.result
+        last_result = None
+        for event in run_pipeline(inp, store=store):
+            _print_event(event, verbose)
+            if getattr(event, "result", None) is not None:
+                last_result = event.result
 
-    elapsed = time.monotonic() - t0
+        elapsed = time.monotonic() - t0
 
-    # Save index metadata.
-    metadata = _collect_metadata(root, repo_id, elapsed, last_result)
-    graph_store.save_metadata(metadata)
+        # Save index metadata.
+        metadata = _collect_metadata(root, repo_id, elapsed, last_result)
+        graph_store.save_metadata(metadata)
 
-    store.close()
+        store.close()
+    except BaseException:
+        # Clean up the staging file on failure.
+        Path(staging_db).unlink(missing_ok=True)
+        raise
+
+    # Atomically replace the live database.  Readers holding the old
+    # file descriptor continue to see the previous data until they
+    # detect the inode change and reopen.
+    os.replace(staging_db, resolved_db)
 
     click.echo(f"Done in {elapsed:.1f}s.")
 
@@ -363,6 +378,67 @@ def stats(db_path: str | None, output_format: str) -> None:
             click.echo(f"  Indexed: {', '.join(parts)}")
 
 
+class _ReloadableStore:
+    """Mutable GraphStore handle that reopens when the DB file is replaced.
+
+    LadybugDB uses exclusive file locking, so a long-running reader (MCP)
+    blocks writers (``opentrace index``).  The indexer works around this by
+    writing to a staging file and atomically renaming it over the original.
+
+    This class detects the rename (via inode change) and transparently
+    reopens the database on the next access.
+    """
+
+    def __init__(self, db_path: str | None, store: object | None) -> None:
+        self._db_path = db_path
+        self._store = store
+        self._inode = self._stat_inode()
+        self._log = logging.getLogger("opentrace_agent.mcp.reload")
+
+    def _stat_inode(self) -> int | None:
+        if self._db_path is None:
+            return None
+        try:
+            return os.stat(self._db_path).st_ino
+        except OSError:
+            return None
+
+    def get(self) -> object | None:
+        """Return the current store, reopening if the DB file changed."""
+        if self._db_path is None:
+            return self._store
+
+        current_inode = self._stat_inode()
+        if current_inode == self._inode:
+            return self._store
+
+        # File was replaced (or removed).
+        self._log.info("Database file changed (inode %s → %s), reopening", self._inode, current_inode)
+        if self._store is not None:
+            try:
+                self._store.close()
+            except Exception:
+                pass
+
+        self._store = None
+        self._inode = current_inode
+
+        if current_inode is not None:
+            from opentrace_agent.store import GraphStore
+
+            try:
+                self._store = GraphStore(self._db_path, read_only=True)
+            except Exception as e:
+                self._log.warning("Failed to reopen database: %s", e)
+
+        return self._store
+
+    def close(self) -> None:
+        if self._store is not None:
+            self._store.close()
+            self._store = None
+
+
 @app.command("mcp")
 @click.option(
     "--db",
@@ -377,7 +453,7 @@ def mcp_cmd(db_path: str | None, verbose: bool) -> None:
     _configure_logging(verbose)
     log = logging.getLogger("opentrace_agent.mcp")
 
-    log.debug("MCP server starting (pid=%d)", __import__("os").getpid())
+    log.debug("MCP server starting (pid=%d)", os.getpid())
 
     from opentrace_agent.cli.mcp_server import create_mcp_server
     from opentrace_agent.store import GraphStore
@@ -406,16 +482,17 @@ def mcp_cmd(db_path: str | None, verbose: bool) -> None:
             stats["total_edges"],
         )
 
+    reloadable = _ReloadableStore(resolved_db, store)
+
     def _shutdown(signum: int, _frame: object) -> None:
         log.debug("Received signal %d, shutting down", signum)
-        if store is not None:
-            store.close()
+        reloadable.close()
         raise SystemExit(0)
 
     signal.signal(signal.SIGTERM, _shutdown)
 
     try:
-        server = create_mcp_server(store)
+        server = create_mcp_server(reloadable.get)
         log.debug("MCP server running on stdio")
         server.run(transport="stdio")
     except KeyboardInterrupt:
@@ -424,8 +501,7 @@ def mcp_cmd(db_path: str | None, verbose: bool) -> None:
         log.error("MCP server error: %s", e, exc_info=True)
         raise
     finally:
-        if store is not None:
-            store.close()
+        reloadable.close()
         log.debug("MCP server stopped")
 
 

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import threading
 import time
 from pathlib import Path
 
@@ -189,29 +190,31 @@ def index(
     # that hold an exclusive lock on the live database.
     staging_db = resolved_db + ".staging"
 
-    click.echo(f"Opening database at {resolved_db} ...")
+    click.echo(f"Opening staging database at {staging_db} ...")
     try:
-        graph_store = GraphStore(staging_db)
-        store = GraphStoreAdapter(graph_store, batch_size=batch_size)
+        with GraphStore(staging_db) as graph_store:
+            store = GraphStoreAdapter(graph_store, batch_size=batch_size)
 
-        click.echo(f"Indexing {root} ...")
-        t0 = time.monotonic()
+            click.echo(f"Indexing {root} ...")
+            t0 = time.monotonic()
 
-        inp = PipelineInput(path=str(root), repo_id=repo_id)
+            inp = PipelineInput(path=str(root), repo_id=repo_id)
 
-        last_result = None
-        for event in run_pipeline(inp, store=store):
-            _print_event(event, verbose)
-            if getattr(event, "result", None) is not None:
-                last_result = event.result
+            last_result = None
+            for event in run_pipeline(inp, store=store):
+                _print_event(event, verbose)
+                if getattr(event, "result", None) is not None:
+                    last_result = event.result
 
-        elapsed = time.monotonic() - t0
+            elapsed = time.monotonic() - t0
 
-        # Save index metadata.
-        metadata = _collect_metadata(root, repo_id, elapsed, last_result)
-        graph_store.save_metadata(metadata)
+            # Save index metadata.
+            metadata = _collect_metadata(root, repo_id, elapsed, last_result)
+            graph_store.save_metadata(metadata)
 
-        store.close()
+            # Flush pending batches; the GraphStore is closed by the
+            # context manager on exit.
+            store.flush()
     except BaseException:
         # Clean up the staging file on failure.
         Path(staging_db).unlink(missing_ok=True)
@@ -393,6 +396,7 @@ class _ReloadableStore:
         self._db_path = db_path
         self._store = store
         self._inode = self._stat_inode()
+        self._lock = threading.Lock()
         self._log = logging.getLogger("opentrace_agent.mcp.reload")
 
     def _stat_inode(self) -> int | None:
@@ -404,39 +408,54 @@ class _ReloadableStore:
             return None
 
     def get(self) -> object | None:
-        """Return the current store, reopening if the DB file changed."""
+        """Return the current store, reopening if the DB file changed.
+
+        Thread-safe: FastMCP may dispatch tool calls from a thread pool,
+        so we serialize the inode check + reopen with a lock.
+        """
         if self._db_path is None:
             return self._store
 
-        current_inode = self._stat_inode()
-        if current_inode == self._inode:
+        with self._lock:
+            # Re-check inode under the lock (double-checked).
+            current_inode = self._stat_inode()
+            if current_inode == self._inode:
+                return self._store
+
+            self._log.info(
+                "Database file changed (inode %s → %s), reopening",
+                self._inode,
+                current_inode,
+            )
+
+            # Close the old store first.  LadybugDB associates a WAL file
+            # with the open database; if we tried to open the new file
+            # while the old store still holds its WAL open, the new open
+            # would fail with a "Database ID does not match" error.
+            if self._store is not None:
+                try:
+                    self._store.close()
+                except Exception:
+                    pass
+
+            self._store = None
+            self._inode = current_inode
+
+            if current_inode is not None:
+                from opentrace_agent.store import GraphStore
+
+                try:
+                    self._store = GraphStore(self._db_path, read_only=True)
+                except Exception as e:
+                    self._log.warning("Failed to reopen database: %s", e)
+
             return self._store
 
-        # File was replaced (or removed).
-        self._log.info("Database file changed (inode %s → %s), reopening", self._inode, current_inode)
-        if self._store is not None:
-            try:
-                self._store.close()
-            except Exception:
-                pass
-
-        self._store = None
-        self._inode = current_inode
-
-        if current_inode is not None:
-            from opentrace_agent.store import GraphStore
-
-            try:
-                self._store = GraphStore(self._db_path, read_only=True)
-            except Exception as e:
-                self._log.warning("Failed to reopen database: %s", e)
-
-        return self._store
-
     def close(self) -> None:
-        if self._store is not None:
-            self._store.close()
-            self._store = None
+        with self._lock:
+            if self._store is not None:
+                self._store.close()
+                self._store = None
 
 
 @app.command("mcp")

--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import traceback
+from collections.abc import Callable
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -54,12 +55,24 @@ NO_INDEX_MSG = json.dumps(
 )
 
 
-def create_mcp_server(store: GraphStore | None) -> FastMCP:
-    """Create a FastMCP server with graph query tools backed by *store*.
+def create_mcp_server(store: GraphStore | Callable[[], GraphStore | None] | None) -> FastMCP:
+    """Create a FastMCP server with graph query tools.
 
-    When *store* is ``None`` (no database found), every tool returns a
-    friendly "no index" response instead of raising an error.
+    *store* can be a :class:`GraphStore`, ``None``, or a **callable** that
+    returns a ``GraphStore | None`` on each invocation.  The callable form
+    lets the MCP server pick up a replaced database file without restarting.
+
+    When the resolved store is ``None``, every tool returns a friendly
+    "no index" response instead of raising an error.
     """
+    if callable(store):
+        get_store = store
+    else:
+        _fixed = store
+
+        def get_store() -> GraphStore | None:
+            return _fixed
+
     server = FastMCP("opentrace")
 
     @server.tool()
@@ -68,6 +81,7 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
 
         Returns matching nodes with their types and properties.
         """
+        store = get_store()
         if store is None:
             logger.info("search_graph called but no index exists")
             return NO_INDEX_MSG
@@ -88,6 +102,7 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
         Valid types include: Repository, Class, Function, File, Directory,
         Package, Module, Service, Endpoint, Database.
         """
+        store = get_store()
         if store is None:
             logger.info("list_nodes called but no index exists")
             return NO_INDEX_MSG
@@ -103,6 +118,7 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
     @server.tool()
     def get_node(nodeId: str) -> str:
         """Get full details of a single node by its ID, including all properties and immediate neighbors."""
+        store = get_store()
         if store is None:
             logger.info("get_node called but no index exists")
             return NO_INDEX_MSG
@@ -136,6 +152,7 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
         Direction can be 'outgoing', 'incoming', or 'both'.
         Optionally filter by relationship type (e.g. 'CALLS', 'DEFINES', 'CONTAINS').
         """
+        store = get_store()
         if store is None:
             logger.info("traverse_graph called but no index exists")
             return NO_INDEX_MSG
@@ -171,6 +188,7 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
 
         Use this as a first step to understand what has been indexed before running targeted queries.
         """
+        store = get_store()
         if store is None:
             logger.info("get_stats called but no index exists")
             return NO_INDEX_MSG

--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import logging
 import traceback
-from collections.abc import Callable
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -55,24 +54,12 @@ NO_INDEX_MSG = json.dumps(
 )
 
 
-def create_mcp_server(store: GraphStore | Callable[[], GraphStore | None] | None) -> FastMCP:
-    """Create a FastMCP server with graph query tools.
+def create_mcp_server(store: GraphStore | None) -> FastMCP:
+    """Create a FastMCP server with graph query tools backed by *store*.
 
-    *store* can be a :class:`GraphStore`, ``None``, or a **callable** that
-    returns a ``GraphStore | None`` on each invocation.  The callable form
-    lets the MCP server pick up a replaced database file without restarting.
-
-    When the resolved store is ``None``, every tool returns a friendly
-    "no index" response instead of raising an error.
+    When *store* is ``None`` (no database found), every tool returns a
+    friendly "no index" response instead of raising an error.
     """
-    if callable(store):
-        get_store = store
-    else:
-        _fixed = store
-
-        def get_store() -> GraphStore | None:
-            return _fixed
-
     server = FastMCP("opentrace")
 
     @server.tool()
@@ -81,8 +68,7 @@ def create_mcp_server(store: GraphStore | Callable[[], GraphStore | None] | None
 
         Returns matching nodes with their types and properties.
         """
-        store = get_store()
-        if store is None:
+        if not store:
             logger.info("search_graph called but no index exists")
             return NO_INDEX_MSG
         logger.debug("search_graph(query=%r, limit=%d, nodeTypes=%r)", query, limit, nodeTypes)
@@ -102,8 +88,7 @@ def create_mcp_server(store: GraphStore | Callable[[], GraphStore | None] | None
         Valid types include: Repository, Class, Function, File, Directory,
         Package, Module, Service, Endpoint, Database.
         """
-        store = get_store()
-        if store is None:
+        if not store:
             logger.info("list_nodes called but no index exists")
             return NO_INDEX_MSG
         logger.debug("list_nodes(type=%r, limit=%d, filters=%r)", type, limit, filters)
@@ -118,8 +103,7 @@ def create_mcp_server(store: GraphStore | Callable[[], GraphStore | None] | None
     @server.tool()
     def get_node(nodeId: str) -> str:
         """Get full details of a single node by its ID, including all properties and immediate neighbors."""
-        store = get_store()
-        if store is None:
+        if not store:
             logger.info("get_node called but no index exists")
             return NO_INDEX_MSG
         logger.debug("get_node(nodeId=%r)", nodeId)
@@ -152,8 +136,7 @@ def create_mcp_server(store: GraphStore | Callable[[], GraphStore | None] | None
         Direction can be 'outgoing', 'incoming', or 'both'.
         Optionally filter by relationship type (e.g. 'CALLS', 'DEFINES', 'CONTAINS').
         """
-        store = get_store()
-        if store is None:
+        if not store:
             logger.info("traverse_graph called but no index exists")
             return NO_INDEX_MSG
         logger.debug(
@@ -188,8 +171,7 @@ def create_mcp_server(store: GraphStore | Callable[[], GraphStore | None] | None
 
         Use this as a first step to understand what has been indexed before running targeted queries.
         """
-        store = get_store()
-        if store is None:
+        if not store:
             logger.info("get_stats called but no index exists")
             return NO_INDEX_MSG
         logger.debug("get_stats()")

--- a/agent/tests/opentrace_agent/cli/test_reloadable_store.py
+++ b/agent/tests/opentrace_agent/cli/test_reloadable_store.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for _ReloadableStore — inode-based database hot-reload."""
+"""Tests for _ReloadableStore — inode-based database hot-reload proxy."""
 
 from __future__ import annotations
 
@@ -37,14 +37,14 @@ def _create_db(path: str, node_id: str = "n1") -> GraphStore:
 
 
 class TestReloadableStore:
-    def test_returns_store_when_unchanged(self, tmp_path):
+    def test_truthy_when_store_exists(self, tmp_path):
         db = str(tmp_path / "test.db")
         store = _create_db(db)
 
         reloadable = _ReloadableStore(db, store)
-        assert reloadable.get() is store
-        # Calling again still returns the same instance.
-        assert reloadable.get() is store
+        assert reloadable  # truthy
+        # Proxy delegates attribute access to the inner store.
+        assert reloadable.get_node("n1") is not None
         reloadable.close()
 
     def test_reopens_on_inode_change(self, tmp_path):
@@ -54,43 +54,37 @@ class TestReloadableStore:
         original = _create_db(db, node_id="original")
         reloadable = _ReloadableStore(db, original)
 
-        # Verify initial state.
-        s = reloadable.get()
-        assert s is not None
-        assert s.get_node("original") is not None
+        assert reloadable.get_node("original") is not None
 
         # Write a new DB with different content and atomically replace.
         replacement = _create_db(staging, node_id="replaced")
         replacement.close()
         os.replace(staging, db)
 
-        # Next get() should detect the inode change and reopen.
-        s2 = reloadable.get()
-        assert s2 is not original  # Different instance.
-        assert s2 is not None
-        assert s2.get_node("replaced") is not None
-        assert s2.get_node("original") is None
+        # Proxy should detect the inode change and serve new data.
+        assert reloadable.get_node("replaced") is not None
+        assert reloadable.get_node("original") is None
 
         reloadable.close()
 
-    def test_handles_missing_file(self, tmp_path):
+    def test_falsy_when_file_removed(self, tmp_path):
         db = str(tmp_path / "test.db")
         store = _create_db(db)
 
         reloadable = _ReloadableStore(db, store)
-        assert reloadable.get() is store
+        assert reloadable
 
         # Remove the DB file.
         os.unlink(db)
 
-        # Next get() should detect the disappearance and return None.
-        assert reloadable.get() is None
+        # Proxy should become falsy.
+        assert not reloadable
         reloadable.close()
 
-    def test_handles_no_db_path(self):
-        """When db_path is None, always returns the initial store."""
+    def test_falsy_when_no_db_path(self):
+        """When db_path is None, proxy is always falsy."""
         reloadable = _ReloadableStore(None, None)
-        assert reloadable.get() is None
+        assert not reloadable
         reloadable.close()
 
     def test_recovers_after_file_reappears(self, tmp_path):
@@ -101,15 +95,14 @@ class TestReloadableStore:
 
         # Remove the DB file.
         os.unlink(db)
-        assert reloadable.get() is None
+        assert not reloadable
 
         # Re-create a DB at the same path.
         new_store = _create_db(db, node_id="recovered")
         new_store.close()
 
-        s = reloadable.get()
-        assert s is not None
-        assert s.get_node("recovered") is not None
+        assert reloadable
+        assert reloadable.get_node("recovered") is not None
         reloadable.close()
 
     def test_close_is_idempotent(self, tmp_path):

--- a/agent/tests/opentrace_agent/cli/test_reloadable_store.py
+++ b/agent/tests/opentrace_agent/cli/test_reloadable_store.py
@@ -1,0 +1,121 @@
+# Copyright 2026 OpenTrace Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for _ReloadableStore — inode-based database hot-reload."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("real_ladybug")
+
+from opentrace_agent.cli.main import _ReloadableStore  # noqa: E402
+from opentrace_agent.store import GraphStore  # noqa: E402
+
+
+def _create_db(path: str, node_id: str = "n1") -> GraphStore:
+    """Create a small GraphStore at *path* with one node."""
+    store = GraphStore(path)
+    store.add_node(node_id, "File", node_id)
+    return store
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestReloadableStore:
+    def test_returns_store_when_unchanged(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        store = _create_db(db)
+
+        reloadable = _ReloadableStore(db, store)
+        assert reloadable.get() is store
+        # Calling again still returns the same instance.
+        assert reloadable.get() is store
+        reloadable.close()
+
+    def test_reopens_on_inode_change(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        staging = str(tmp_path / "test.db.staging")
+
+        original = _create_db(db, node_id="original")
+        reloadable = _ReloadableStore(db, original)
+
+        # Verify initial state.
+        s = reloadable.get()
+        assert s is not None
+        assert s.get_node("original") is not None
+
+        # Write a new DB with different content and atomically replace.
+        replacement = _create_db(staging, node_id="replaced")
+        replacement.close()
+        os.replace(staging, db)
+
+        # Next get() should detect the inode change and reopen.
+        s2 = reloadable.get()
+        assert s2 is not original  # Different instance.
+        assert s2 is not None
+        assert s2.get_node("replaced") is not None
+        assert s2.get_node("original") is None
+
+        reloadable.close()
+
+    def test_handles_missing_file(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        store = _create_db(db)
+
+        reloadable = _ReloadableStore(db, store)
+        assert reloadable.get() is store
+
+        # Remove the DB file.
+        os.unlink(db)
+
+        # Next get() should detect the disappearance and return None.
+        assert reloadable.get() is None
+        reloadable.close()
+
+    def test_handles_no_db_path(self):
+        """When db_path is None, always returns the initial store."""
+        reloadable = _ReloadableStore(None, None)
+        assert reloadable.get() is None
+        reloadable.close()
+
+    def test_recovers_after_file_reappears(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        store = _create_db(db)
+
+        reloadable = _ReloadableStore(db, store)
+
+        # Remove the DB file.
+        os.unlink(db)
+        assert reloadable.get() is None
+
+        # Re-create a DB at the same path.
+        new_store = _create_db(db, node_id="recovered")
+        new_store.close()
+
+        s = reloadable.get()
+        assert s is not None
+        assert s.get_node("recovered") is not None
+        reloadable.close()
+
+    def test_close_is_idempotent(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        store = _create_db(db)
+        reloadable = _ReloadableStore(db, store)
+
+        reloadable.close()
+        reloadable.close()  # Should not raise.

--- a/agent/tests/opentrace_agent/graph/test_mcp_integration.py
+++ b/agent/tests/opentrace_agent/graph/test_mcp_integration.py
@@ -21,6 +21,7 @@ GraphStore, then exercises every MCP tool against the resulting graph.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -440,3 +441,85 @@ class TestMCPRoundTrip:
         # Neighbors should include methods or the file it's defined in
         neighbor_types = {n["relationship"]["type"] for n in details["neighbors"]}
         assert len(neighbor_types) > 0
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload: MCP picks up a replaced database
+# ---------------------------------------------------------------------------
+
+
+class TestMCPReload:
+    """Verify that a callable store provider enables hot-reload."""
+
+    def test_callable_provider_returns_fresh_store(self, tmp_path):
+        """MCP tools resolve the store per-request via callable."""
+        db = str(tmp_path / "test.db")
+        store = GraphStore(db)
+        store.add_node("n1", "File", "hello.py")
+        # keep store open — pass a callable that returns it
+
+        server = create_mcp_server(lambda: store)
+        tool = server._tool_manager._tools["get_stats"]
+        result = json.loads(tool.fn())
+        assert result["total_nodes"] >= 1
+        store.close()
+
+    def test_picks_up_replaced_database(self, tmp_path):
+        """Simulates the staging-swap pattern: MCP sees new data after replace."""
+        from opentrace_agent.cli.main import _ReloadableStore
+
+        db = str(tmp_path / "test.db")
+        staging = str(tmp_path / "test.db.staging")
+
+        # Create original DB with one node.
+        original = GraphStore(db)
+        original.add_node("original", "File", "old.py")
+        original.close()
+
+        # Open as read-only (like MCP does) via ReloadableStore.
+        ro = GraphStore(db, read_only=True)
+        reloadable = _ReloadableStore(db, ro)
+        server = create_mcp_server(reloadable.get)
+
+        # Verify initial state via MCP tool.
+        get_node = server._tool_manager._tools["get_node"]
+        result = json.loads(get_node.fn(nodeId="original"))
+        assert result["node"]["name"] == "old.py"
+
+        # Build a replacement DB and atomically swap.
+        replacement = GraphStore(staging)
+        replacement.add_node("replaced", "File", "new.py")
+        replacement.close()
+        os.replace(staging, db)
+
+        # MCP should detect the change and serve new data.
+        result2 = json.loads(get_node.fn(nodeId="replaced"))
+        assert result2["node"]["name"] == "new.py"
+
+        # Old node should be gone.
+        result3 = json.loads(get_node.fn(nodeId="original"))
+        assert "error" in result3
+
+        reloadable.close()
+
+    def test_no_index_after_db_removed(self, tmp_path):
+        """MCP returns no-index message when DB file is deleted."""
+        from opentrace_agent.cli.main import _ReloadableStore
+
+        db = str(tmp_path / "test.db")
+        store = GraphStore(db)
+        store.add_node("n1", "File", "f.py")
+        store.close()
+
+        ro = GraphStore(db, read_only=True)
+        reloadable = _ReloadableStore(db, ro)
+        server = create_mcp_server(reloadable.get)
+
+        # Remove the database.
+        os.unlink(db)
+
+        get_stats = server._tool_manager._tools["get_stats"]
+        result = json.loads(get_stats.fn())
+        assert result.get("message", "").startswith("No index available")
+
+        reloadable.close()

--- a/agent/tests/opentrace_agent/graph/test_mcp_integration.py
+++ b/agent/tests/opentrace_agent/graph/test_mcp_integration.py
@@ -449,20 +449,7 @@ class TestMCPRoundTrip:
 
 
 class TestMCPReload:
-    """Verify that a callable store provider enables hot-reload."""
-
-    def test_callable_provider_returns_fresh_store(self, tmp_path):
-        """MCP tools resolve the store per-request via callable."""
-        db = str(tmp_path / "test.db")
-        store = GraphStore(db)
-        store.add_node("n1", "File", "hello.py")
-        # keep store open — pass a callable that returns it
-
-        server = create_mcp_server(lambda: store)
-        tool = server._tool_manager._tools["get_stats"]
-        result = json.loads(tool.fn())
-        assert result["total_nodes"] >= 1
-        store.close()
+    """Verify that the ReloadableStore proxy enables hot-reload."""
 
     def test_picks_up_replaced_database(self, tmp_path):
         """Simulates the staging-swap pattern: MCP sees new data after replace."""
@@ -476,10 +463,10 @@ class TestMCPReload:
         original.add_node("original", "File", "old.py")
         original.close()
 
-        # Open as read-only (like MCP does) via ReloadableStore.
+        # Open as read-only (like MCP does) via ReloadableStore proxy.
         ro = GraphStore(db, read_only=True)
         reloadable = _ReloadableStore(db, ro)
-        server = create_mcp_server(reloadable.get)
+        server = create_mcp_server(reloadable)
 
         # Verify initial state via MCP tool.
         get_node = server._tool_manager._tools["get_node"]
@@ -513,7 +500,7 @@ class TestMCPReload:
 
         ro = GraphStore(db, read_only=True)
         reloadable = _ReloadableStore(db, ro)
-        server = create_mcp_server(reloadable.get)
+        server = create_mcp_server(reloadable)
 
         # Remove the database.
         os.unlink(db)


### PR DESCRIPTION
## Allow concurrent indexing while MCP server is running
✨ **Improvement** · ♻️ **Refactor** · 🧪 **Tests**

Allows `opentrace index` to run concurrently while an MCP server is active by using a staging-file + atomic-swap pattern. 

The MCP server now monitors the database inode and transparently reopens the file when it detects an update.

### Complexity
🟡 Moderate · `4 files changed, 323 insertions(+), 25 deletions(-)`

This PR introduces a new state management pattern across the CLI and MCP server to handle file-system-level atomicity. It requires careful review of resource lifecycles (closing/reopening connections) and the use of closures for dynamic dependency injection in the MCP server.

### Tests
🧪 Includes unit tests for the reload logic and integration tests verifying the MCP server picks up new data after a file swap.

### Review focus
Pay particular attention to the following areas:

- **Resource Lifecycle** — verify that `_ReloadableStore` correctly closes old connections before reopening to prevent file descriptor leaks.
- **Atomic Replace** — check the `os.replace` logic in the `index` command to ensure the staging file is cleaned up on failure.

---

<details>
<summary><strong>Additional details</strong></summary>

### The Problem
LadybugDB uses exclusive process-level file locking. Even opening a database with `read_only=True` acquires an exclusive lock, meaning a long-running MCP server process completely blocks the `opentrace index` command from updating the knowledge graph.

### The Solution: Staging and Atomic Swaps
1.  **Indexing**: The `index` command now writes to `index.db.staging`. Once the index is complete, it calls `os.replace(staging, live)`, which is atomic on POSIX (and generally on Windows for non-open files).
2.  **Detection**: The MCP server cannot hold the file open indefinitely if we want to replace it. However, keeping it open is necessary for performance. The new `_ReloadableStore` wrapper checks the file's inode (`st_ino`) before each tool execution.
3.  **Reloading**: If the inode changes (indicating the file was replaced by a new index run), the wrapper closes the old connection and opens a new one to the updated file.

### Architectural Changes
- `create_mcp_server` was updated to accept a `Callable` store provider. This allows the FastMCP tools to resolve the "current" active store instance at runtime rather than being bound to a stale object.
- The `GraphStoreAdapter` and `GraphStore` lifecycles are explicitly managed during the swap to prevent connection leaks.

</details>
<!-- opentrace:jid=j-92ba17d9-2ef1-4e03-affd-aa003ee3b84b|sha=1dafe5fd593b7ba9b918a28c37175e95b91d9335 -->