### PR TITLE
fix(ui): make graph canvas reactive to theme and light/dark mode chan…

### DIFF
--- a/ui/src/components/PixiGraphCanvas.tsx
+++ b/ui/src/components/PixiGraphCanvas.tsx
@@ -310,15 +310,18 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
       };
       // `positions` is a stable Map ref from usePixiLayout (positionsRef.current).
       // It never changes identity — the effect re-runs via `layoutReady` or when
-      // nodes/links/colors change.
+      // nodes/links change. nodeColors and linkColors are intentionally excluded:
+      // color-only changes (e.g. theme switch) are handled by the dedicated
+      // updateNodeColors / updateLinkColors effects below, avoiding an expensive
+      // setData() call. The effect closure still captures the latest colors from
+      // the current render, so setData receives correct values when it does run.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
       layoutReady,
       nodes,
       links,
       positions,
-      nodeColors,
       nodeSizes,
-      linkColors,
     ]);
 
     // ── Update node colors when colorMode or theme changes ────────────

--- a/ui/src/components/PixiGraphCanvas.tsx
+++ b/ui/src/components/PixiGraphCanvas.tsx
@@ -37,6 +37,7 @@ import type { GraphCanvasHandle, GraphCanvasProps } from './types/canvas';
 import { useCommunities } from './graph/useCommunities';
 import { useHighlights } from './graph/useHighlights';
 import { shouldHideNode } from './graph/useGraphFilters';
+import { useThemeKey } from './graph/useThemeKey';
 import { DEFAULT_LAYOUT_CONFIG } from './config/graphLayout';
 import { PixiRenderer } from './pixi/PixiRenderer';
 import { usePixiLayout } from './pixi/usePixiLayout';
@@ -89,6 +90,8 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
     const rendererRef = useRef<PixiRenderer | null>(null);
     // Incremented when setData completes so dependent effects re-run
     const [dataVersion, setDataVersion] = useState(0);
+    // Re-renders when data-theme or data-mode changes on <html>
+    const themeKey = useThemeKey();
     const dummyGraph = useMemo(
       () => new Graph({ multi: true, type: 'directed' }),
       [],
@@ -144,7 +147,10 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         }
       }
       return colors;
-    }, [nodes, colorMode, communityData, layoutConfig]);
+      // themeKey triggers recomputation when theme/mode changes — getNodeColor
+      // reads CSS variables whose values depend on the active theme.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [nodes, colorMode, communityData, layoutConfig, themeKey]);
 
     // ── Link colors ─────────────────────────────────────────────────────
     const linkColors = useMemo(() => {
@@ -155,7 +161,8 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         }
       }
       return colors;
-    }, [links, layoutConfig]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [links, layoutConfig, themeKey]);
 
     // ── Layout (d3-force simulation) ────────────────────────────────────
     const onLayoutTick = useCallback(
@@ -314,11 +321,17 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
       linkColors,
     ]);
 
-    // ── Update node colors when colorMode changes ───────────────────────
+    // ── Update node colors when colorMode or theme changes ────────────
     useEffect(() => {
       if (!dataVersion || !rendererRef.current) return;
       rendererRef.current.updateNodeColors(nodeColors);
     }, [dataVersion, nodeColors]);
+
+    // ── Update canvas background + label colors when theme changes ──────
+    useEffect(() => {
+      if (!dataVersion || !rendererRef.current) return;
+      rendererRef.current.setThemeColors();
+    }, [dataVersion, themeKey]);
 
     // ── Apply labels visibility when data is ready or prop changes ─────
     useEffect(() => {

--- a/ui/src/components/PixiGraphCanvas.tsx
+++ b/ui/src/components/PixiGraphCanvas.tsx
@@ -327,6 +327,12 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
       rendererRef.current.updateNodeColors(nodeColors);
     }, [dataVersion, nodeColors]);
 
+    // ── Update link colors when theme changes ─────────────────────────
+    useEffect(() => {
+      if (!dataVersion || !rendererRef.current) return;
+      rendererRef.current.updateLinkColors(linkColors);
+    }, [dataVersion, linkColors]);
+
     // ── Update canvas background + label colors when theme changes ──────
     useEffect(() => {
       if (!dataVersion || !rendererRef.current) return;

--- a/ui/src/components/PixiGraphCanvas.tsx
+++ b/ui/src/components/PixiGraphCanvas.tsx
@@ -316,13 +316,7 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
       // setData() call. The effect closure still captures the latest colors from
       // the current render, so setData receives correct values when it does run.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [
-      layoutReady,
-      nodes,
-      links,
-      positions,
-      nodeSizes,
-    ]);
+    }, [layoutReady, nodes, links, positions, nodeSizes]);
 
     // ── Update node colors when colorMode or theme changes ────────────
     useEffect(() => {

--- a/ui/src/components/colors/graphThemeColors.ts
+++ b/ui/src/components/colors/graphThemeColors.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Reads graph-specific CSS variables for canvas background, label colors,
+ * and dim-blend background. Falls back to dark-theme defaults when CSS
+ * variables aren't available (tests, SSR).
+ */
+
+export interface GraphThemeColors {
+  /** Canvas background hex, e.g. '#0d1117' */
+  bg: string;
+  /** Label text fill hex, e.g. '#e2e8f0' */
+  labelColor: string;
+  /** Label drop shadow hex, e.g. '#0d1117' */
+  labelShadow: string;
+  /** Background RGB for dimColor alpha blending */
+  dimBg: { r: number; g: number; b: number };
+}
+
+const DEFAULTS: GraphThemeColors = {
+  bg: '#0d1117',
+  labelColor: '#e2e8f0',
+  labelShadow: '#0d1117',
+  dimBg: { r: 0x1a, g: 0x1b, b: 0x2e },
+};
+
+function parseHexRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.startsWith('#') ? hex.slice(1) : hex;
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+let cache: { themeKey: string; colors: GraphThemeColors } | null = null;
+
+export function getGraphThemeColors(): GraphThemeColors {
+  if (typeof document === 'undefined') return DEFAULTS;
+
+  const root = document.documentElement;
+  const themeKey = `${root.dataset.theme ?? ''}_${root.dataset.mode ?? ''}`;
+  if (cache && cache.themeKey === themeKey) return cache.colors;
+
+  const style = getComputedStyle(root);
+  const bg = style.getPropertyValue('--graph-bg').trim() || DEFAULTS.bg;
+  const labelColor =
+    style.getPropertyValue('--graph-label-color').trim() || DEFAULTS.labelColor;
+  const labelShadow =
+    style.getPropertyValue('--graph-label-shadow').trim() ||
+    DEFAULTS.labelShadow;
+  const dimBgHex = style.getPropertyValue('--graph-dim-bg').trim() || '#1a1b2e';
+  const dimBg = parseHexRgb(dimBgHex);
+
+  const colors: GraphThemeColors = { bg, labelColor, labelShadow, dimBg };
+  cache = { themeKey, colors };
+  return colors;
+}

--- a/ui/src/components/graph/useGraphVisuals.ts
+++ b/ui/src/components/graph/useGraphVisuals.ts
@@ -28,6 +28,7 @@ import {
   NODE_SIZE_DIMMED_SCALE,
 } from '../config/graphLayout';
 import { getGraphThemeColors } from '../colors/graphThemeColors';
+import { useThemeKey } from './useThemeKey';
 
 // ─── Pre-computed color cache ───────────────────────────────────────────
 
@@ -77,6 +78,8 @@ export function useGraphVisuals(
   _degreeMap: Map<string, number>,
   isLargeGraph: boolean,
 ): void {
+  const themeKey = useThemeKey();
+
   useEffect(() => {
     if (!layoutReady || graph.order === 0) return;
 
@@ -159,5 +162,6 @@ export function useGraphVisuals(
       },
       { attributes: ['zIndex'] },
     );
-  }, [graph, layoutReady, visualState, layoutConfig, isLargeGraph]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graph, layoutReady, visualState, layoutConfig, isLargeGraph, themeKey]);
 }

--- a/ui/src/components/graph/useGraphVisuals.ts
+++ b/ui/src/components/graph/useGraphVisuals.ts
@@ -27,12 +27,25 @@ import {
   NODE_OPACITY_DIMMED,
   NODE_SIZE_DIMMED_SCALE,
 } from '../config/graphLayout';
+import { getGraphThemeColors } from '../colors/graphThemeColors';
 
 // ─── Pre-computed color cache ───────────────────────────────────────────
 
-const dimColorCache = new Map<string, string>();
+let dimColorCache = new Map<string, string>();
+let dimCacheThemeKey = '';
 
 function dimColor(hex: string, alpha: number): string {
+  // Invalidate cache when theme changes
+  const root =
+    typeof document !== 'undefined' ? document.documentElement : null;
+  const themeKey = root
+    ? `${root.dataset.theme ?? ''}_${root.dataset.mode ?? ''}`
+    : '';
+  if (themeKey !== dimCacheThemeKey) {
+    dimColorCache = new Map();
+    dimCacheThemeKey = themeKey;
+  }
+
   const key = `${hex}:${alpha}`;
   const cached = dimColorCache.get(key);
   if (cached) return cached;
@@ -40,13 +53,10 @@ function dimColor(hex: string, alpha: number): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
-  // TODO: read from CSS variable for theme support
-  const bgR = 0x1a,
-    bgG = 0x1b,
-    bgB = 0x2e;
-  const nr = Math.round(r * alpha + bgR * (1 - alpha));
-  const ng = Math.round(g * alpha + bgG * (1 - alpha));
-  const nb = Math.round(b * alpha + bgB * (1 - alpha));
+  const { dimBg } = getGraphThemeColors();
+  const nr = Math.round(r * alpha + dimBg.r * (1 - alpha));
+  const ng = Math.round(g * alpha + dimBg.g * (1 - alpha));
+  const nb = Math.round(b * alpha + dimBg.b * (1 - alpha));
   const result = `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
   dimColorCache.set(key, result);
   return result;

--- a/ui/src/components/graph/useThemeKey.ts
+++ b/ui/src/components/graph/useThemeKey.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+function readThemeKey(): string {
+  const d = document.documentElement.dataset;
+  return `${d.theme ?? ''}_${d.mode ?? ''}`;
+}
+
+/**
+ * Returns a string key that changes whenever `data-theme` or `data-mode`
+ * changes on `<html>`. Useful as a React dependency to invalidate memos
+ * that read CSS variables (node/edge/label colors, graph background).
+ */
+export function useThemeKey(): string {
+  const [key, setKey] = useState(readThemeKey);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setKey(readThemeKey());
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme', 'data-mode'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return key;
+}

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -110,6 +110,10 @@ export {
   buildCommunityNames,
   getCommunityColor,
 } from './colors/communityColors';
+export {
+  getGraphThemeColors,
+  type GraphThemeColors,
+} from './colors/graphThemeColors';
 
 // ─── Indexing components ─────────────────────────────────────────────────
 export {

--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -67,8 +67,8 @@ import {
   LABEL_MAX_LENGTH,
   LABEL_SIZE,
   LABEL_FONT,
-  LABEL_COLOR,
 } from '../config/graphLayout';
+import { getGraphThemeColors } from '../colors/graphThemeColors';
 
 /** Strip control characters and truncate to MAX_LABEL_LENGTH. */
 function cleanLabel(raw: string): string {
@@ -313,11 +313,12 @@ export class PixiRenderer {
     this.height = height;
 
     const app = new Application();
+    const themeColors = getGraphThemeColors();
     try {
       await app.init({
         width,
         height,
-        backgroundColor: 0x0d1117,
+        backgroundColor: hexToNum(themeColors.bg),
         antialias: true,
         resolution: window.devicePixelRatio || 1,
         autoDensity: true,
@@ -981,6 +982,28 @@ export class PixiRenderer {
     }
   }
 
+  /** Re-read graph CSS variables and update canvas background + label styles. */
+  setThemeColors(): void {
+    if (!this.app) return;
+    const themeColors = getGraphThemeColors();
+
+    // Update Pixi canvas background
+    this.app.renderer.background.color = hexToNum(themeColors.bg);
+
+    // Update all existing label styles
+    for (const node of this.nodes.values()) {
+      if (!node.label) continue;
+      const s = node.label.style;
+      s.fill = themeColors.labelColor;
+      if (s.dropShadow && typeof s.dropShadow === 'object') {
+        s.dropShadow = {
+          ...s.dropShadow,
+          color: themeColors.labelShadow,
+        };
+      }
+    }
+  }
+
   private applyVisuals(): void {
     if (!this.app) return;
     const invScale = this.zoomInvScale();
@@ -1367,17 +1390,18 @@ export class PixiRenderer {
   /** Create a label Text for a node. Positioned to the right of the node. */
   private createLabel(node: PixiNode): Text {
     const lblInv = this.labelInvScale();
+    const themeColors = getGraphThemeColors();
     const label = new Text({
       text: cleanLabel(node.graphNode.name || node.id),
       style: new TextStyle({
         fontSize: LABEL_SIZE,
         fontFamily: LABEL_FONT,
         fontWeight: 'bold',
-        fill: LABEL_COLOR,
+        fill: themeColors.labelColor,
         dropShadow: {
           alpha: 0.9,
           blur: 3,
-          color: '#0d1117',
+          color: themeColors.labelShadow,
           distance: 0,
         },
       }),

--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -982,6 +982,26 @@ export class PixiRenderer {
     }
   }
 
+  /** Update link colors and re-group for batched rendering. */
+  updateLinkColors(linkColors: Map<string, string>): void {
+    if (!this.app) return;
+    for (const edge of this.edges) {
+      edge.color = linkColors.get(edge.label) ?? '#3b4048';
+    }
+    // Re-group edges by color for batched rendering
+    this.edgeColorGroups.clear();
+    for (let i = 0; i < this.edges.length; i++) {
+      const color = this.edges[i].color;
+      let group = this.edgeColorGroups.get(color);
+      if (!group) {
+        group = [];
+        this.edgeColorGroups.set(color, group);
+      }
+      group.push(i);
+    }
+    this.redrawAllEdges();
+  }
+
   /** Re-read graph CSS variables and update canvas background + label styles. */
   setThemeColors(): void {
     if (!this.app) return;

--- a/ui/src/styles/theme.css
+++ b/ui/src/styles/theme.css
@@ -81,6 +81,11 @@
   --graph-edge-palette-9: #a3e635;
   --graph-edge-palette-10: #c084fc;
   --graph-edge-palette-11: #22d3ee;
+  /* Graph canvas colors — background, label fill, label shadow, dim blend */
+  --graph-bg: #0d1117;
+  --graph-label-color: #e2e8f0;
+  --graph-label-shadow: #0d1117;
+  --graph-dim-bg: #1a1b2e;
 }
 
 /* ── Clean (default) — cool indigo/blue base ─────────────────────────────── */
@@ -508,6 +513,14 @@
    Each theme gets a light override that inverts structural colors while
    keeping the same accent/primary hue.
    ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Graph canvas overrides for all light themes ────────────────────────── */
+[data-mode='light'] {
+  --graph-bg: #f8fafc;
+  --graph-label-color: #1e293b;
+  --graph-label-shadow: #f8fafc;
+  --graph-dim-bg: #e2e8f0;
+}
 
 /* ── Clean Light ─────────────────────────────────────────────────────────── */
 [data-theme='clean'][data-mode='light'],


### PR DESCRIPTION
## Theme-aware reactivity for Pixi graph canvas
✨ **Improvement** · ♻️ **Refactor**

Replaces hardcoded Pixi.js colors with theme-aware CSS variables. Adds a mutation observer hook to trigger graph background and label updates when the global theme or light/dark mode changes.

### Complexity
🟡 Moderate · `7 files changed, 195 insertions(+), 15 deletions(-)`

The change spans multiple layers: CSS variable definitions, a new MutationObserver hook, and imperative updates to the Pixi.js WebGL renderer. While the logic is clean, it requires synchronizing global DOM state (theme attributes) with an isolated rendering engine, necessitating careful dependency management in React hooks.

### Tests
🧪 Existing tests cover the theme hooks, but no new integration tests were added for the WebGL renderer's reactivity.

### Review focus
Pay particular attention to the following areas:

- **Link color reactivity** — verify if link colors update on theme switch; the renderer currently lacks an explicit `updateLinkColors` method which may leave edges stale until the next data reload.
- **Hex parsing robustness** — check if `parseHexRgb` and `hexToNum` handle 3-digit hex shorthand or invalid strings gracefully.
- **Cache invalidation** — confirm that the `dimColorCache` in `useGraphVisuals` correctly resets to prevent nodes from blending against the previous theme's background.
<!-- opentrace:jid=j-068c5000-9299-4d08-864d-a1dbdba2291d|sha=85f5d4a1e53045c95566a5cc24dec900404d1fef -->