### PR TITLE
fix(ui): reset buffered write counters in clearGraph

### DIFF
--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -1445,6 +1445,10 @@ export class LadybugGraphStore implements GraphStore {
     this.flushedSourceIds.clear();
     this.sourceCache.clear();
     this.sourceSnippets.clear();
+    this.pendingNodes = [];
+    this.pendingRels = [];
+    this.totalNodesBuffered = 0;
+    this.totalRelsBuffered = 0;
   }
 
   async importDatabase(
@@ -1476,13 +1480,7 @@ export class LadybugGraphStore implements GraphStore {
       );
     }
 
-    // Drain any pending buffered writes so they don't leak into the import
-    this.pendingNodes = [];
-    this.pendingRels = [];
-    this.totalNodesBuffered = 0;
-    this.totalRelsBuffered = 0;
-
-    // Clear current data and reset caches
+    // Clear current data and reset caches (also drains pending buffered writes)
     await this.clearGraph();
 
     let totalNodes = 0;


### PR DESCRIPTION
## Reset buffered write counters in clearGraph
🐛 **Bug Fix**

Resets buffered write counters during `clearGraph` to ensure consistent state management across the UI.

This ensures that `hasData()` correctly returns `false` after a manual clear, preventing the UI from attempting to fetch or visualize non-existent data.

### Complexity
🟢 Trivial · `1 file changed, 5 insertions(+), 7 deletions(-)`

Narrow scope bug fix in a single store implementation that moves state-resetting logic to the correct lifecycle method.
<!-- opentrace:jid=j-4624e69a-7060-4543-bd0d-b2d962157e33|sha=0b33cc8a7698db451799d4a3d3926a4d41d23719 -->