### PR TITLE
fix(ci): resolve preview-publish PR by head ref

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -12,8 +12,11 @@ name: Publish Preview Release
 #
 # Trust model:
 #   - The PR number and the `preview-publish` label are resolved here via the
-#     GitHub API from `workflow_run.head_sha` — never from the artifact, since
-#     the build workflow runs from fork-controlled code and could lie.
+#     GitHub API from the workflow_run's head ref (head_repository owner +
+#     head_branch) — never from the artifact, since the build workflow runs
+#     from fork-controlled code and could lie. We use the head ref rather than
+#     listPullRequestsAssociatedWithCommit because the latter is unreliable
+#     for fork PR commits (GitHub only indexes those associations post-merge).
 #   - The label gate from publish-preview-build.yml is re-verified here because
 #     a fork can edit the build workflow file in their PR to remove it.
 #   - The version string is read from the artifact but must end with the
@@ -44,24 +47,36 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
         with:
           script: |
             const headSha = process.env.HEAD_SHA;
+            const headBranch = process.env.HEAD_BRANCH;
+            const headRepoOwner = process.env.HEAD_REPO_OWNER;
 
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            // Look up the PR by its head ref. listPullRequestsAssociatedWithCommit
+            // is unreliable for fork PR commits — GitHub only consistently indexes
+            // commit → PR associations after merge. The head ref (fork:branch) is
+            // the authoritative identifier from the workflow_run payload.
+            const headRef = `${headRepoOwner}:${headBranch}`;
+            const { data: pulls } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              commit_sha: headSha,
+              state: 'open',
+              head: headRef,
             });
 
-            // Match by head SHA so we only consider PRs whose head is this commit
-            // (not PRs that merely contain it via base-branch updates).
-            const pr = prs.find(p => p.head.sha === headSha && p.state === 'open');
-            if (!pr) {
-              core.setFailed(`No open PR found with head SHA ${headSha}`);
+            if (pulls.length === 0) {
+              core.setFailed(`No open PR found for head ref ${headRef} (build SHA ${headSha})`);
+              return;
+            }
+            if (pulls.length > 1) {
+              core.setFailed(`Multiple open PRs found for head ref ${headRef}: ${pulls.map(p => '#' + p.number).join(', ')}`);
               return;
             }
 
+            const pr = pulls[0];
             const hasLabel = pr.labels.some(l => l.name === 'preview-publish');
             if (!hasLabel) {
               core.setFailed(
@@ -73,7 +88,7 @@ jobs:
             }
 
             core.setOutput('pr_number', pr.number);
-            core.info(`Verified PR #${pr.number} has 'preview-publish' label`);
+            core.info(`Verified PR #${pr.number} (${headRef}, build SHA ${headSha}) has 'preview-publish' label`);
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

Follow-up to #326. The new publish workflow failed on a real fork PR with:

```
Error: No open PR found with head SHA 89b5775de55145a6b1ff9edae0b5f6a170b770d8
```

Root cause: `listPullRequestsAssociatedWithCommit` returns `[]` for fork PR commits — GitHub only indexes commit→PR associations after merge, even though the commit is reachable in the base repo via `refs/pull/N/head`. (Verified: `gh api repos/.../commits/{sha}/pulls` returns `[]` for that SHA.)

Switched to looking up the PR by **head ref** (`head_repository.owner.login:head_branch`) via `pulls.list({head: ...})`. This is the authoritative identifier in the `workflow_run` payload and works reliably for both same-repo and fork PRs.

## Changes

- `publish-preview.yml`: replace commit-association lookup with head-ref lookup
- Require exactly one open PR for the head ref (defense against ambiguous matches)
- Keep `head_sha` around for log correlation only
- Update trust-model docstring

## Test plan

- [ ] Merge to `main`
- [ ] Re-trigger on the failing fork PR (push a new commit, or remove + re-apply `preview-publish` label)
- [ ] Confirm the publish workflow's `Resolve PR and verify label` step succeeds
- [ ] Confirm publish + PR comment proceed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)