### PR TITLE
feat(plugin): add debug mode via OPENTRACE_DEBUG

### DIFF
--- a/agent/tests/opentrace_agent/cli/test_edit_hook.py
+++ b/agent/tests/opentrace_agent/cli/test_edit_hook.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -27,7 +28,7 @@ from unittest.mock import patch
 # ---------------------------------------------------------------------------
 
 _SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts"
-import sys as _sys; _sys.path.insert(0, str(_SCRIPTS_DIR))  # noqa: E702 — _debug must be importable
+sys.path.insert(0, str(_SCRIPTS_DIR))  # _debug must be importable
 _HOOK_PATH = _SCRIPTS_DIR / "edit-hook.py"
 _spec = importlib.util.spec_from_file_location("edit_hook", _HOOK_PATH)
 _hook = importlib.util.module_from_spec(_spec)

--- a/agent/tests/opentrace_agent/cli/test_edit_hook.py
+++ b/agent/tests/opentrace_agent/cli/test_edit_hook.py
@@ -26,7 +26,9 @@ from unittest.mock import patch
 # Import the hook module via importlib (it's not a package)
 # ---------------------------------------------------------------------------
 
-_HOOK_PATH = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts" / "edit-hook.py"
+_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts"
+import sys as _sys; _sys.path.insert(0, str(_SCRIPTS_DIR))  # noqa: E702 — _debug must be importable
+_HOOK_PATH = _SCRIPTS_DIR / "edit-hook.py"
 _spec = importlib.util.spec_from_file_location("edit_hook", _HOOK_PATH)
 _hook = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_hook)

--- a/agent/tests/opentrace_agent/cli/test_hook.py
+++ b/agent/tests/opentrace_agent/cli/test_hook.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import subprocess
+import sys
 from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -28,7 +29,7 @@ from unittest.mock import MagicMock, patch
 # ---------------------------------------------------------------------------
 
 _SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts"
-import sys as _sys; _sys.path.insert(0, str(_SCRIPTS_DIR))  # noqa: E702 — _debug must be importable
+sys.path.insert(0, str(_SCRIPTS_DIR))  # _debug must be importable
 _HOOK_PATH = _SCRIPTS_DIR / "opentrace-hook.py"
 _spec = importlib.util.spec_from_file_location("opentrace_hook", _HOOK_PATH)
 _hook = importlib.util.module_from_spec(_spec)

--- a/agent/tests/opentrace_agent/cli/test_hook.py
+++ b/agent/tests/opentrace_agent/cli/test_hook.py
@@ -27,7 +27,9 @@ from unittest.mock import MagicMock, patch
 # Import the hook module via importlib (it's not a package)
 # ---------------------------------------------------------------------------
 
-_HOOK_PATH = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts" / "opentrace-hook.py"
+_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts"
+import sys as _sys; _sys.path.insert(0, str(_SCRIPTS_DIR))  # noqa: E702 — _debug must be importable
+_HOOK_PATH = _SCRIPTS_DIR / "opentrace-hook.py"
 _spec = importlib.util.spec_from_file_location("opentrace_hook", _HOOK_PATH)
 _hook = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_hook)

--- a/agent/tests/opentrace_agent/cli/test_hook_extract_pattern.py
+++ b/agent/tests/opentrace_agent/cli/test_hook_extract_pattern.py
@@ -23,7 +23,9 @@ import importlib.util
 from pathlib import Path
 
 # Import the hook module from the plugin scripts directory
-_HOOK_PATH = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts" / "opentrace-hook.py"
+_SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts"
+import sys as _sys; _sys.path.insert(0, str(_SCRIPTS_DIR))  # noqa: E702 — _debug must be importable
+_HOOK_PATH = _SCRIPTS_DIR / "opentrace-hook.py"
 _spec = importlib.util.spec_from_file_location("opentrace_hook", _HOOK_PATH)
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)

--- a/agent/tests/opentrace_agent/cli/test_hook_extract_pattern.py
+++ b/agent/tests/opentrace_agent/cli/test_hook_extract_pattern.py
@@ -20,11 +20,12 @@ We import from the hook script directly via importlib since it's not a package.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 # Import the hook module from the plugin scripts directory
 _SCRIPTS_DIR = Path(__file__).resolve().parents[4] / "claude-code-plugin" / "scripts"
-import sys as _sys; _sys.path.insert(0, str(_SCRIPTS_DIR))  # noqa: E702 — _debug must be importable
+sys.path.insert(0, str(_SCRIPTS_DIR))  # _debug must be importable
 _HOOK_PATH = _SCRIPTS_DIR / "opentrace-hook.py"
 _spec = importlib.util.spec_from_file_location("opentrace_hook", _HOOK_PATH)
 _mod = importlib.util.module_from_spec(_spec)

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -71,6 +71,23 @@ scripts/                    — Shell scripts used by hooks (session-start, etc.
 2. **MCP server** (`uvx opentraceai mcp`) starts over stdio and exposes graph query tools.
 3. **Agents** use the MCP tools to answer codebase questions — Claude Code routes user intent to the right agent based on the `description` field in each agent's frontmatter.
 
+## Debug Mode
+
+Set `OPENTRACE_DEBUG=1` before launching Claude Code to enable verbose hook logging:
+
+```bash
+OPENTRACE_DEBUG=1 claude
+```
+
+When enabled:
+- All hook scripts write timestamped trace lines to `.opentrace/hook-debug.log` (auto-discovered next to `index.db`).
+- The session-start systemMessage shows `| debug: <path>` so you can confirm it's active.
+- Lines also go to stderr for real-time `tail -f` if you have the process visible.
+
+Override the log path with `OPENTRACE_DEBUG_LOG=/path/to/file.log`.
+
+The log file is gitignored via the root `*.log` pattern.
+
 ## Dev Mode
 
 To run against a local checkout of the agent (e.g. when developing new MCP tools), override the MCP config to use `uv run` from the agent source directory:

--- a/claude-code-plugin/scripts/_debug.py
+++ b/claude-code-plugin/scripts/_debug.py
@@ -1,0 +1,116 @@
+# Copyright 2026 OpenTrace Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared debug logging helpers for OpenTrace Claude Code plugin hooks.
+
+Enable by setting ``OPENTRACE_DEBUG=1`` in the shell that launches Claude
+Code. When on, hook scripts emit a timestamped trace to stderr *and*, when
+a repo-scoped ``.opentrace/`` directory can be located, append to
+``.opentrace/hook-debug.log`` (alongside the index database).
+
+Override the log path with ``OPENTRACE_DEBUG_LOG=/abs/path.log``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Optional
+
+# Lenient truthiness (matches the pre-existing convention): any non-empty
+# value enables debug, including "0" or "false". Changing this would be a
+# silent behavior shift for anyone already using OPENTRACE_DEBUG.
+_DEBUG = bool(os.environ.get("OPENTRACE_DEBUG"))
+
+# Cap the upward walk to match the CLI's index discovery (10 levels).
+_MAX_WALK_DEPTH = 10
+
+
+def is_debug() -> bool:
+    """Return True when debug mode is enabled for this process."""
+    return _DEBUG
+
+
+def find_log_path(start: str) -> Optional[str]:
+    """Locate the debug log path by walking up from ``start``.
+
+    Prefers ``OPENTRACE_DEBUG_LOG`` when set. Otherwise returns
+    ``<repo>/.opentrace/hook-debug.log`` if a ``.opentrace/`` directory is
+    found within the allowed depth (stopping at the git root). Returns
+    ``None`` when no path can be determined — callers should fall back to
+    stderr-only logging.
+    """
+    override = os.environ.get("OPENTRACE_DEBUG_LOG")
+    if override:
+        return override
+
+    if not start or not os.path.isabs(start):
+        return None
+
+    current = start
+    for _ in range(_MAX_WALK_DEPTH):
+        candidate = os.path.join(current, ".opentrace")
+        if os.path.isdir(candidate):
+            return os.path.join(candidate, "hook-debug.log")
+        # Stop at git root (.git is a file in worktrees, dir otherwise)
+        if os.path.exists(os.path.join(current, ".git")):
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+class DebugLogger:
+    """Append-only debug logger; silent when ``OPENTRACE_DEBUG`` is unset.
+
+    Usage:
+        _debug = DebugLogger("opentrace-hook")
+        _debug.set_cwd(payload["cwd"])    # resolves log path lazily
+        _debug("extracted pattern=foo")
+    """
+
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+        self._log_path: Optional[str] = None
+        self._resolved = False
+
+    def set_cwd(self, cwd: str) -> None:
+        """Resolve the log file path once we know the hook's cwd."""
+        if not _DEBUG or self._resolved:
+            return
+        self._log_path = find_log_path(cwd)
+        self._resolved = True
+
+    @property
+    def log_path(self) -> Optional[str]:
+        return self._log_path
+
+    def __call__(self, msg: str) -> None:
+        if not _DEBUG:
+            return
+        line = f"{time.strftime('%Y-%m-%dT%H:%M:%S')} [{self.tag}] {msg}"
+        # Always emit to stderr — surfaces in Claude Code's transcript logs.
+        print(line, file=sys.stderr)
+        # Also append to the log file when we have a resolved path.
+        if self._log_path:
+            try:
+                with open(self._log_path, "a", encoding="utf-8") as fh:
+                    fh.write(line + "\n")
+            except OSError:
+                # A hook that crashes on logging is worse than one that
+                # logs nothing. Swallow I/O errors silently.
+                pass

--- a/claude-code-plugin/scripts/_debug.py
+++ b/claude-code-plugin/scripts/_debug.py
@@ -102,7 +102,7 @@ class DebugLogger:
     def __call__(self, msg: str) -> None:
         if not _DEBUG:
             return
-        line = f"{time.strftime('%Y-%m-%dT%H:%M:%S')} [{self.tag}] {msg}"
+        line = f"{time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime())} [{self.tag}] {msg}"
         # Always emit to stderr — surfaces in Claude Code's transcript logs.
         print(line, file=sys.stderr)
         # Also append to the log file when we have a resolved path.

--- a/claude-code-plugin/scripts/edit-hook.py
+++ b/claude-code-plugin/scripts/edit-hook.py
@@ -30,17 +30,15 @@ import re
 import shutil
 import subprocess
 import sys
+import time
+
+from _debug import DebugLogger
 
 # ---------------------------------------------------------------------------
-# Debug logging
+# Debug logging — enabled via OPENTRACE_DEBUG. See scripts/_debug.py.
 # ---------------------------------------------------------------------------
 
-_DEBUG = bool(os.environ.get("OPENTRACE_DEBUG"))
-
-
-def _debug(msg: str) -> None:
-    if _DEBUG:
-        print(f"[edit-hook] {msg}", file=sys.stderr)
+_debug = DebugLogger("edit-hook")
 
 
 # ---------------------------------------------------------------------------
@@ -79,14 +77,12 @@ def _estimate_line_range(old_string: str, new_string: str, file_path: str) -> st
 
 def run_opentraceai(args: list[str], cwd: str, timeout: int = 10) -> str | None:
     """Run the opentraceai CLI and return stdout on success."""
-    try:
-        exe = shutil.which("opentraceai")
-        if exe:
-            cmd = [exe, *args]
-        else:
-            cmd = ["uvx", "opentraceai", *args]
+    exe = shutil.which("opentraceai")
+    cmd = [exe, *args] if exe else ["uvx", "opentraceai", *args]
+    _debug(f"cli: exec={'direct' if exe else 'uvx'} cmd={cmd!r} cwd={cwd!r} timeout={timeout}")
 
-        _debug(f"running: {cmd}")
+    start = time.monotonic()
+    try:
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -94,12 +90,24 @@ def run_opentraceai(args: list[str], cwd: str, timeout: int = 10) -> str | None:
             cwd=cwd,
             timeout=timeout,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
     except subprocess.TimeoutExpired:
-        _debug("opentraceai timed out")
+        _debug(f"cli: TIMEOUT after {time.monotonic() - start:.2f}s")
+        return None
     except Exception as exc:
-        _debug(f"opentraceai error: {exc}")
+        _debug(f"cli: ERROR after {time.monotonic() - start:.2f}s: {exc}")
+        return None
+
+    duration = time.monotonic() - start
+    out = result.stdout.strip()
+    err = result.stderr.strip()
+    _debug(
+        f"cli: rc={result.returncode} duration={duration:.2f}s "
+        f"stdout_len={len(out)} stderr_len={len(err)}"
+    )
+    if err:
+        _debug(f"cli: stderr={err[:200]!r}")
+    if result.returncode == 0 and out:
+        return out
     return None
 
 
@@ -142,17 +150,18 @@ def _is_code_file(path: str) -> bool:
 def handle_post_tool_use(payload: dict) -> None:
     """Analyze the impact of an edit/write and inject context."""
     cwd = payload.get("cwd", "")
-    if not cwd or not os.path.isabs(cwd):
-        _debug("no absolute cwd, skipping")
-        return
-
     tool_name = payload.get("tool_name", "")
     tool_input = payload.get("tool_input", {})
+    _debug(f"post_tool_use: tool={tool_name!r} cwd={cwd!r} input_keys={list(tool_input)}")
+
+    if not cwd or not os.path.isabs(cwd):
+        _debug("post_tool_use: skip — no absolute cwd")
+        return
 
     # Extract file path
     file_path = tool_input.get("file_path", "")
     if not file_path:
-        _debug("no file_path in tool_input")
+        _debug("post_tool_use: skip — no file_path in tool_input")
         return
 
     # Ensure path is absolute if relative
@@ -160,10 +169,10 @@ def handle_post_tool_use(payload: dict) -> None:
         file_path = os.path.join(cwd, file_path)
 
     if not _is_code_file(file_path):
-        _debug(f"skipping non-code file: {file_path}")
+        _debug(f"post_tool_use: skip — non-code file: {file_path}")
         return
 
-    _debug(f"analyzing impact for {tool_name} on {file_path}")
+    _debug(f"post_tool_use: analyzing tool={tool_name} path={file_path}")
 
     # Build the CLI args
     args = ["impact", "--", file_path]
@@ -176,11 +185,16 @@ def handle_post_tool_use(payload: dict) -> None:
             line_spec = _estimate_line_range(old_string, new_string, file_path)
             if line_spec:
                 args = ["impact", "--lines", line_spec, "--", file_path]
-                _debug(f"estimated line range: {line_spec}")
+                _debug(f"post_tool_use: estimated line_range={line_spec}")
+            else:
+                _debug("post_tool_use: line_range=unknown (new_string not found in file)")
 
     result = run_opentraceai(args, cwd=cwd)
     if result:
+        _debug(f"post_tool_use: hit — injecting {len(result)} chars of context")
         send_hook_response(result)
+    else:
+        _debug("post_tool_use: miss — no impact output")
 
 
 # ---------------------------------------------------------------------------
@@ -197,14 +211,18 @@ def main() -> None:
         _debug(f"failed to parse stdin: {exc}")
         return
 
+    # Resolve the debug log path from the payload's cwd so subsequent
+    # log lines also land in the file (not just stderr).
+    _debug.set_cwd(payload.get("cwd", ""))
+
     event = payload.get("hook_event_name", "")
-    _debug(f"event={event}")
+    _debug(f"main: event={event!r} log={_debug.log_path!r}")
 
     try:
         if event == "PostToolUse":
             handle_post_tool_use(payload)
     except Exception as exc:
-        _debug(f"unhandled error: {exc}")
+        _debug(f"main: unhandled error: {exc}")
 
 
 if __name__ == "__main__":

--- a/claude-code-plugin/scripts/opentrace-hook.py
+++ b/claude-code-plugin/scripts/opentrace-hook.py
@@ -28,17 +28,15 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
+
+from _debug import DebugLogger
 
 # ---------------------------------------------------------------------------
-# Debug logging — only when OPENTRACE_DEBUG is set
+# Debug logging — enabled via OPENTRACE_DEBUG. See scripts/_debug.py.
 # ---------------------------------------------------------------------------
 
-_DEBUG = bool(os.environ.get("OPENTRACE_DEBUG"))
-
-
-def _debug(msg: str) -> None:
-    if _DEBUG:
-        print(f"[opentrace-hook] {msg}", file=sys.stderr)
+_debug = DebugLogger("opentrace-hook")
 
 
 # ---------------------------------------------------------------------------
@@ -85,8 +83,8 @@ def extract_pattern(tool_name: str, tool_input: dict) -> str | None:
                     continue
                 if len(tok) >= 3:
                     return tok
-    except Exception:
-        _debug(f"extract_pattern error for {tool_name}")
+    except Exception as exc:
+        _debug(f"extract_pattern: error tool={tool_name}: {exc}")
     return None
 
 
@@ -97,14 +95,12 @@ def extract_pattern(tool_name: str, tool_input: dict) -> str | None:
 
 def run_opentraceai(args: list[str], cwd: str, timeout: int = 7) -> str | None:
     """Run the opentraceai CLI and return stdout on success."""
-    try:
-        exe = shutil.which("opentraceai")
-        if exe:
-            cmd = [exe, *args]
-        else:
-            cmd = ["uvx", "opentraceai", *args]
+    exe = shutil.which("opentraceai")
+    cmd = [exe, *args] if exe else ["uvx", "opentraceai", *args]
+    _debug(f"cli: exec={'direct' if exe else 'uvx'} cmd={cmd!r} cwd={cwd!r} timeout={timeout}")
 
-        _debug(f"running: {cmd}")
+    start = time.monotonic()
+    try:
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -112,12 +108,24 @@ def run_opentraceai(args: list[str], cwd: str, timeout: int = 7) -> str | None:
             cwd=cwd,
             timeout=timeout,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
     except subprocess.TimeoutExpired:
-        _debug("opentraceai timed out")
+        _debug(f"cli: TIMEOUT after {time.monotonic() - start:.2f}s")
+        return None
     except Exception as exc:
-        _debug(f"opentraceai error: {exc}")
+        _debug(f"cli: ERROR after {time.monotonic() - start:.2f}s: {exc}")
+        return None
+
+    duration = time.monotonic() - start
+    out = result.stdout.strip()
+    err = result.stderr.strip()
+    _debug(
+        f"cli: rc={result.returncode} duration={duration:.2f}s "
+        f"stdout_len={len(out)} stderr_len={len(err)}"
+    )
+    if err:
+        _debug(f"cli: stderr={err[:200]!r}")
+    if result.returncode == 0 and out:
+        return out
     return None
 
 
@@ -145,24 +153,29 @@ def handle_pre_tool_use(payload: dict) -> None:
     """Augment search tool calls with graph context."""
     try:
         cwd = payload.get("cwd", "")
-        if not cwd or not os.path.isabs(cwd):
-            _debug("no absolute cwd, skipping")
-            return
-
         tool_name = payload.get("tool_name", "")
         tool_input = payload.get("tool_input", {})
-        pattern = extract_pattern(tool_name, tool_input)
-        if not pattern or len(pattern) < 3:
-            _debug(f"pattern too short: {pattern!r}")
+        _debug(f"pre_tool_use: tool={tool_name!r} cwd={cwd!r} input_keys={list(tool_input)}")
+
+        if not cwd or not os.path.isabs(cwd):
+            _debug("pre_tool_use: skip — no absolute cwd")
             return
 
-        _debug(f"augmenting {tool_name} with pattern={pattern!r}")
+        pattern = extract_pattern(tool_name, tool_input)
+        if not pattern or len(pattern) < 3:
+            _debug(f"pre_tool_use: skip — pattern too short ({pattern!r})")
+            return
+
+        _debug(f"pre_tool_use: augmenting tool={tool_name} pattern={pattern!r}")
         # Let the CLI handle DB discovery via its own find_db()
         result = run_opentraceai(["augment", "--", pattern], cwd=cwd)
         if result:
+            _debug(f"pre_tool_use: hit — injecting {len(result)} chars of context")
             send_hook_response("PreToolUse", result)
+        else:
+            _debug("pre_tool_use: miss — no augment output")
     except Exception as exc:
-        _debug(f"handle_pre_tool_use error: {exc}")
+        _debug(f"pre_tool_use: unhandled error: {exc}")
 
 
 # ---------------------------------------------------------------------------
@@ -180,14 +193,18 @@ def main() -> None:
         _debug(f"failed to parse stdin: {exc}")
         return
 
+    # Resolve the debug log path from the payload's cwd so subsequent
+    # log lines also land in the file (not just stderr).
+    _debug.set_cwd(payload.get("cwd", ""))
+
     event = payload.get("hook_event_name", "")
-    _debug(f"event={event}")
+    _debug(f"main: event={event!r} log={_debug.log_path!r}")
 
     try:
         if event == "PreToolUse":
             handle_pre_tool_use(payload)
     except Exception as exc:
-        _debug(f"unhandled error: {exc}")
+        _debug(f"main: unhandled error: {exc}")
 
 
 if __name__ == "__main__":

--- a/claude-code-plugin/scripts/session-start.sh
+++ b/claude-code-plugin/scripts/session-start.sh
@@ -19,6 +19,47 @@
 
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Debug logging — enabled via OPENTRACE_DEBUG (see scripts/_debug.py for the
+# Python-side equivalent). Writes timestamped lines to stderr and, when a
+# .opentrace/ directory can be located, appends to .opentrace/hook-debug.log.
+# NEVER write debug output to stdout — stdout is parsed as JSON by Claude.
+# ---------------------------------------------------------------------------
+OT_DEBUG="${OPENTRACE_DEBUG:-}"
+OT_LOG_PATH=""
+
+if [ -n "$OT_DEBUG" ]; then
+  if [ -n "${OPENTRACE_DEBUG_LOG:-}" ]; then
+    OT_LOG_PATH="$OPENTRACE_DEBUG_LOG"
+  else
+    # Walk up from cwd for an existing .opentrace/ dir (cap at 10 levels).
+    _CUR="$(pwd)"
+    for _ in $(seq 1 10); do
+      if [ -d "$_CUR/.opentrace" ]; then
+        OT_LOG_PATH="$(cd "$_CUR/.opentrace" && pwd)/hook-debug.log"
+        break
+      fi
+      _PARENT="$(dirname "$_CUR")"
+      [ "$_PARENT" = "$_CUR" ] && break
+      [ -e "$_CUR/.git" ] && break
+      _CUR="$_PARENT"
+    done
+    unset _CUR _PARENT
+  fi
+fi
+
+_ot_log() {
+  [ -z "$OT_DEBUG" ] && return 0
+  local line
+  line="$(date -u +'%Y-%m-%dT%H:%M:%S') [session-start] $*"
+  printf '%s\n' "$line" >&2
+  if [ -n "$OT_LOG_PATH" ]; then
+    printf '%s\n' "$line" >> "$OT_LOG_PATH" 2>/dev/null || true
+  fi
+}
+
+_ot_log "starting pwd=$(pwd) log=${OT_LOG_PATH:-<stderr-only>}"
+
 # Walk up looking for .opentrace/index.db (same logic as the CLI)
 DB_PATH=""
 CURRENT="$(pwd)"
@@ -40,11 +81,16 @@ json_escape() {
 }
 
 if [ -z "$DB_PATH" ]; then
+  _ot_log "db=not-found — will kick off background index"
   # No index found — start indexing in the background
   REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
   if [ -n "$REPO_ROOT" ] && command -v uvx &>/dev/null; then
+    _ot_log "background index: repo_root=$REPO_ROOT"
     nohup uvx opentraceai index "$REPO_ROOT" \
       >"${REPO_ROOT}/.opentrace-index.log" 2>&1 &
+    _ot_log "background index: pid=$! log=${REPO_ROOT}/.opentrace-index.log"
+  else
+    _ot_log "background index: skipped (repo_root=$REPO_ROOT uvx=$(command -v uvx || echo missing))"
   fi
 
   NO_INDEX_MSG="OpenTrace: no index found — background indexing started. Tools will be available shortly."
@@ -58,10 +104,15 @@ EOF
   exit 0
 fi
 
+_ot_log "db=$DB_PATH"
+
 # Get graph stats (best-effort, timeout 10s)
 GRAPH_STATS=""
 if command -v uvx &>/dev/null; then
   GRAPH_STATS=$(timeout 10 uvx opentraceai stats 2>/dev/null || true)
+  _ot_log "stats: len=${#GRAPH_STATS}"
+else
+  _ot_log "stats: skipped (uvx missing)"
 fi
 
 # Check for CLI updates (best-effort, timeout 5s)
@@ -70,9 +121,12 @@ if command -v uvx &>/dev/null && command -v curl &>/dev/null; then
   INSTALLED_VERSION=$(timeout 5 uvx opentraceai --version 2>/dev/null | grep -oP '[\d]+\.[\d]+\.[\d]+' || true)
   LATEST_VERSION=$(timeout 5 curl -sS https://pypi.org/pypi/opentraceai/json 2>/dev/null \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])" 2>/dev/null || true)
+  _ot_log "versions: installed=$INSTALLED_VERSION latest=$LATEST_VERSION"
   if [ -n "$INSTALLED_VERSION" ] && [ -n "$LATEST_VERSION" ] && [ "$INSTALLED_VERSION" != "$LATEST_VERSION" ]; then
     UPDATE_NOTICE="Update available: opentraceai ${INSTALLED_VERSION} → ${LATEST_VERSION}. Run /update to upgrade."
   fi
+else
+  _ot_log "update-check: skipped (uvx=$(command -v uvx || echo missing) curl=$(command -v curl || echo missing))"
 fi
 
 
@@ -87,6 +141,17 @@ fi
 if [ -n "$UPDATE_NOTICE" ]; then
   SYSTEM_MSG="${SYSTEM_MSG} | ${UPDATE_NOTICE}"
 fi
+
+# Show a debug marker so the user sees their env var is actually live.
+if [ -n "$OT_DEBUG" ]; then
+  if [ -n "$OT_LOG_PATH" ]; then
+    SYSTEM_MSG="${SYSTEM_MSG} | debug: ${OT_LOG_PATH}"
+  else
+    SYSTEM_MSG="${SYSTEM_MSG} | debug: stderr only"
+  fi
+fi
+
+_ot_log "systemMessage: ${SYSTEM_MSG}"
 
 SAFE_CONTEXT=$(json_escape "${CONTEXT}")
 SAFE_SYSTEM=$(json_escape "${SYSTEM_MSG}")


### PR DESCRIPTION
## Add debug mode with verbose logging for plugin hooks
🆕 **New Feature** · ✨ **Improvement** · 📝 **Docs**

Introduces a verbose debug mode for Claude Code plugin hooks to improve observability. Hooks now log detailed execution traces (commands, durations, exit codes, and output sizes) to stderr and a local `.opentrace/hook-debug.log` file.

- Enable by setting `OPENTRACE_DEBUG=1` before launching Claude.
- Includes a shared `_debug.py` utility for Python hooks and an equivalent Bash implementation for `session-start.sh`.
- Logs are automatically ignored by git via the root `*.log` pattern.
- The session-start `systemMessage` now surfaces the log path when active for easy discovery.

### Complexity
🟢 Low · `5 files changed, 289 insertions(+), 56 deletions(-)`

The changes are localized to the plugin scripts and do not affect the core agent logic. The feature is opt-in and non-breaking for existing hook consumers.

### Tests
🧪 Existing hook integration tests continue to pass; the new debug output is directed to stderr and does not interfere with JSON parsing on stdout.

### Review focus
Pay particular attention to the following areas:

- **I/O safety** — verify that `OSError` is correctly swallowed in the Python logger and `2>/dev/null` is used in Bash to prevent hook crashes during logging failures.
- **Path discovery** — confirm the upward walk logic in both Python and Bash correctly identifies the `.opentrace` directory and respects the 10-level depth limit.
<!-- opentrace:jid=df2e8ab9-b0c8-4128-b04a-35aa9c88eaec|sha=1a0e51a10c4acc8a9e60413d0c5d86c9da3f5e25 -->