### PR TITLE
feat(ui): add regenerate button to assistant messages

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -623,7 +623,8 @@
   box-sizing: border-box;
 }
 
-.edit-message-btn {
+.edit-message-btn,
+.regenerate-message-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -637,9 +638,26 @@
   transition: all 0.15s;
 }
 
-.edit-message-btn:hover {
+.edit-message-btn:hover,
+.regenerate-message-btn:hover {
   color: var(--foreground);
   background: color-mix(in oklch, var(--accent) 40%, transparent);
+}
+
+.regenerate-message-btn {
+  padding: 2px 4px;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.regenerate-message-btn:hover {
+  opacity: 1;
+}
+
+.assistant-message-footer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 /* When editing, expand the user message to the full chat-panel width */

--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -794,6 +794,7 @@ export default function ChatPanel({
     }
     if (userIdx < 0) return;
     const userMsg = messages[userIdx];
+    if (userMsg.role !== 'user') return;
     if (streaming) {
       abortRef.current?.abort();
       streamingRef.current = false;

--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -784,6 +784,26 @@ export default function ChatPanel({
     setEditText('');
     await sendMessage(trimmed, original.images, original.attachments);
   };
+  const regenerateMessage = async (assistantIndex: number) => {
+    let userIdx = -1;
+    for (let k = assistantIndex - 1; k >= 0; k--) {
+      if (messages[k].role === 'user') {
+        userIdx = k;
+        break;
+      }
+    }
+    if (userIdx < 0) return;
+    const userMsg = messages[userIdx];
+    if (streaming) {
+      abortRef.current?.abort();
+      streamingRef.current = false;
+      setStreaming(false);
+    }
+    const truncated = messages.slice(0, userIdx);
+    setMessages(truncated);
+    messagesRef.current = truncated;
+    await sendMessage(userMsg.content, userMsg.images, userMsg.attachments);
+  };
   const handleTemplate = (prompt: string) => sendMessage(prompt);
 
   const addAttachments = useCallback(
@@ -1424,11 +1444,40 @@ export default function ChatPanel({
                     )}
                   </div>
                   {m.role === 'assistant' &&
-                    (m as AssistantMessage).usage &&
-                    !(streaming && i === messages.length - 1) && (
-                      <TokenUsageFooter
-                        usage={(m as AssistantMessage).usage!}
-                      />
+                    !(streaming && i === messages.length - 1) &&
+                    ((m as AssistantMessage).usage ||
+                      (i === messages.length - 1 && lastUserIdx >= 0)) && (
+                      <div className="assistant-message-footer">
+                        {(m as AssistantMessage).usage && (
+                          <TokenUsageFooter
+                            usage={(m as AssistantMessage).usage!}
+                          />
+                        )}
+                        {i === messages.length - 1 && lastUserIdx >= 0 && (
+                          <button
+                            className="regenerate-message-btn"
+                            onClick={() => regenerateMessage(i)}
+                            title="Regenerate response"
+                            aria-label="Regenerate response"
+                          >
+                            <svg
+                              width="12"
+                              height="12"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            >
+                              <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                              <path d="M21 3v5h-5" />
+                              <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+                              <path d="M3 21v-5h5" />
+                            </svg>
+                          </button>
+                        )}
+                      </div>
                     )}
                   {m.role === 'user' &&
                     i === lastUserIdx &&


### PR DESCRIPTION
## Add regenerate button and fix message role type narrowing
🆕 **New Feature** · 🐛 **Bug Fix**

This PR adds a "Regenerate" button to the final assistant message in a thread. It also fixes a TypeScript build error caused by lost type narrowing when indexing into the message array.

Clicking the button aborts any active stream, removes the current turn, and re-submits the previous user prompt (including attachments) to get a fresh response.

### Complexity
🟢 Low · `2 files changed, 75 insertions(+), 7 deletions(-)`

Introduces a straightforward UI feature by leveraging existing message truncation and resending patterns. The fix is a simple type guard to resolve a compiler limitation.

### Review focus
Pay particular attention to the following areas:

- **Message Truncation** — verify that `regenerateMessage` correctly slices the array to remove both the old user and assistant messages before resending.
- **Stream Abortion** — confirm that `abortRef` is triggered correctly if a user regenerates while a response is still in progress.
<!-- opentrace:jid=j-862a25fe-1720-4382-8bf6-18b39210634f|sha=1b05299ad562fd76225745a191f7a02d389f5a42 -->