### PR TITLE
ci: fix preview PyPI publish for fork PRs

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,7 +1,7 @@
 name: Publish Preview Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize]
     paths:
       - "agent/**"


### PR DESCRIPTION
## Summary
- Switch `publish-preview.yml` trigger from `pull_request` to `pull_request_target` so fork PRs can obtain an OIDC token for PyPI Trusted Publishing.
- Fork PRs currently fail with `ACTIONS_ID_TOKEN_REQUEST_TOKEN unset` because `pull_request` events from forks run with a clamped `GITHUB_TOKEN` and no OIDC access.
- Safe here because the workflow is already label-gated (`preview-publish`, maintainer-only) and already checks out `pull_request.head.sha` explicitly.

## Notes
- GitHub reads workflow files from the **base branch** for `pull_request_target`, so the fix only takes effect for PRs opened/re-triggered **after** this merges.
- No PyPI Trusted Publisher config change needed — it keys on `(repo, workflow filename, environment)`, not event type.

## Test plan
- [ ] Merge to `main`.
- [ ] On the failing fork PR, remove and re-apply the `preview-publish` label to re-trigger.
- [ ] Confirm the `Publish to PyPI` step succeeds (OIDC exchange no longer errors).
- [ ] Confirm the PR comment with `opentraceai==X.Y.Z.devN` is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)