### PR TITLE
docs: add CLAUDE.md files throughout repo for agent context

### DIFF
--- a/agent/CLAUDE.md
+++ b/agent/CLAUDE.md
@@ -1,0 +1,57 @@
+# Agent
+
+Python package `opentrace_agent` — the indexing and serving CLI (`opentraceai`) that walks a codebase, extracts symbols and relationships into a knowledge graph, and exposes that graph via REST and MCP.
+
+## Layout
+
+```
+src/opentrace_agent/
+  cli/         — Click commands: index, serve, mcp, augment, bench, auth
+  sources/     — Source discovery + per-language symbol extraction (tree-sitter)
+  pipeline/    — Four-stage pipeline (scan → process → resolve → save) as LangGraph
+  store/       — LadybugDB persistence (Cypher queries, schema)
+  summarizer/  — Pluggable code summarization (Flan-T5)
+  benchmarks/  — SWE-bench harness and accuracy benchmark CLI
+  gen/         — Generated protobuf code (do not edit; regenerate via `make py` in proto/)
+tests/         — Mirrors src layout; fixture-based extractor + pipeline tests
+```
+
+## Tooling
+
+- **Package manager:** `uv` (lock at `uv.lock`, sync with `uv sync`)
+- **Build backend:** `hatchling`
+- **CLI entrypoint:** `opentraceai = opentrace_agent.cli.main:cli` in `pyproject.toml`
+- **Tests:** `uv run pytest`; async tests use `pytest-anyio` with `@pytest.mark.anyio`
+- **Format/lint:** invoke via `make fmt` / `make lint` from repo root
+
+## Configuration
+
+`opentrace_agent.cli.config` uses `pydantic-settings` with the `OT_` env prefix. Fields are typed; missing required env triggers a startup error rather than runtime `KeyError`.
+
+## Database Discovery
+
+Every CLI subcommand calls `cli.main.find_db()`, which walks up from cwd looking for `.opentrace/index.db`, stopping at the git root. Override with `--db <path>`. Discovery rejects symlinks that escape the repo and caps traversal depth — touch with care, this is a security boundary.
+
+## Pipeline at a Glance
+
+The graph build is a generator-based four-stage chain in `pipeline/`:
+
+1. **scanning** — `DirectoryWalker` emits `Repository`/`Directory`/`File` nodes
+2. **processing** — Per-file tree-sitter extraction → `Class`/`Function` nodes + per-file `Registries`
+3. **resolving** — 7-strategy call resolution → `CALLS` relationships
+4. **saving** — Persist events to `Store` (LadybugDB)
+
+Each stage yields `PipelineEvent` objects. Cancellation is **cooperative** (`ctx.cancelled` is checked between units of work, never mid-parse). See `pipeline/CLAUDE.md` for details.
+
+## Conventions
+
+- **Node subclasses** must define `graph_type` and `save_function_name` ClassVars; `relationship_mapping` dict maps `RelationType` → MCP function names.
+- **Tree-sitter ASTs are expensive.** Never re-parse — pass `root_node` through `ExtractionResult` and reuse it. (Past O(n²) regression.)
+- **Pre-compute shared sets/dicts** (e.g. `known_paths`) once outside per-file loops, not per file.
+- **Generated code lives in `gen/`** and must not be hand-edited. Source of truth is `proto/`.
+
+## Cross-Cutting Pitfalls
+
+- `MagicMock` cannot intercept `__getattr__` — when mocking the MCP client or store, use a small custom class.
+- External-package nodes use synthetic IDs of the form `pkg:registry:name` and are version-agnostic — multiple versions collapse into one node.
+- Large repos can OOM during `processing` because all `Registries` are held in memory before `resolving` consumes them.

--- a/agent/src/opentrace_agent/cli/CLAUDE.md
+++ b/agent/src/opentrace_agent/cli/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLI
+
+Click-based command-line interface for the `opentraceai` binary. Also hosts the two server modes (REST and MCP) that wrap the underlying graph store.
+
+## Commands
+
+```
+main.py          — Click root group; --db override, find_db() discovery
+index            — Run the four-stage pipeline against a target path/repo
+serve.py         — Starlette HTTP server; REST API consumed by the UI
+mcp_server.py    — MCP (Model Context Protocol) server for Claude Code agents
+augment.py       — Post-process: add AI summaries to existing graph nodes
+bench.py         — SWE-bench / accuracy benchmark runner (see /benchmark)
+impact.py        — Blast-radius analysis for a given symbol or file
+auth.py          — GitHub token onboarding flows
+credentials.py   — Token storage helpers
+config.py        — pydantic-settings (env prefix OT_)
+export_import.py — Dump and reload graph state for backups / cross-machine moves
+```
+
+## Database Discovery
+
+`find_db()` walks up from cwd until it finds `.opentrace/index.db`, stopping at the git root. The walk:
+
+- caps traversal at 10 levels (symlink-loop defense)
+- rejects resolved paths that escape the original repo root (symlink-jailbreak defense)
+- can be fully bypassed with `--db <path>`
+
+This is a **security boundary** — don't loosen the symlink check casually. If you need to support arbitrary paths, route them through `--db`, not through the discovery logic.
+
+## Server Modes
+
+| Mode | Module | Transport | Consumer | Auth |
+|---|---|---|---|---|
+| REST | `serve.py` | Starlette HTTP | UI (`ServerGraphStore` in `ui/src/store/`) | None today |
+| MCP | `mcp_server.py` | stdio JSON-RPC | Claude Code plugin | OAuth flow (separate) |
+
+REST endpoints: `/api/health`, `/api/stats`, `/api/graph`, `/api/nodes/{id}`, `/api/traverse`, `/api/source/{id}`, `/api/nodes/search`, `/api/nodes/list`, `/api/metadata`. The UI is the contract holder — see `ui/src/store/CLAUDE.md` for the client side.
+
+MCP tools mirror the same operations but with names matching the plugin agents' expectations: `get_stats`, `search_graph`, `list_nodes`, `get_node`, `traverse_graph`. Tool list lives in `claude-code-plugin/CLAUDE.md`.
+
+## Adding a Subcommand
+
+1. New module under `cli/` exporting a `@click.command` (or group)
+2. Register on the root group in `main.py`
+3. If it needs the DB, accept `--db` and call `find_db(...)` — don't reimplement discovery
+4. If it produces long-running output, yield events through `pipeline/types.PipelineEvent` so progress is consistent across CLI / REST / MCP
+
+## Pitfalls
+
+- **REST has no auth.** Anyone with network access to `serve` can read the entire graph. Fine for localhost dev, not for production exposure — document that you're aware before binding non-loopback.
+- **MCP `get_stats` may fail under DB lock contention.** The session-start hook in the plugin handles this gracefully; treat lock errors as best-effort, not fatal.
+- **`augment` is destructive in spirit.** It updates summary fields in place. Run on a copy if you need the un-summarized graph for debugging.
+- **`config.py` settings load eagerly at import time.** Missing required env crashes the CLI before `--help` works — keep required fields to a minimum.

--- a/agent/src/opentrace_agent/pipeline/CLAUDE.md
+++ b/agent/src/opentrace_agent/pipeline/CLAUDE.md
@@ -1,0 +1,62 @@
+# Pipeline
+
+Four-stage generator pipeline that turns a discovered codebase into a saved knowledge graph. Built as a linear LangGraph `StateGraph`.
+
+## Files
+
+```
+pipeline.py    — Public entrypoints: core_pipeline(), run_pipeline(), collect_pipeline()
+types.py       — PipelineEvent, PipelineInput/Context/Result, Phase, EventKind, GraphNode/Relationship
+scanning.py    — Stage 1: DirectoryWalker → Repository/Directory/File + CONTAINS edges
+processing.py  — Stage 2: per-file extraction → Class/Function nodes + Registries
+resolving.py   — Stage 3: 7-strategy call resolution → CALLS edges
+saving.py      — Stage 4: stream events into Store (LadybugDB)
+adapters.py    — Convert SymbolExtractor results into pipeline graph primitives
+store.py       — Store protocol + LadybugDB-backed implementation
+```
+
+## Stage Contract
+
+Each stage is an async generator:
+
+```python
+async def stage(ctx: PipelineContext, input: T_in, output: StageResult[T_out]) -> AsyncIterator[PipelineEvent]:
+    yield PipelineEvent(kind=STAGE_START, ...)
+    # do work, yielding PROGRESS events
+    output.value = ...   # MUST set before STAGE_STOP
+    yield PipelineEvent(kind=STAGE_STOP, ...)
+```
+
+`StageResult` is the cross-stage handoff: the next stage reads `prev_output.value`. Setting it after `STAGE_STOP` is a bug — downstream sees `None`.
+
+## Call Resolution (Stage 3)
+
+`resolving.py` applies seven strategies **in priority order**, stopping at the first match:
+
+1. **self/this** — `self.foo()` resolved against the enclosing class's methods
+2. **Go receiver** — `r.method()` matched via `_receiver_type` recorded by Go extractor
+3. **`ClassName.method`** — explicit class-qualified call
+4. **Imports** — alias map from `import_analyzer` resolves `fmt.Println` → external `pkg:*`
+5. **Constructor** — `Foo()` matched against class definition (Python-style)
+6. **Intra-file** — bare `foo()` matched against same-file functions
+7. **Cross-file** — fall back to global `Registries` lookup by FQN
+
+Strategies emit only "confident" matches; ambiguous calls are dropped silently. If you change priority order, run `tests/opentrace_agent/pipeline/test_resolving.py` end-to-end.
+
+## Events
+
+Consumers (CLI, UI via `serve.py`) iterate the generator to drive progress UI. Events are typed by `EventKind`:
+
+- `STAGE_START` / `STAGE_STOP` — stage boundaries
+- `PROGRESS` — per-unit-of-work updates (file scanned, symbol extracted)
+- `LOG` — diagnostic messages
+- `ERROR` — recoverable; pipeline continues
+
+Use `collect_pipeline()` for tests (drains the generator, returns final `PipelineResult`). Use `run_pipeline()` for fire-and-forget. Use `core_pipeline()` when you need the raw event stream.
+
+## Pitfalls
+
+- **Cancellation is cooperative.** Stages check `ctx.cancelled` between units; an in-progress tree-sitter parse cannot be interrupted. Don't expect sub-second cancel latency on large files.
+- **Registries are in-memory.** All extracted symbols persist for the duration of `resolving`; very large monorepos are the dominant memory pressure.
+- **Cyclic class hierarchies can loop.** The receiver-type strategy walks up the superclass chain; malformed input (A → B → A) is not currently detected. Add a visited set if you touch this.
+- **Saving is a wrapper, not a stage.** `saving.run_with_save()` consumes events from `core_pipeline` and side-effects into the store; tests using `collect_pipeline()` skip persistence on purpose.

--- a/agent/src/opentrace_agent/sources/CLAUDE.md
+++ b/agent/src/opentrace_agent/sources/CLAUDE.md
@@ -1,0 +1,58 @@
+# Sources
+
+Source discovery and language-specific symbol extraction. A **Source** is a category (e.g. `code`); a **Loader** is a provider implementation under that source. Today only `code/` is populated.
+
+## Layout
+
+```
+code/
+  directory_walker.py   — Local filesystem walk; emits Directory/File nodes
+  git_cloner.py         — Clone remote repos into a temp dir before scanning
+  manifest_parser.py    — Read go.mod / package.json / pyproject.toml for module paths
+  import_analyzer.py    — Resolve imports per language using the existing tree-sitter AST
+  extractors/
+    base.py             — SymbolExtractor protocol, dataclasses (CodeSymbol, CallRef, ...)
+    python_extractor.py
+    typescript_extractor.py
+    go_extractor.py
+    generic_extractor.py — Table-driven fallback for unsupported languages
+```
+
+## Architecture
+
+- **Two-phase per file:** extract symbols → register them → (later, in `pipeline/resolving.py`) resolve calls. The two-phase split is what lets a method in file A call a method in file B that hasn't been parsed yet.
+- **Reuse ASTs.** Extraction stores `root_node` on `ExtractionResult`; `import_analyzer` consumes the same node. **Never call `parser.parse()` twice on the same source** — that was a real perf regression.
+- **Bare vs attribute calls.** `CallRef` distinguishes `foo()` (bare) from `self.foo()` / `fmt.Println()` (attribute). Resolution strategies depend on which kind it is.
+- **Go receiver bookkeeping.** Go method extractors set `_receiver_var` and `_receiver_type` attrs on the `FunctionNode` so the resolver can match `r.method()` calls against the correct receiver type.
+
+## SymbolExtractor Contract
+
+```python
+class SymbolExtractor(Protocol):
+    language: str
+    def extract(self, file_path: str, source: bytes) -> ExtractionResult: ...
+```
+
+`ExtractionResult` carries:
+- `symbols: list[CodeSymbol]` — class/function/variable definitions
+- `calls: list[CallRef]` — unresolved invocations
+- `derivations: list[DerivationRef]` — base-class / interface relationships
+- `root_node` — the tree-sitter root, kept for downstream import analysis
+
+## Adding a Language
+
+Pick the right pattern:
+- **Bespoke extractor** (Python/TS/Go) — write a new `*_extractor.py` if the language has structurally novel features (Python decorators, Go receivers, TS generics).
+- **Generic extractor** — extend the per-language config table in `generic_extractor.py` for languages with a standard "function/class declaration" shape.
+
+You also need:
+1. A tree-sitter grammar package installable via `uv add tree-sitter-<lang>`
+2. An entry in the language→extractor registry (search `extractors/__init__.py` for the pattern)
+3. Cross-validation fixtures under `../../tests/fixtures/<lang>/` (see `/tests/CLAUDE.md`)
+
+## Pitfalls
+
+- **Relative imports need directory context.** Python's `from .foo import bar` requires the analyzer to know the file's package path; missing it silently drops the mapping.
+- **Manifest parsing is best-effort.** A malformed `go.mod` won't crash but will leave external imports unresolved — they'll surface as orphan `pkg:*` nodes.
+- **AST node names differ across grammars.** Kotlin uses `simple_identifier` (not `identifier`); Rust trait methods are `function_signature_item` (not `function_item`). Validate against the grammar's `node-types.json` before hardcoding.
+- **YAML grammar fails to build for WASM** (C++ external scanner). It works in Python tree-sitter but is excluded from the UI build — keep extractor logic agnostic of "all my languages will work in the browser too".

--- a/agent/src/opentrace_agent/store/CLAUDE.md
+++ b/agent/src/opentrace_agent/store/CLAUDE.md
@@ -1,0 +1,40 @@
+# Store
+
+Graph persistence layer. Wraps LadybugDB (a Cypher-speaking embedded graph DB) and exposes a `GraphStore` interface used by the pipeline saving stage and by `serve.py` / `mcp_server.py`.
+
+## Files
+
+```
+graph_store.py   — GraphStore class: Cypher query builder, node/edge CRUD, search
+constants.py     — Schema: node types, relationship types, reserved property keys
+_schema_gen.py   — Generates LadybugDB schema DDL from the constants above
+__init__.py      — Re-exports
+```
+
+## Schema
+
+The schema is **enumerated**, not free-form. Allowed node and relationship types live in `constants.py`. Adding a new type means:
+
+1. Add it to the type enum in `constants.py`
+2. Regenerate the LadybugDB schema (`_schema_gen.py` is the source for the DDL)
+3. Update node-subclass `graph_type` ClassVars on the pipeline side
+4. Update the corresponding TS types in `ui/src/store/types.ts` (UI is the second consumer)
+
+## Property Marshalling
+
+LadybugDB stores primitives natively. Dicts are JSON-serialized into a string column and unmarshalled on read. Nested structures (dict of lists of dicts) work but are brittle — the unmarshaller has thrown on edge cases historically. Keep stored properties shallow when you can.
+
+## Cypher Conventions
+
+Queries are parameterized (`$param`) — never string-format user input into Cypher. Node labels and relationship types **are** hardcoded in the query strings; this is intentional (it lets the query planner optimize) but it means schema changes are not transparent — every query touching the renamed type needs an update.
+
+## Search
+
+Full-text search runs across `name`, `summary`, and `path` properties. There's no semantic / vector search at this layer — that's handled in the UI's `src/store/search/` (BM25 + vector + RRF) for browser-mode indexing.
+
+## Pitfalls
+
+- **No transaction support.** Concurrent writers can corrupt the graph. Today the pipeline writes single-threaded; if you parallelize saving, add a write lock or batch externally.
+- **MAP literal parsing is brittle.** When property unmarshalling fails the read returns the raw string — callers that assume `dict` will hit `AttributeError`. Add an explicit `isinstance` check at API boundaries.
+- **Hardcoded labels = silent breakage.** Renaming a node type in `constants.py` without sweeping `graph_store.py` produces queries that return zero rows — no error, no warning. Grep all string occurrences when renaming.
+- **Schema is not migrated.** There's no migration system; an existing `index.db` with an old schema will fail in subtle ways against newer code. Re-index from scratch when the schema changes.

--- a/agent/src/opentrace_agent/summarizer/CLAUDE.md
+++ b/agent/src/opentrace_agent/summarizer/CLAUDE.md
@@ -1,0 +1,35 @@
+# Summarizer
+
+One-line code summaries for graph nodes (functions, classes, files). Used by `cli/augment.py` to enrich an already-saved graph.
+
+## Files
+
+```
+base.py     — Summarizer protocol, SummarizerConfig dataclass
+flan_t5.py  — Xenova/flan-t5 implementation; batched, optionally cached
+```
+
+## Protocol
+
+```python
+class Summarizer(Protocol):
+    async def init(self) -> None: ...
+    async def summarize(self, batch: list[SummarizationInput]) -> list[str]: ...
+    async def dispose(self) -> None: ...
+```
+
+`init` / `dispose` exist because model loading is expensive — call once per process. `summarize` is batched on purpose; per-call overhead dominates inference time for short snippets.
+
+## Adding a Backend
+
+Implement `Summarizer` and wire it into `cli/augment.py`'s factory. Things to think about:
+
+- **Cold start.** Model load can take >10s. Don't init lazily inside `summarize()`.
+- **Batching.** Honor `SummarizerConfig.batch_size`; very large batches OOM small GPUs.
+- **Truncation.** Inputs longer than `max_input_length` must be cut, not rejected — augmentation should never fail an entire run because of one big file.
+
+## Pitfalls
+
+- **Flan-T5 outputs are often generic** ("This function does X") — don't rely on them as documentation. Their value is similarity search and clustering, not human reading.
+- **No fallback on init failure.** If the model can't load (missing weights, no internet for first download), the entire `augment` command fails. Acceptable today; revisit if augmentation becomes a default step.
+- **Cache keys are content-hash based.** Renaming a function with identical body returns the cached summary — fine for one-liners, but be aware if you start storing more context-dependent output.

--- a/benchmark/CLAUDE.md
+++ b/benchmark/CLAUDE.md
@@ -1,0 +1,50 @@
+# Benchmark
+
+Accuracy validation and SWE-bench evaluation harness. Driven entirely via the `Makefile` here; actual benchmark logic lives in `agent/src/opentrace_agent/benchmarks/`.
+
+## Quick Reference
+
+```bash
+make download          # Fetch SWE-bench Lite dataset (required before swe-bench targets)
+make accuracy          # All 3 graph accuracy levels
+make accuracy-1        # Level 1: single file, 8 tasks
+make accuracy-2        # Level 2: multi-file, 16 tasks
+make accuracy-3        # Level 3: polyglot, 26 tasks
+make swe-bench-smoke   # 1 SWE-bench instance (sanity check)
+make swe-bench-5       # 5 diverse instances
+make swe-bench         # Full 300 instances
+make compare           # A/B: with vs without OpenTrace
+```
+
+## Tuning Knobs
+
+| Variable | Default | Description |
+|---|---|---|
+| `V=1` | off | Verbose — show per-task results and index stats |
+| `WORKERS=N` | 1 | Parallel SWE-bench workers |
+| `BACKEND` | `claude-code` | Agent backend (`claude-code` or `api`) |
+| `MODEL` | `sonnet` | Model to use |
+
+## Accuracy Levels
+
+Accuracy benchmarks test graph extraction correctness against golden fixtures:
+
+| Level | Fixture Dir | Scope |
+|---|---|---|
+| 1 | `tests/fixtures/level1` | Single-file extraction |
+| 2 | `tests/fixtures/level2` | Multi-file with cross-file calls |
+| 3 | `tests/fixtures/level3` | Polyglot (multiple languages in one project) |
+
+Tasks (JSON) live in `agent/src/opentrace_agent/benchmarks/tasks/`. Fixtures live in `/tests/fixtures/`.
+
+## Adding a Benchmark
+
+1. Create a fixture codebase under `tests/fixtures/level{N}/` (or a new level)
+2. Write a task JSON in `agent/src/opentrace_agent/benchmarks/tasks/`
+3. Add a `make` target here, following the `accuracy-{1,2,3}` pattern
+
+## Pitfalls
+
+- **`make download` is required before any SWE-bench target.** Without it, the data file dependency fails silently (Makefile target not found).
+- **`clean` preserves `data/`.** Only `clean-all` removes downloaded datasets. This is intentional — re-downloading 300 instances is slow.
+- **All benchmarks invoke `uv run opentraceai-bench`** from the agent dir. The benchmark CLI is part of the agent package, not a standalone binary.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,42 @@
+# Docs
+
+Public documentation site built with MkDocs Material, deployed to GitHub Pages at `opentrace.github.io/opentrace`.
+
+## Build & Serve
+
+```bash
+pip install mkdocs-material   # or uv pip install
+mkdocs serve                  # Local preview at http://127.0.0.1:8000
+mkdocs build                  # Static site → site/
+```
+
+CI handles deployment — don't run `mkdocs gh-deploy` manually.
+
+## Structure
+
+```
+index.md               — Home page
+getting-started/       — Per-audience install guides (browser, CLI, plugin)
+architecture/          — System overview
+development/           — Contributor setup, contributing guide
+reference/             — Languages, chat providers, graph tools, browser requirements
+assets/                — Logo, favicon
+stylesheets/extra.css  — Custom colors overriding Material theme palette
+```
+
+Navigation is defined in `../mkdocs.yml` (`nav:` key). Adding a new page means:
+1. Create the `.md` file in the appropriate section directory
+2. Add it to the `nav:` section in `mkdocs.yml`
+
+## Conventions
+
+- **Admonitions** (`!!! note`, `!!! warning`) are enabled — use them for callouts
+- **Tabbed content** (`=== "Tab 1"`) for showing alternatives (pip vs uv, Mac vs Linux)
+- **Code copy buttons** are on by default — no annotation needed
+- **Edit links** point to `edit/main/docs/<path>` — makes "Edit this page" work on GitHub
+
+## Pitfalls
+
+- **`site_url` is hardcoded** to the GitHub Pages path. `mkdocs serve` works locally but links may render differently in dev vs production — always test with both.
+- **Custom colors** in `extra.css` override the Material palette. If you change the theme `palette` in `mkdocs.yml`, check that `extra.css` doesn't fight it.
+- **No API reference generation.** All docs are hand-written Markdown. If the agent or UI grows a generated API reference, it would need a new MkDocs plugin.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,60 @@
+# Tests
+
+Shared test fixtures for cross-validating the Python and TypeScript extractors and for integration-testing the full pipeline. These are **not** unit tests — each subsystem's unit tests live within that subsystem (`agent/tests/`, `ui/src/**/__tests__/`).
+
+## Layout
+
+```
+cross_validation/
+  test_extractors.py     — Validates Python extractors against golden .expected.json files
+fixtures/
+  cross-validation/      — Language-agnostic golden test cases (TS arrow functions, calls, etc.)
+  python/                — Python-specific: extraction/ (unit) + imports/ (analyzer) + project/ (integration)
+  typescript/            — Same layout for TypeScript
+  go/                    — Same layout for Go
+  c/ cpp/ csharp/ java/ kotlin/ ruby/ rust/ swift/  — Same pattern per language
+```
+
+## Fixture Conventions
+
+### Extraction fixtures (`<lang>/extraction/`)
+
+Each test case is a pair:
+- `<name>.<ext>` — source file input (e.g., `classes.py`, `functions.go`)
+- `<name>.expected.json` — golden output: expected `CodeSymbol[]` as JSON
+
+The `expected.json` encodes exact symbol names, types, and line numbers. Changes to the extraction format must update all relevant `.expected.json` files — there's no auto-regeneration.
+
+### Import fixtures (`<lang>/imports/`)
+
+`<name>.fixture.json` — self-contained test describing an import statement, the file context, and expected resolution result. Used by `import_analyzer` tests on both Python and TS sides.
+
+### Project fixtures (`<lang>/project/`)
+
+Multi-file mini-codebases for integration testing:
+- Pipeline integration tests in `agent/tests/` index these directories end-to-end
+- Benchmark accuracy levels (`tests/fixtures/level{1,2,3}`) reuse this structure
+
+## Cross-Validation Guarantee
+
+The Python agent and TS browser pipeline implement the **same** extraction logic independently. Fixtures here are the contract:
+
+1. Python test (`cross_validation/test_extractors.py`) runs the Python extractor on each fixture and asserts against `.expected.json`
+2. TS tests (`ui/src/components/pipeline/__tests__/`) run the TS extractor on the same fixture and assert against the same `.expected.json`
+
+If one extractor changes behavior, the fixture stays fixed, and the other extractor's test will catch the divergence. **Never update an `.expected.json` without running both test suites.**
+
+## Adding a Fixture
+
+1. Create `<lang>/extraction/<name>.<ext>` with the source code
+2. Run the extractor on it and manually verify the output
+3. Save the verified output as `<name>.expected.json`
+4. Run `make test` from the repo root — both Python and TS suites should pass
+
+For a new language: create the directory `tests/fixtures/<lang>/extraction/` and follow the same pair convention.
+
+## Pitfalls
+
+- **Exact line numbers matter.** Fixtures encode `start_line` / `end_line`; inserting a blank line in a `.py` fixture silently breaks the golden file.
+- **No auto-regen tool.** If extraction format changes (field rename, new field), you must manually update every `.expected.json`. Grep for the old field name across `tests/fixtures/`.
+- **Fixture scope is cumulative.** Some fixtures intentionally combine features (`mixed.py`) to test interactions; don't split them into single-feature files.

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -1,0 +1,80 @@
+# UI
+
+React/TypeScript frontend for OpenTrace — graph visualization, browser-based indexing, and chat. Built with Vite; renders graphs with Pixi.js v8 + d3-force.
+
+## Layout
+
+```
+src/
+  App.tsx / OpenTraceApp.tsx  — Top-level shell (settings, graph viewer, chat)
+  store/                      — GraphStore abstraction (pluggable backend)
+  job/                        — Browser job service (submits & streams indexing work)
+  components/
+    pixi/                     — WebGL graph renderer (Pixi.js + d3-force workers)
+    pipeline/                 — Browser tree-sitter extraction pipeline
+    indexing/                 — Repo-add UI (AddRepoModal, IndexingProgress)
+    graph/                    — Graphology helpers, Louvain clustering, filtering
+    workers/                  — Web Worker orchestration (layout, community)
+  graph/                      — Graph data hooks (useGraphData, useGraphInstance)
+  chat/                       — AI chat panel (tool-use against the graph)
+  config/                     — Runtime feature flags
+  gen/                        — Generated proto types (do not edit; regen via `make ts` in proto/)
+```
+
+## Two Operating Modes
+
+The UI runs in one of two modes, chosen at startup:
+
+| Mode | Store | Backend | Writes? | Use case |
+|---|---|---|---|---|
+| **Server** | `ServerGraphStore` | `opentrace serve` REST | Read-only (no-op `importBatch`) | CLI-indexed repo, production |
+| **In-memory** | `LadybugStore` (WASM) | Browser-local LadybugDB | Full read/write | Browser-only indexing |
+
+Mode is determined by whether a server URL is configured. The `StoreContext` React provider wraps the singleton store; swapping mode requires re-mounting the provider — there's no hot-swap.
+
+## Build & Dev
+
+```bash
+npm install
+npm run dev          # Vite dev server, default port 5173
+PORT=5174 npm run dev  # alternate port (strictPort — fails if taken)
+```
+
+### Vite Config Quirks
+
+- **`resolveEnvDir()`** — `.env` is gitignored; worktrees fall back to the main tree's `.env`
+- **COOP/COEP headers** — `crossOriginIsolation()` plugin sets `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` so `SharedArrayBuffer` works (required by `lbug-wasm`)
+- **WASM middleware** — force-sets `Content-Type: application/wasm` on `.wasm` responses (Vite default is wrong)
+- **Worker format** — ES modules (`worker.format: 'es'`)
+- **Aliases** — resolve to `src/components/` sources, not pre-built dist, so Vite processes workers
+
+### Thread Model
+
+Heavy computation runs off the main thread:
+
+| Worker | Purpose |
+|---|---|
+| `pixiLayoutWorker` | Persistent d3-force simulation (streamed positions) |
+| `communityWorker` | Louvain clustering |
+| `d3LayoutWorker` | One-shot layout snapshot |
+
+Workers use transferable objects (Float64Array) for zero-copy position handoff. **Copy the buffer before React state updates** — ownership transfers on `postMessage`.
+
+## Key Interfaces
+
+- `GraphStore` (`store/types.ts`) — the data-access contract. Add methods here, implement in both `serverStore.ts` and `ladybugStore.ts`, or make them optional with `?`.
+- `JobService` (`job/types.ts`) — submits indexing work, returns `JobStream` (async-iterable events).
+- `PipelineEvent` (`components/pipeline/types.ts`) — mirrors the agent's `PipelineEvent` shape; phases are `scanning → processing → resolving → summarizing → submitting`.
+
+## Dependencies on `agent/`
+
+- **Proto types** — `gen/` is generated from the same protobuf source as the agent
+- **REST endpoints** — `ServerGraphStore` calls `opentrace serve` (see `agent/src/opentrace_agent/cli/CLAUDE.md`)
+- **Extractors mirror** — the browser pipeline reimplements the same extraction logic in TS; cross-validation fixtures in `/tests/` ensure they agree
+
+## Pitfalls
+
+- **Pre-existing build errors.** `App.tsx` and `gen/` may have minor type issues that pre-date your changes — don't fix them unless they block your work.
+- **Parser init race.** `TreeSitter.Parser.init()` is global and async; calling it concurrently corrupts state. Use a singleton promise guard (`wasm.ts`).
+- **Store immutability.** Don't try to hot-swap from server to in-memory mode — re-mount `StoreContext`.
+- **SharedArrayBuffer fails silently** without COOP/COEP headers. If the dev server starts but WASM features break, check that `crossOriginIsolation()` plugin is enabled.

--- a/ui/src/components/pipeline/CLAUDE.md
+++ b/ui/src/components/pipeline/CLAUDE.md
@@ -1,0 +1,64 @@
+# Pipeline
+
+Browser-based code extraction pipeline — the TypeScript equivalent of the Python agent's `pipeline/`. Parses files with web-tree-sitter (WASM), extracts symbols, resolves calls, summarizes, and stores.
+
+## Layout
+
+```
+pipeline.ts        — Orchestrator: runPipeline(), collectPipeline()
+types.ts           — PipelineEvent, PipelinePhase, PipelineResult (mirrors agent's types)
+wasm.ts            — Tree-sitter WASM loader (singleton guard)
+parser/
+  extractors/      — Per-language extractors (python.ts, typescript.ts, go.ts, generic.ts)
+  callResolver.ts  — 7-strategy call resolution (same priorities as agent)
+  importAnalyzer.ts — Import mapping per-language (alias → file ID)
+concurrent/
+  scheduler.ts     — Multi-stage work-queue: FileCacheStage → ExtractStage → ResolveStage → SummarizeStage → StoreStage → EmbedStage
+stages/            — Individual stage implementations
+store/
+  memory.ts        — In-memory graph accumulator (collects nodes/relationships before batch flush)
+summarizer/        — Template-based code summarization
+__tests__/         — Extractor and pipeline tests
+```
+
+## Relationship to `agent/`
+
+This pipeline is a **parallel reimplementation**, not a port. It shares:
+- The same 7-strategy call resolution priorities
+- The same node type names (`Class`, `Function`, `File`, etc.)
+- Cross-validation against the same fixtures (`/tests/fixtures/`)
+
+It does NOT share code. Changes to extraction logic must be made in both places and validated via cross-validation tests.
+
+## WASM Concerns
+
+- **`web-tree-sitter`** gives a module namespace; use `TreeSitter.Parser`, `TreeSitter.Language`, etc.
+- **`Parser.init()` is global.** Concurrent calls corrupt state. `wasm.ts` wraps it in a singleton promise.
+- **`parser.parse()` returns `Tree | null`.** Must null-check before `.rootNode`.
+- **Lazy loading.** WASM grammars are loaded on first use from `/public/wasm/`. The `ParserMap` scans repo files and loads only needed grammars.
+- **SharedArrayBuffer required.** WASM streaming needs COOP/COEP headers (set by Vite config). Without them, parsing silently fails in some browsers.
+
+### Supported Languages
+
+12 parseable languages via bespoke (Python, TypeScript, Go) + generic extractor:
+
+| Bespoke | Generic |
+|---|---|
+| Python, TypeScript/TSX, Go | JavaScript, Rust, Java, Kotlin, Ruby, C, C++, C#, Swift |
+
+To add a generic language: extend the config table in `parser/extractors/generic.ts`. Needs a `tree-sitter-<lang>.wasm` in `/public/wasm/` — build with `npx tree-sitter build --wasm`.
+
+**Exception:** YAML's grammar has a C++ external scanner incompatible with WASM. It was attempted and removed.
+
+## Pipeline Phases
+
+`scanning → processing → resolving → summarizing → submitting`
+
+Each phase emits `PipelineEvent` objects (matching proto `JobPhase`). The concurrent scheduler processes these as work queues — multiple files progress through different stages in parallel. Cancellation is cooperative (checked between files, not mid-parse).
+
+## Pitfalls
+
+- **Grammar packages need `--legacy-peer-deps`** due to optional `tree-sitter` native peer dep. This only matters at install time, not runtime.
+- **Kotlin AST differences.** `simple_identifier` not `identifier`. Rust uses `function_signature_item` for trait methods.
+- **Two extractors, one truth.** When fixing an extraction bug, check if the same bug exists in the Python extractor (and vice versa). The cross-validation tests in `/tests/` will catch divergence, but only for the fixture cases.
+- **Template summarizer is the default.** LLM summarization is opt-in; the template path must work offline with no API keys.

--- a/ui/src/components/pixi/CLAUDE.md
+++ b/ui/src/components/pixi/CLAUDE.md
@@ -1,0 +1,52 @@
+# Pixi Renderer
+
+WebGL graph visualization using Pixi.js v8 + d3-force layout. Renders thousands of nodes as sprite batches with worker-offloaded physics.
+
+## Files
+
+```
+PixiRenderer.ts         — Core scene graph: sprite batching, edge drawing, quadtree hover
+PixiControlPanel.tsx    — Layout mode / zoom controls UI
+usePixiLayout.ts        — React bridge to layout worker (manages message passing)
+scaleBreakpoints.ts     — Responsive label/edge visibility thresholds
+spriteTextures.ts       — Per-color texture atlas generation
+viewport.ts             — Camera transform (zoom/pan state)
+```
+
+## Architecture
+
+- **Sprite batching** — One `Container` per node color; one circle texture per color. Adding a node = adding a sprite to its color's container. This keeps draw calls O(colors) not O(nodes).
+- **Edge throttling** — Edges re-render at max 10fps; during zoom, edges are hidden entirely until the gesture finishes. This prevents expensive line redraws from blocking panning.
+- **Quadtree hover** — O(log n) hover detection via a spatial index rebuilt on each position update. Don't do hit-testing via Pixi's built-in `interactive` (it's O(n) at scene scale).
+- **Labels** — Rendered only above `LABEL_RENDERED_SIZE_THRESHOLD` zoom level (see `scaleBreakpoints.ts`). Below that, labels are removed from the scene graph entirely — not just hidden.
+
+## Layout Worker Protocol
+
+`pixiLayoutWorker` is a **persistent** worker (lives for the session). Messages:
+
+| Message | Direction | Payload | Notes |
+|---|---|---|---|
+| `init` | Main → Worker | nodes, links, config | Returns initial positions after N sync ticks |
+| `positions` | Worker → Main | `Float64Array` (transferable) | Streamed every ~66ms (15fps) |
+| `fix-node` / `unfix-node` | Main → Worker | node id, x/y | Dragging support |
+| `set-layout-mode` | Main → Worker | `'spread'` or `'compact'` | Switches force preset |
+
+### Transferable Buffer Lifecycle
+
+Positions arrive as a `Float64Array` whose **ownership** transfers on `postMessage`. The receiving code must:
+1. **Copy** the buffer into React state (or a local snapshot)
+2. Not mutate the transferred buffer (it's neutered on the sender side)
+
+Mutating without copying causes stale/corrupt position data — this is the #1 gotcha in this module.
+
+## Adding Visual Features
+
+- **New node shapes** — add a texture to `spriteTextures.ts`, then assign it in `PixiRenderer.ts`'s node-setup logic. All nodes of a type share the texture.
+- **New edge styles** — modify the edge drawing loop in `PixiRenderer.ts`. Edges are `Graphics` objects, not sprites — they're redrawn every frame, so keep the draw calls minimal.
+- **Interaction** — all hit-testing should use the quadtree, not Pixi `interactive`.
+
+## Pitfalls
+
+- **PixiRenderer.ts is ~72KB.** It's large because it's a self-contained scene graph manager. Resist extracting small helpers — they'll just create coupling without reducing complexity.
+- **Worker URL resolution.** Rollup can't resolve worker imports from pre-built library bundles. Vite aliases in `vite.config.ts` force source-level resolution — don't change those aliases without testing production builds.
+- **Memory leaks.** Pixi textures must be explicitly destroyed. If you add new textures or containers, add cleanup in the `destroy()` method.

--- a/ui/src/job/CLAUDE.md
+++ b/ui/src/job/CLAUDE.md
@@ -1,0 +1,60 @@
+# Job Service
+
+Bridge between UI job requests and the browser pipeline. Manages job lifecycle, event streaming, and cancellation.
+
+## Files
+
+```
+types.ts              — JobMessage union, JobService interface, JobStream
+browserJobService.ts  — Implements JobService using pipeline stages + loader registry
+eventChannel.ts       — AsyncIterable event stream (push/pull bridge)
+useJobStream.ts       — React hook: job state + events for the UI
+context.tsx           — React JobServiceContext provider
+```
+
+## Execution Flow
+
+1. UI calls `jobService.submit(message)` with a `JobMessage`:
+   - `index-repo` — clone from GitHub/GitLab URL
+   - `index-directory` — local `FileList` (drag-and-drop / file picker)
+   - `import-file` — pre-built export archive (`.parquet.zip`)
+   - `connect-server` — switch to `ServerGraphStore` mode (no pipeline run)
+
+2. Service resolves the appropriate loader (git, filesystem, HTTP)
+3. Runs the concurrent pipeline (6 stages from `components/pipeline/`)
+4. Emits `PipelineEvent` per stage transition via `EventChannel`
+5. Accumulates `ImportBatchRequest` → flushes to store
+6. Streams `JobEvent` back to UI (consumed via `useJobStream` hook)
+
+## EventChannel
+
+`EventChannel<T>` is a push/pull bridge — producers call `channel.push(event)`, consumers `for await (const event of channel)`. It buffers events when the consumer is behind. Call `channel.close()` to signal completion.
+
+This is the backbone of UI progress updates — `IndexingProgress` component reads from the channel to show per-stage counts.
+
+## Cancellation
+
+Job cancellation is **cooperative**:
+- The `JobStream.cancel()` method sets an `AbortSignal`
+- Pipeline stages check `ctx.cancelled` (derived from the signal) **between files**
+- Long tree-sitter parses on individual files **cannot be interrupted mid-parse**
+- After cancellation, the pipeline drains cleanly (no partial writes)
+
+This means cancel latency is bounded by the longest single file's parse time — typically <1s, but pathologically large generated files can take longer.
+
+## React Integration
+
+```typescript
+const { stream, submit, state } = useJobStream();
+// state: 'idle' | 'running' | 'done' | 'error'
+// stream: AsyncIterable<JobEvent>
+// submit(msg: JobMessage): void
+```
+
+`useJobStream` manages job lifecycle state and exposes the event stream for rendering. Only one job runs at a time — submitting while running is a no-op (enforced by state check, not queuing).
+
+## Pitfalls
+
+- **One-job-at-a-time.** No queue, no concurrent jobs. If you need to re-index, wait for the current job to finish or cancel it first.
+- **`connect-server` is not a pipeline job.** It reconfigures the store without running extraction — don't look for pipeline events from it.
+- **EventChannel buffer grows unbounded.** If the consumer hangs (e.g., a React re-render blocks the iteration), events queue in memory. In practice this is fine (events are small), but don't buffer binary data through it.

--- a/ui/src/store/CLAUDE.md
+++ b/ui/src/store/CLAUDE.md
@@ -1,0 +1,71 @@
+# Store
+
+Data access layer — unified `GraphStore` interface with pluggable backends.
+
+## Files
+
+```
+types.ts             — GraphStore interface, DTOs (NodeResult, TraverseResult, ImportBatchRequest, ...)
+serverStore.ts       — REST client to `opentrace serve` (read-only; writes are no-ops)
+ladybugStore.ts      — Browser-local LadybugDB (WASM, Parquet-backed; full read/write)
+inMemoryStore.ts     — Legacy in-memory store (being replaced by ladybugStore)
+createLadybugStore.ts — Factory for LadybugStore (WASM init, schema setup)
+context.tsx          — React StoreContext provider
+search/              — Search implementations: BM25, vector (transformers.js), RRF fusion
+__tests__/           — Store integration tests
+```
+
+## GraphStore Contract
+
+```typescript
+interface GraphStore {
+  hasData(): boolean;            // Sync, no DB call
+  ensureReady?(): Promise<void>; // Lazy WASM init (LadybugStore only)
+  fetchGraph(query?, hops?): Promise<GraphData>;
+  fetchStats(): Promise<GraphStats>;
+  fetchMetadata(): Promise<IndexMetadata[]>;
+  importBatch(batch): Promise<ImportBatchResponse>;
+  flush(): Promise<void>;        // No-op if unbuffered
+  storeSource(files): void;
+  fetchSource(nodeId, startLine?, endLine?): Promise<NodeSourceResponse | null>;
+  searchNodes(query, limit?, nodeTypes?): Promise<NodeResult[]>;
+  listNodes(type, limit?, offset?): Promise<NodeResult[]>;
+  traverseNode(id, direction, maxDepth?, relTypes?): Promise<TraverseResult[]>;
+  // ... optional: importVectors, importDatabase, exportDatabase, setEmbedder, setLimits
+}
+```
+
+Optional methods (`?`) exist on LadybugStore only and are feature-detected at call sites. Add new methods as optional when server mode doesn't need them.
+
+## REST Endpoints (ServerGraphStore)
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/health` | GET | Readiness probe |
+| `/api/stats` | GET | Node/relationship counts |
+| `/api/graph` | GET | Fetch full graph (with optional `?query=` filter) |
+| `/api/nodes/{id}` | GET | Single node details |
+| `/api/traverse` | POST | Walk relationships (direction, depth, relTypes) |
+| `/api/source/{id}` | GET | Source code for a file node |
+| `/api/nodes/search` | GET | Full-text search |
+| `/api/nodes/list` | GET | Paginated node listing by type |
+| `/api/metadata` | GET | Index metadata (when indexed, by whom, counts) |
+
+The server side of these lives in `agent/src/opentrace_agent/cli/serve.py`. Changes must be coordinated.
+
+## Search Architecture
+
+`search/` contains three strategies:
+
+- **BM25** — classic term-frequency search over `name + summary + path`
+- **Vector** — embedding-based similarity using HuggingFace transformers.js (in-browser inference)
+- **RRF** — Reciprocal Rank Fusion to combine BM25 + vector scores
+
+These only apply in browser (LadybugStore) mode. In server mode, search delegates to the REST endpoint (which runs full-text search server-side via the `graph_store.py` Cypher layer).
+
+## Pitfalls
+
+- **Server mode is read-only.** `importBatch`, `storeSource`, `clearGraph` are all no-ops in `ServerGraphStore`. Code calling these must not assume they had an effect.
+- **LadybugStore requires WASM init.** Call `ensureReady()` before querying. The WASM init is async and can take >1s on first load.
+- **Optional method detection.** Use `if (store.importVectors)` — TypeScript's optional interface members don't throw, but calling `undefined()` does.
+- **Concurrent `flush()` calls conflict.** LadybugStore `flush()` issues bulk Parquet writes; overlapping flushes can produce duplicates. The pipeline serializes flushes; don't bypass that.


### PR DESCRIPTION
## Add localized CLAUDE.md files for AI agent context
📝 **Docs**

Adds 14 `CLAUDE.md` files across the repository to provide specialized context for AI coding agents. 

These files document architectural patterns, API boundaries, and non-obvious pitfalls specific to each sub-system (Agent, UI, Pipeline, Tests, etc.). They layer on top of the root `CLAUDE.md` without duplicating high-level information.

### Complexity
🟢 Trivial · `14 files changed, 785 insertions(+)`

Purely documentation changes with zero impact on code execution or existing system behavior.
<!-- opentrace:jid=c40fc0ab-650d-4c74-9cff-83f2bbb82162|sha=31a377b0b8fd96162a9f1924502eea227611d173 -->