### PR TITLE
fix(pixi): stabilize 3D rendering under spread-layout drift

### DIFF
--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -281,6 +281,7 @@ export class PixiRenderer {
   private mode3dPerspectiveD = 2000; // perspective distance
   private nodeDepthT: Map<string, number> = new Map(); // per-node depth [-1, 1]
   private mode3dRadius = 0; // computed from node positions at enable time
+  private mode3dFrameCounter = 0;
 
   // Animation cancel
   private cancelAnimation: (() => void) | null = null;
@@ -1971,6 +1972,7 @@ export class PixiRenderer {
     communityAssignments?: Record<string, number>,
   ): void {
     this.mode3d = enabled;
+    this.mode3dFrameCounter = 0;
     if (!enabled) {
       // Restore 2D positions from stored (x, y)
       for (const node of this.nodeArray) {
@@ -1985,13 +1987,11 @@ export class PixiRenderer {
       return;
     }
 
-    // Compute bounding radius from current positions
-    let maxDist = 0;
-    for (const node of this.nodeArray) {
-      const d = Math.sqrt(node.x * node.x + node.y * node.y);
-      if (d > maxDist) maxDist = d;
-    }
-    this.mode3dRadius = maxDist * 1.1 || 500;
+    // Compute initial bounding radius from current positions.
+    // Reset first so recomputeMode3DExtents() picks the real extent
+    // rather than a stale (possibly larger) previous radius.
+    this.mode3dRadius = 0;
+    this.recomputeMode3DExtents();
 
     // Assign Z depth per node: community-based + jitter
     this.nodeDepthT.clear();
@@ -2016,12 +2016,6 @@ export class PixiRenderer {
       }
     }
 
-    // Scale perspective distance to graph size so the 3D effect is proportional.
-    // PerspectiveD should be ~3-4x the radius for a natural look.
-    this.mode3dPerspectiveD = this.mode3dRadius * 3;
-    // Depth scale relative to radius — controls how "thick" the sphere is
-    this.mode3dDepthScale = this.mode3dRadius * 0.6;
-
     this.mode3dAngle = 0;
     this.mode3dAutoRotate = true;
 
@@ -2029,6 +2023,32 @@ export class PixiRenderer {
     this.update3D();
     this.lastLabelCull = 0;
     this.throttledLabelCull();
+  }
+
+  /**
+   * Recompute `mode3dRadius` (and derived perspective/depth scales) from the
+   * current node positions. Radius only grows: while the simulation is warm,
+   * nodes can drift outward and we must keep the sphere bounds in sync so
+   * `getNodeZ()` does not hard-clamp drifted nodes to Z=0 (which collapses the
+   * sphere into a disk). Called from `set3DMode()` and periodically from
+   * `update3D()`.
+   */
+  private recomputeMode3DExtents(): void {
+    let maxDist = 0;
+    for (const node of this.nodeArray) {
+      if (!node.visible) continue;
+      const d = Math.sqrt(node.x * node.x + node.y * node.y);
+      if (d > maxDist) maxDist = d;
+    }
+    const candidate = maxDist * 1.1 || 500;
+    const newRadius = Math.max(this.mode3dRadius, candidate);
+    if (newRadius !== this.mode3dRadius) {
+      this.mode3dRadius = newRadius;
+      // PerspectiveD ~3-4x the radius for a natural look.
+      this.mode3dPerspectiveD = newRadius * 3;
+      // Depth scale relative to radius — controls how "thick" the sphere is.
+      this.mode3dDepthScale = newRadius * 0.6;
+    }
   }
 
   /** Get Z coordinate for a node (filled sphere distribution). */
@@ -2072,6 +2092,14 @@ export class PixiRenderer {
       this.mode3dAngle += this.mode3dSpeed;
     }
 
+    // Keep sphere bounds in sync with drifting node positions (spread layout
+    // can push nodes beyond the initial radius over time). Throttled to every
+    // ~0.5s at 60fps — amortized cost is negligible even at thousands of nodes.
+    this.mode3dFrameCounter++;
+    if (this.mode3dFrameCounter % 30 === 0) {
+      this.recomputeMode3DExtents();
+    }
+
     const invScale = this.zoomInvScale();
     const lblInv = this.labelInvScale();
     for (const node of this.nodeArray) {
@@ -2081,7 +2109,10 @@ export class PixiRenderer {
       const z = this.getNodeZ(node);
       const p = this.project3d(node.x, node.y, z);
       node.sprite.position.set(p.px, p.py);
-      const depthScale = Math.max(p.scale, 0.3);
+      // Clamp both ends: the lower bound prevents far nodes from vanishing,
+      // the upper bound prevents near-singular perspective scale from exploding
+      // sprite/label sizes when rz approaches -mode3dPerspectiveD during rotation.
+      const depthScale = Math.max(0.3, Math.min(p.scale, 2));
       const depthAlpha = 0.3 + 0.6 * Math.max(Math.min(p.scale, 1), 0);
 
       // Depth sorting: closer nodes (lower rz) render on top (higher zIndex)


### PR DESCRIPTION
## Summary

Fixes two defects in the pseudo-3D renderer that caused progressive visual degradation of the graph when 3D mode, spread layout, and zoom-to-node were active at the same time (OT-1691). After repeated node/background clicking, the initial sphere collapsed into a disk/cylinder, and individual labels/sprites would grow unboundedly as the auto-rotation swept through the critical angles.

Scope is deliberately narrow: only `PixiRenderer.ts` is touched. The layout worker is untouched, so compact mode and existing consumers (e.g. `insight-ui`) see no behavioural change.

## Root cause

### 1. `mode3dRadius` frozen at enable time

`set3DMode()` captured `mode3dRadius` once from the current node positions (`maxDist * 1.1`) and never updated it. The spread simulation can push nodes outward over time (reheats on add-nodes, drag end, layout-mode switch, etc.). Once a node's `sqrt(x² + y²) >= mode3dRadius`, `getNodeZ()` hard-clamps its Z to 0 with no recovery path, so the outermost nodes flatten first. That is why the shape progressively decayed from sphere to cylinder/disk.

### 2. Unbounded perspective scale

`project3d()` returns `scale = mode3dPerspectiveD / (mode3dPerspectiveD + rz)`. When a drifted node rotates through `rz → -mode3dPerspectiveD`, the denominator approaches zero and `scale` diverges. `update3D()` had only a lower clamp (`Math.max(p.scale, 0.3)`) with no ceiling, so sprite and label scales followed the divergence — the reported "labels suddenly get huge in the foreground" symptom.

## Fixes

All changes in `ui/src/components/pixi/PixiRenderer.ts`:

- Extracted the radius computation into `recomputeMode3DExtents()`, which also re-derives `mode3dPerspectiveD` and `mode3dDepthScale` from the new radius.
- `update3D()` now calls `recomputeMode3DExtents()` every ~30 frames (~0.5 s at 60 fps). Amortized O(n) overhead is negligible at thousands of nodes.
- The radius only grows (hysteresis), so stable layouts do not wobble.
- Added an upper clamp of `2` on `depthScale` in `update3D()`: `Math.max(0.3, Math.min(p.scale, 2))`. Two is the maximum sensible perspective magnification and bounds both sprite and label scale.

## Test plan

- [x] `npm run lint` — passes (no new warnings)
- [x] `npm run test` — 880 tests pass
- [x] `npm run build` — production build green
- [x] `npm run build:lib` — library build green
- [x] Manual reproduction in the opentrace dev UI on a 6132-node / 9190-edge graph, 3D + spread + zoom-to-node active, ~47 click cycles (node → background, various screen regions, aggressive zoom, many rotation passes):
    - Sphere remained stable — no collapse to disk/cylinder
    - No label or sprite explosions — label sizes stayed uniform across all frames
    - Auto-rotation swept cleanly through all angles, no hitches
- [x] Verified as a downstream library consumer via `insight-ui` (tarball install):
    - 2D mode renders correctly on project switch
    - 3D mode renders correctly and remains stable through the OT-1691 repro sequence
- [x] 2D mode untouched — `set3DMode(false, …)` short-circuits before the radius logic, and `update3D()` only runs while `this.mode3d === true`.
- [x] Layout worker untouched — compact and spread force configurations are unchanged.

Closes OT-1691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)