### PR TITLE
fix(queue): clear graph abort pending queries

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1047,7 +1047,7 @@ wheels = [
 
 [[package]]
 name = "opentraceai"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -978,7 +978,10 @@ const GraphViewer = memo(
             }
           })
           .catch((err) => {
-            if (!cancelled) setSourceError(err.message);
+            if (cancelled) return;
+            // Swallow AbortError — clearGraph fired mid-fetch, expected.
+            if (err?.name === 'AbortError') return;
+            setSourceError(err.message);
           })
           .finally(() => {
             if (!cancelled) setSourceLoading(false);

--- a/ui/src/components/panels/useDiscoverTree.ts
+++ b/ui/src/components/panels/useDiscoverTree.ts
@@ -140,7 +140,13 @@ export function useDiscoverTree({
         if (!cancelled) setLoading(false);
       }
     }
-    init();
+    init().catch((err: unknown) => {
+      // AbortError fires when clearGraph races with in-flight expansions
+      // (e.g. project switch). Expected — swallow silently. Preserve
+      // existing unhandled-rejection behavior for anything else.
+      if ((err as { name?: string })?.name === 'AbortError') return;
+      throw err;
+    });
     return () => {
       cancelled = true;
     };

--- a/ui/src/hooks/useGraphData.ts
+++ b/ui/src/hooks/useGraphData.ts
@@ -75,8 +75,11 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
             .catch(() => {});
         })
         .catch((err) => {
-          setError(err.message);
           setLoading(false);
+          // Swallow AbortError — clearGraph fired mid-load, expected on
+          // project switch. Any real error still surfaces.
+          if (err?.name === 'AbortError') return;
+          setError(err.message);
         });
     },
     [store],

--- a/ui/src/store/__tests__/ladybugStore.test.ts
+++ b/ui/src/store/__tests__/ladybugStore.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from 'vitest';
-import { REL_PAIRS } from '../ladybugStore';
+import { describe, it, expect, vi } from 'vitest';
+import { LadybugGraphStore, REL_PAIRS } from '../ladybugStore';
 
 describe('REL_PAIRS', () => {
   it('has no duplicate FROM→TO pairs', () => {
@@ -27,5 +27,81 @@ describe('REL_PAIRS', () => {
       seen.add(key);
     }
     expect(duplicates).toEqual([]);
+  });
+});
+
+// Helper: build a store with WASM init bypassed and a mock conn that
+// resolves every query() call into a trivial result.
+function makeStoreWithMockConn() {
+  const store = new LadybugGraphStore();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const s = store as any;
+  s.ready = Promise.resolve();
+  const connQuery = vi.fn().mockImplementation(async () => ({
+    getAllObjects: async () => [],
+    close: async () => {},
+  }));
+  s.conn = { query: connQuery };
+  return { store, s, connQuery };
+}
+
+describe('LadybugGraphStore clearGraph abort behavior', () => {
+  it('aborts queued query()/exec() tasks when clearGraph fires', async () => {
+    const { store, s, connQuery } = makeStoreWithMockConn();
+
+    // Hold the queue open so pending tasks can't run until we say so.
+    let releaseGate: () => void = () => {};
+    s.queue = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+
+    // Enqueue two tasks before clearGraph fires — they capture generation 0.
+    const pendingQuery = s.query('MATCH (n) RETURN n');
+    const pendingExec = s.exec('CREATE (n)');
+
+    // clearGraph bumps the generation and enqueues its own DDL.
+    const clearPromise = store.clearGraph();
+
+    // Release the gate so the chain can drain.
+    releaseGate();
+
+    // Pre-clearGraph tasks should reject with AbortError.
+    await expect(pendingQuery).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(pendingExec).rejects.toMatchObject({ name: 'AbortError' });
+
+    // clearGraph itself completes.
+    await expect(clearPromise).resolves.toBeUndefined();
+
+    // conn.query was called only for clearGraph's DDL, never for the
+    // aborted user queries.
+    const cyphers = connQuery.mock.calls.map((c: [string]) => c[0]);
+    expect(cyphers).not.toContain('MATCH (n) RETURN n');
+    expect(cyphers).not.toContain('CREATE (n)');
+    // Sanity: clearGraph did dispatch some DROP/CREATE DDL.
+    expect(cyphers.some((c: string) => c.startsWith('DROP TABLE'))).toBe(true);
+  });
+
+  it('allows queries enqueued after clearGraph to run normally', async () => {
+    const { store, s, connQuery } = makeStoreWithMockConn();
+
+    // Fire clearGraph first (bumps gen 0 → 1, completes its DDL).
+    await store.clearGraph();
+
+    // Subsequent query captures gen 1, matches current gen 1, runs normally.
+    const rows = await s.query('MATCH (n) RETURN n');
+    expect(rows).toEqual([]);
+
+    const cyphers = connQuery.mock.calls.map((c: [string]) => c[0]);
+    expect(cyphers).toContain('MATCH (n) RETURN n');
+  });
+
+  it('bumps the generation counter on clearGraph', async () => {
+    const { store, s } = makeStoreWithMockConn();
+
+    expect(s.generation).toBe(0);
+    await store.clearGraph();
+    expect(s.generation).toBe(1);
+    await store.clearGraph();
+    expect(s.generation).toBe(2);
   });
 });

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -282,6 +282,13 @@ function logQuery(cypher: string, rowCount: number, ms: number): void {
   );
 }
 
+/** Build an AbortError in the web-platform convention so callers can
+ *  pattern-match on err.name === 'AbortError' the same way they do
+ *  for fetch/AbortController. */
+function abortError(message: string): DOMException {
+  return new DOMException(message, 'AbortError');
+}
+
 // ---- Cypher helpers ----
 
 /** Escape a string for use inside a Cypher single-quoted literal. */
@@ -524,6 +531,12 @@ export class LadybugGraphStore implements GraphStore {
   // --- Serialization queue (lbug-wasm wraps single-threaded C++ engine) ---
   private queue: Promise<void> = Promise.resolve();
 
+  /** Monotonic counter bumped by clearGraph(). Each queued task captures the
+   *  current value at enqueue; when it runs, a mismatch means clearGraph fired
+   *  in the meantime and the task is aborted. Keeps clearGraph fast by letting
+   *  it skip work that's about to be invalidated anyway. */
+  private generation = 0;
+
   constructor() {
     // Don't init WASM here — the constructor runs at app startup.
     // WASM loads lazily on first DB operation via ensureReady().
@@ -660,12 +673,20 @@ export class LadybugGraphStore implements GraphStore {
    * Execute a Cypher query and return all result rows as objects.
    * Uses conn.query() + getAllObjects() for row extraction.
    * Serialized through a queue to prevent concurrent calls.
+   *
+   * If clearGraph() fires between the enqueue and the run, the task
+   * rejects with an AbortError (DOMException) instead of executing.
    */
   private async query(cypher: string): Promise<Record<string, unknown>[]> {
+    const enqueuedGeneration = this.generation;
     await this.ensureReady();
     return new Promise<Record<string, unknown>[]>((resolve, reject) => {
       this.queue = this.queue
         .then(async () => {
+          if (this.generation !== enqueuedGeneration) {
+            reject(abortError('Query aborted: store was cleared'));
+            return;
+          }
           const qt0 = performance.now();
           const result = await this.conn.query(cypher);
           try {
@@ -684,8 +705,34 @@ export class LadybugGraphStore implements GraphStore {
 
   /**
    * Execute a Cypher statement that doesn't return rows (DDL, COPY, etc.).
+   * Aborts with an AbortError if clearGraph() fires between enqueue and run.
    */
   private async exec(cypher: string): Promise<void> {
+    const enqueuedGeneration = this.generation;
+    await this.ensureReady();
+    return new Promise<void>((resolve, reject) => {
+      this.queue = this.queue
+        .then(async () => {
+          if (this.generation !== enqueuedGeneration) {
+            reject(abortError('Exec aborted: store was cleared'));
+            return;
+          }
+          const result = await this.conn.query(cypher);
+          await result.close();
+          resolve();
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    });
+  }
+
+  /**
+   * Queue a DDL statement that bypasses the generation check. Used by
+   * clearGraph() for its own DROP/CREATE calls, since it's the thing
+   * bumping the generation.
+   */
+  private async execInternal(cypher: string): Promise<void> {
     await this.ensureReady();
     return new Promise<void>((resolve, reject) => {
       this.queue = this.queue
@@ -1415,14 +1462,19 @@ export class LadybugGraphStore implements GraphStore {
   }
 
   async clearGraph(): Promise<void> {
+    // Bump the generation synchronously before any await, so every task
+    // already on the queue sees a mismatch and aborts instead of running
+    // against state that's about to be torn down. Must happen before we
+    // enqueue our own DDL below — execInternal bypasses the check.
+    this.generation++;
     // Drop REL TABLE GROUP first (references node tables)
     try {
-      await this.exec(`DROP TABLE IF EXISTS RELATES`);
+      await this.execInternal(`DROP TABLE IF EXISTS RELATES`);
     } catch {
       // If group drop fails, try dropping individual sub-tables
       for (const [from, to] of REL_PAIRS) {
         try {
-          await this.exec(`DROP TABLE IF EXISTS RELATES_${from}_${to}`);
+          await this.execInternal(`DROP TABLE IF EXISTS RELATES_${from}_${to}`);
         } catch {
           /* ignore */
         }
@@ -1430,12 +1482,12 @@ export class LadybugGraphStore implements GraphStore {
     }
     // Drop all typed node tables and SourceText
     for (const type of NODE_TYPES) {
-      await this.exec(`DROP TABLE IF EXISTS ${type}`);
+      await this.execInternal(`DROP TABLE IF EXISTS ${type}`);
     }
-    await this.exec(`DROP TABLE IF EXISTS SourceText`);
+    await this.execInternal(`DROP TABLE IF EXISTS SourceText`);
     // Recreate schema
     for (const stmt of SCHEMA_STATEMENTS) {
-      await this.exec(stmt);
+      await this.execInternal(stmt);
     }
     this.hasVectorIndex = false;
     this.bm25Index = new BM25Index(1.5, 0.75, { name: 2.0 }, 1);


### PR DESCRIPTION
## Abort pending store queries on project switch
✨ **Improvement** · ♻️ **Refactor** · 🧪 **Tests** · 🔧 **Chore**

Improves UI responsiveness when switching projects by aborting backlogged queries in the `LadybugGraphStore`. 

A monotonic generation counter now allows the serialized query queue to short-circuit tasks invalidated by a `clearGraph` call.

### Complexity
🟡 Moderate · `6 files changed, 151 insertions(+), 11 deletions(-)`

This PR introduces a foundational change to the `LadybugGraphStore` query lifecycle by adding a generation-based cancellation mechanism. It touches both the core data store and several high-level UI hooks/components, requiring a review of how `AbortError` is propagated and handled across these layers.

### Tests
🧪 Adds new unit tests to `ladybugStore.test.ts` that specifically verify the generation-based abort logic using mocked connections and queued promises.

### Review focus
Pay particular attention to the following areas:

- **AbortError Handling** — Ensure all UI-side callers of `query` and `exec` correctly swallow or handle the new `AbortError` to prevent unhandled promise rejections.
- **Generation Sync** — Verify that `generation++` occurs synchronously within `clearGraph` to prevent race conditions where new queries could capture an old generation before the clear operation enqueues its DDL.

---

<details>
<summary><strong>Additional details</strong></summary>

### Approach
The `LadybugGraphStore` uses a single `Promise` chain (`this.queue`) to serialize all operations against the underlying WASM engine. Previously, a `clearGraph` operation (triggered on project switch) had to wait for every pending query to execute, which could take over 10 seconds if many discovery-tree expansions were queued.

The new logic captures a `generation` ID at the moment a task is enqueued. When the task eventually reaches the front of the queue, it compares its captured ID with the store's current `generation`. If they don't match, the task rejects immediately with a `DOMException('...', 'AbortError')`.

### Internal Execution
`clearGraph` uses a private `execInternal` method to bypass this check for its own DDL (DROP/CREATE) statements. This is necessary because `clearGraph` itself increments the generation counter before performing the work to reset the database state.

### UI Integration
The following hooks were updated to recognize and swallow `AbortError`:
- `useGraphData`: Swallows errors during initial graph loads on project switch.
- `useDiscoverTree`: Silently ignores errors during background auto-expansion.
- `GraphViewer`: Skips error state updates when source-code fetching is aborted by a store clear.

</details>
<!-- opentrace:jid=j-96ec9a84-fd75-4563-a9c8-83c836159107|sha=9d7d364b9af6b82280cb068d0858dbce090439d7 -->