### PR TITLE
fix(ci): correct preview artifact paths after LCA stripping

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -104,7 +104,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
           BUILD_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
         run: |
-          VERSION=$(cat artifact/agent/preview-version.txt)
+          VERSION=$(cat artifact/preview-version.txt)
           if ! [[ "${VERSION}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
             echo "Invalid version string: ${VERSION}" >&2
             exit 1
@@ -121,7 +121,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          packages-dir: artifact/agent/dist/
+          packages-dir: artifact/dist/
 
       - name: Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Fix artifact paths in preview publish workflow
🐛 **Bug Fix**

Corrects artifact paths in the preview publish workflow.

Fixes a "No such file or directory" error caused by automatic path stripping during artifact upload.

### Complexity
🟢 Trivial · `1 file changed, 2 insertions(+), 2 deletions(-)`

Single-file CI configuration fix addressing a path mismatch with no impact on application logic.
<!-- opentrace:jid=j-9d8442a9-52b0-494f-bacb-c5bd638b9ec8|sha=6c08a4e3bcb74503d965079eb35b2e0190e048a6 -->