### PR TITLE
feat(ui): enforce 500 MB repository archive limit with clear errors

### DIFF
--- a/ui/src/components/indexing/AddRepoModal.tsx
+++ b/ui/src/components/indexing/AddRepoModal.tsx
@@ -970,7 +970,7 @@ export default function AddRepoModal({
           )}
 
           {source === 'url' && (
-            <div className="form-info form-info--limit">
+            <div className="form-info">
               <svg
                 width="14"
                 height="14"

--- a/ui/src/components/indexing/AddRepoModal.tsx
+++ b/ui/src/components/indexing/AddRepoModal.tsx
@@ -969,6 +969,26 @@ export default function AddRepoModal({
             </div>
           )}
 
+          {source === 'url' && (
+            <div className="form-info form-info--limit">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="16" x2="12" y2="12" />
+                <line x1="12" y1="8" x2="12.01" y2="8" />
+              </svg>
+              <span>Repositories must be under 500 MB.</span>
+            </div>
+          )}
+
           <button
             type="submit"
             className="btn-cta"

--- a/ui/src/runner/browser/loader/constants.ts
+++ b/ui/src/runner/browser/loader/constants.ts
@@ -216,3 +216,10 @@ export const BINARY_EXTENSIONS = new Set([
 
 /** Max file size (bytes) to attempt parsing. Files larger are skipped. */
 export const MAX_FILE_SIZE = 1_000_000;
+
+/**
+ * Max archive size (bytes) for repository downloads.
+ * Matches the UI's MiB-based display boundary: fires as soon as
+ * `(bytes / 1024 / 1024).toFixed(1)` rounds to "500.0" MB.
+ */
+export const MAX_ARCHIVE_SIZE = Math.ceil(499.95 * 1024 * 1024);

--- a/ui/src/runner/browser/loader/shared.ts
+++ b/ui/src/runner/browser/loader/shared.ts
@@ -26,6 +26,7 @@ import {
   BINARY_EXTENSIONS,
   EXCLUDED_DIRS,
   IMAGE_EXTENSIONS,
+  MAX_ARCHIVE_SIZE,
   MAX_FILE_SIZE,
 } from './constants';
 import type { RepoFile } from '../types';
@@ -221,6 +222,13 @@ export async function fetchResolvedArchive(
 
   const total = contentLength || 0;
 
+  // Reject archives that exceed the size limit
+  if (total >= MAX_ARCHIVE_SIZE) {
+    throw new Error(
+      `Repository exceeds 500 MB limit (${(total / 1024 / 1024).toFixed(0)} MB). Try a smaller repository or use the CLI agent for large codebases.`,
+    );
+  }
+
   // If no ReadableStream body (unlikely in modern browsers), fall back
   if (!zipRes.body) {
     const buf = new Uint8Array(await zipRes.arrayBuffer());
@@ -238,7 +246,14 @@ export async function fetchResolvedArchive(
     if (done) break;
     chunks.push(value);
     received += value.length;
+    // Update UI first so the user sees the 500 MB value before the error.
     onProgress?.({ phase: 'download', current: received, total });
+    if (received >= MAX_ARCHIVE_SIZE) {
+      reader.cancel();
+      throw new Error(
+        'Repository exceeds 500 MB limit. Try a smaller repository or use the CLI agent for large codebases.',
+      );
+    }
   }
 
   // Concatenate chunks

--- a/ui/src/runner/browser/loader/shared.ts
+++ b/ui/src/runner/browser/loader/shared.ts
@@ -225,13 +225,18 @@ export async function fetchResolvedArchive(
   // Reject archives that exceed the size limit
   if (total >= MAX_ARCHIVE_SIZE) {
     throw new Error(
-      `Repository exceeds 500 MB limit (${(total / 1024 / 1024).toFixed(0)} MB). Try a smaller repository or use the CLI agent for large codebases.`,
+      `Repository exceeds 500 MB limit (${(total / 1024 / 1024).toFixed(1)} MB). Try a smaller repository or use the CLI agent for large codebases.`,
     );
   }
 
   // If no ReadableStream body (unlikely in modern browsers), fall back
   if (!zipRes.body) {
     const buf = new Uint8Array(await zipRes.arrayBuffer());
+    if (buf.length >= MAX_ARCHIVE_SIZE) {
+      throw new Error(
+        `Repository exceeds 500 MB limit (${(buf.length / 1024 / 1024).toFixed(1)} MB). Try a smaller repository or use the CLI agent for large codebases.`,
+      );
+    }
     onProgress?.({ phase: 'download', current: buf.length, total: buf.length });
     return { data: buf, gitMeta };
   }
@@ -251,7 +256,7 @@ export async function fetchResolvedArchive(
     if (received >= MAX_ARCHIVE_SIZE) {
       reader.cancel();
       throw new Error(
-        'Repository exceeds 500 MB limit. Try a smaller repository or use the CLI agent for large codebases.',
+        `Repository exceeds 500 MB limit (reached ${(received / 1024 / 1024).toFixed(1)} MB). Try a smaller repository or use the CLI agent for large codebases.`,
       );
     }
   }


### PR DESCRIPTION
## Enforce 500 MB limit for repository archive downloads
🆕 **New Feature** · ✨ **Improvement**

This PR enforces a 500 MB limit on repository archives to prevent browser-side stalling and memory crashes. 

It adds an upfront notice to the repository modal and implements a streaming size check that aborts the download immediately if the limit is exceeded.

### Complexity
🟢 Low · `3 files changed, 42 insertions(+)`

The scope is limited to the repository fetch utility and a single UI component. It introduces a safeguard using existing progress-reporting patterns without altering core indexing logic.

### Tests
🧪 The new size-limiting logic in the fetch helper is currently untested in the automated suite.

### Review focus
Pay particular attention to the following areas:

- **Rounding boundary** — verify that `MAX_ARCHIVE_SIZE` correctly triggers exactly when the UI would round the display value to 500.0 MB.
- **Stream cancellation** — ensure `reader.cancel()` effectively halts the network request to prevent further data usage once the limit is hit.
<!-- opentrace:jid=j-4dc832d9-b596-449a-ab35-609ac4d529ec|sha=adb3d404f15bfe951cd7e3c26fb66ba30e5b3340 -->