### PR TITLE
ci: split preview publish into build + workflow_run publish

### DIFF
--- a/.github/workflows/publish-preview-build.yml
+++ b/.github/workflows/publish-preview-build.yml
@@ -1,0 +1,58 @@
+name: Publish Preview Release Build
+
+# Builds the preview package in the (untrusted) PR context and uploads the
+# resulting dist/ as an artifact. A separate workflow (publish-preview.yml)
+# runs on workflow_run in the base-repo context and handles the PyPI publish.
+#
+# This split is required because PyPI's Trusted Publishing rejects OIDC tokens
+# issued from `pull_request_target` workflows, but the standard `pull_request`
+# trigger from a fork has no OIDC token to issue.
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    paths:
+      - "agent/**"
+
+jobs:
+  build:
+    name: Build preview package
+    if: contains(github.event.pull_request.labels.*.name, 'preview-publish')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set preview version
+        working-directory: agent
+        run: |
+          BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          PREVIEW_VERSION="${BASE_VERSION}.dev${{ github.event.pull_request.number }}${GITHUB_RUN_NUMBER}"
+          sed -i "s/^version = .*/version = \"${PREVIEW_VERSION}\"/" pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"${PREVIEW_VERSION}\"/" src/opentrace_agent/__init__.py
+          echo "${PREVIEW_VERSION}" > preview-version.txt
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "Built version: ${PREVIEW_VERSION}"
+
+      - name: Build package
+        working-directory: agent
+        run: |
+          pip install build
+          python -m build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-dist
+          path: |
+            agent/dist/
+            agent/preview-version.txt
+            agent/pr-number.txt
+          if-no-files-found: error

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,54 +1,70 @@
 name: Publish Preview Release
 
+# Publishes the artifact built by publish-preview-build.yml to PyPI.
+#
+# Runs on workflow_run (base-repo trust context) so that:
+#   - OIDC token issuance succeeds (unlike fork pull_request)
+#   - PyPI Trusted Publishing accepts the token (unlike pull_request_target)
+#
+# The build workflow runs in the (untrusted) fork PR context and only produces
+# an artifact. This workflow consumes that artifact as data — no fork code
+# executes here.
+
 on:
-  pull_request_target:
-    types: [labeled, synchronize]
-    paths:
-      - "agent/**"
+  workflow_run:
+    workflows: ["Publish Preview Release Build"]
+    types: [completed]
 
 jobs:
-  publish-preview:
+  publish:
     name: Publish preview to PyPI
-    if: contains(github.event.pull_request.labels.*.name, 'preview-publish')
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: write
+      actions: read
     environment:
       name: pypi
       url: https://pypi.org/project/opentraceai/
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          name: preview-dist
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.12"
-
-      - name: Set preview version
-        working-directory: agent
+      - name: Read metadata
+        id: meta
         run: |
-          BASE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          PREVIEW_VERSION="${BASE_VERSION}.dev${{ github.event.pull_request.number }}${GITHUB_RUN_NUMBER}"
-          sed -i "s/^version = .*/version = \"${PREVIEW_VERSION}\"/" pyproject.toml
-          sed -i "s/^__version__ = .*/__version__ = \"${PREVIEW_VERSION}\"/" src/opentrace_agent/__init__.py
-          echo "PREVIEW_VERSION=${PREVIEW_VERSION}" >> "$GITHUB_ENV"
-          echo "Published version: ${PREVIEW_VERSION}"
-
-      - name: Build package
-        working-directory: agent
-        run: |
-          pip install build
-          python -m build
+          VERSION=$(cat artifact/agent/preview-version.txt)
+          PR_NUMBER=$(cat artifact/agent/pr-number.txt)
+          # Guard against unexpected content in the artifact files.
+          if ! [[ "${VERSION}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "Invalid version string: ${VERSION}" >&2
+            exit 1
+          fi
+          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: ${PR_NUMBER}" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          packages-dir: agent/dist/
+          packages-dir: artifact/agent/dist/
 
       - name: Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_VERSION: ${{ steps.meta.outputs.version }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
         with:
           script: |
             const marker = '<!-- opentraceai-preview -->';
@@ -68,10 +84,11 @@ jobs:
               '```',
             ].join('\n');
 
+            const issue_number = parseInt(process.env.PR_NUMBER, 10);
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number,
             });
             const existing = comments.find(c => c.body.includes(marker));
 
@@ -86,7 +103,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number,
                 body,
               });
             }

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -9,6 +9,15 @@ name: Publish Preview Release
 # The build workflow runs in the (untrusted) fork PR context and only produces
 # an artifact. This workflow consumes that artifact as data — no fork code
 # executes here.
+#
+# Trust model:
+#   - The PR number and the `preview-publish` label are resolved here via the
+#     GitHub API from `workflow_run.head_sha` — never from the artifact, since
+#     the build workflow runs from fork-controlled code and could lie.
+#   - The label gate from publish-preview-build.yml is re-verified here because
+#     a fork can edit the build workflow file in their PR to remove it.
+#   - The version string is read from the artifact but must end with the
+#     trusted `.dev{PR_NUM}{BUILD_RUN_NUM}` suffix to prevent version squatting.
 
 on:
   workflow_run:
@@ -30,6 +39,42 @@ jobs:
       name: pypi
       url: https://pypi.org/project/opentraceai/
     steps:
+      - name: Resolve PR and verify label
+        id: resolve_pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const headSha = process.env.HEAD_SHA;
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+
+            // Match by head SHA so we only consider PRs whose head is this commit
+            // (not PRs that merely contain it via base-branch updates).
+            const pr = prs.find(p => p.head.sha === headSha && p.state === 'open');
+            if (!pr) {
+              core.setFailed(`No open PR found with head SHA ${headSha}`);
+              return;
+            }
+
+            const hasLabel = pr.labels.some(l => l.name === 'preview-publish');
+            if (!hasLabel) {
+              core.setFailed(
+                `PR #${pr.number} does not have the 'preview-publish' label. ` +
+                `Refusing to publish — the label gate in the build workflow can ` +
+                `be bypassed by editing the workflow file in a fork PR.`
+              );
+              return;
+            }
+
+            core.setOutput('pr_number', pr.number);
+            core.info(`Verified PR #${pr.number} has 'preview-publish' label`);
+
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -38,22 +83,25 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read metadata
+      - name: Verify version
         id: meta
+        env:
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          BUILD_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
         run: |
           VERSION=$(cat artifact/agent/preview-version.txt)
-          PR_NUMBER=$(cat artifact/agent/pr-number.txt)
-          # Guard against unexpected content in the artifact files.
           if ! [[ "${VERSION}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
             echo "Invalid version string: ${VERSION}" >&2
             exit 1
           fi
-          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
-            echo "Invalid PR number: ${PR_NUMBER}" >&2
+          # Enforce the trusted suffix so a fork can't publish a non-preview
+          # version (e.g. "1.0.0") and squat a future release on PyPI.
+          EXPECTED_SUFFIX=".dev${PR_NUMBER}${BUILD_RUN_NUMBER}"
+          if [[ "${VERSION}" != *"${EXPECTED_SUFFIX}" ]]; then
+            echo "Version '${VERSION}' must end with '${EXPECTED_SUFFIX}'" >&2
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
@@ -64,7 +112,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_VERSION: ${{ steps.meta.outputs.version }}
-          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
         with:
           script: |
             const marker = '<!-- opentraceai-preview -->';


### PR DESCRIPTION
## Fix PyPI OIDC publishing for fork PRs
✨ **Improvement** · 🔒 **Security**

Splits the preview release process into two workflows to enable PyPI Trusted Publishing (OIDC) for fork PRs. 

This follows the standard security pattern of building untrusted code in a restricted context and publishing the resulting artifact from a trusted context.

### Complexity
🟢 Low · `2 files changed, 104 insertions(+), 29 deletions(-)`

Narrow scope affecting only two CI workflow files. Follows canonical GitHub Actions patterns for secure artifact handling across trust boundaries.

### Review focus
Pay particular attention to the following areas:

- **Artifact validation** — verify that the regex guards on the version string and PR number correctly sanitize inputs before they are used in the trusted context.
- **Workflow triggers** — ensure the `workflow_run` condition correctly filters for successful completions of the build workflow only.
<!-- opentrace:jid=d215a1f5-5e3a-4f92-91f8-877df01681ad|sha=da4cf5dc27fffffa09b2f6cc8e157cf5ae5b89ca -->