### PR TITLE
feat(ui): add reindex-repo job to rebuild a single repo's graph

### DIFF
--- a/ui/src/job/browserJobService.ts
+++ b/ui/src/job/browserJobService.ts
@@ -164,7 +164,8 @@ export class BrowserJobService implements JobService {
 
   async startJob(message: JobMessage): Promise<JobStream> {
     let input: LoaderInput;
-    if (message.type === 'index-repo') {
+    const isReindex = message.type === 'reindex-repo';
+    if (message.type === 'index-repo' || message.type === 'reindex-repo') {
       input = {
         kind: 'url',
         url: message.repoUrl,
@@ -257,6 +258,30 @@ export class BrowserJobService implements JobService {
 
       // Store source files for UI code viewing
       const repoId = `${repoTree.owner}/${repoTree.repo}`;
+
+      // Reindex: wipe the existing rows for this repo before any writes, so
+      // the COPY FROM path doesn't hit PK violations on shared ids. Runs
+      // after the fetch succeeds — a failed fetch must not destroy existing
+      // data. No-op when deleteRepo is absent (server mode), matching the
+      // rest of the store's server-mode write-path conventions.
+      if (isReindex && this.store.deleteRepo) {
+        debug.log('reindex', `clearing existing data for ${repoId}`);
+        channel.push({
+          ...emptyEvent(),
+          kind: JobEventKind.JOB_EVENT_KIND_PROGRESS,
+          phase: JobPhase.JOB_PHASE_INITIALIZING,
+          message: 'Clearing existing data…',
+        });
+        await this.store.deleteRepo(repoId);
+        channel.push({
+          ...emptyEvent(),
+          kind: JobEventKind.JOB_EVENT_KIND_STAGE_COMPLETE,
+          phase: JobPhase.JOB_PHASE_INITIALIZING,
+          message: 'Existing data cleared',
+        });
+        if (cancelled) return;
+      }
+
       this.store.storeSource(
         repoTree.files.map((f) => ({
           id: `${repoId}/${f.path}`,

--- a/ui/src/job/types.ts
+++ b/ui/src/job/types.ts
@@ -36,12 +36,24 @@ import type { JobEvent } from '../gen/opentrace/v1/agent_service';
 
 export type JobMessage =
   | IndexRepoMessage
+  | ReindexRepoMessage
   | IndexDirectoryMessage
   | ImportFileMessage
   | ConnectServerMessage;
 
 export interface IndexRepoMessage {
   type: 'index-repo';
+  repoUrl: string;
+  token?: string;
+  ref?: string;
+}
+
+/** Re-fetch a repo's files and rebuild its graph from scratch. Deletes the
+ *  repo's existing nodes/relationships after the fetch succeeds (so a failed
+ *  fetch leaves the existing data intact) and then runs the normal index
+ *  pipeline. Other repos in the graph are unaffected. */
+export interface ReindexRepoMessage {
+  type: 'reindex-repo';
   repoUrl: string;
   token?: string;
   ref?: string;

--- a/ui/src/store/__tests__/ladybugStore.test.ts
+++ b/ui/src/store/__tests__/ladybugStore.test.ts
@@ -105,3 +105,241 @@ describe('LadybugGraphStore clearGraph abort behavior', () => {
     expect(s.generation).toBe(2);
   });
 });
+
+describe('LadybugGraphStore deleteRepo', () => {
+  it('issues scoped Cypher deletes (rels first, then each repo-scoped table)', async () => {
+    const { store, connQuery } = makeStoreWithMockConn();
+
+    await store.deleteRepo('alice/foo');
+
+    const cyphers = connQuery.mock.calls.map((c: [string]) => c[0]);
+    // Relationship delete must come before every node delete — Kuzu
+    // rejects node drops while endpoint rels still reference them. A
+    // single findIndex only proves the FIRST node-delete is ordered,
+    // so walk the whole list.
+    const relIdx = cyphers.findIndex((c: string) =>
+      c.includes('-[r:RELATES]->'),
+    );
+    expect(relIdx).toBeGreaterThanOrEqual(0);
+    const nodeDeletePattern =
+      /^MATCH \(n:(Repository|Directory|File|Class|Function|Variable|PullRequest|IndexMetadata|SourceText)\).*DELETE n$/;
+    const nodeDeleteIndexes = cyphers
+      .map((c: string, i: number) => (nodeDeletePattern.test(c) ? i : -1))
+      .filter((i: number) => i >= 0);
+    expect(nodeDeleteIndexes.length).toBeGreaterThan(0);
+    for (const idx of nodeDeleteIndexes) {
+      expect(idx).toBeGreaterThan(relIdx);
+    }
+
+    // Every repo-scoped table is targeted.
+    const tables = [
+      'Repository',
+      'Directory',
+      'File',
+      'Class',
+      'Function',
+      'Variable',
+      'PullRequest',
+      'IndexMetadata',
+      'SourceText',
+    ];
+    for (const table of tables) {
+      expect(
+        cyphers.some(
+          (c: string) =>
+            c.includes(`MATCH (n:${table})`) && c.includes('DELETE n'),
+        ),
+      ).toBe(true);
+    }
+
+    // Repo-scoped match clause uses the correct id patterns. Only
+    // applies to DELETE queries — the post-delete pass issues a global
+    // `MATCH (n:Dependency) RETURN n.id` to rebuild the dedup set, and
+    // that one intentionally has no repo predicate.
+    for (const c of cyphers) {
+      if (c.startsWith('MATCH (n:') && c.includes('DELETE n')) {
+        expect(c).toContain("'alice/foo'");
+        expect(c).toContain("'alice/foo/'");
+        expect(c).toContain("'_meta:index:alice/foo'");
+      }
+    }
+
+    // Dependency is the only global table; it must never be deleted.
+    // (A read-only MATCH on Dependency is expected — that's the dedup-set
+    // rebuild.)
+    expect(
+      cyphers.some(
+        (c: string) => c.includes('MATCH (n:Dependency)') && c.includes('DELETE n'),
+      ),
+    ).toBe(false);
+  });
+
+  it('prunes in-memory state keyed by the repo but spares other repos', async () => {
+    const { store, s, connQuery } = makeStoreWithMockConn();
+
+    // The post-delete pass queries surviving Dependency rows to rebuild
+    // the in-memory dedup set. Make the mock return the shared package
+    // so the assertion below sees a set populated from DB ground truth.
+    connQuery.mockImplementation(async (cypher: string) => ({
+      getAllObjects: async () =>
+        cypher.includes('(n:Dependency)') && cypher.includes('RETURN n.id')
+          ? [{ id: 'pkg:npm:lodash' }]
+          : [],
+      close: async () => {},
+    }));
+
+    // Seed state that would exist after an index run of two repos plus a
+    // shared package.
+    const aRepo = 'alice/foo';
+    const bRepo = 'bob/bar';
+    const seedNode = (id: string, type: string) => {
+      s.nodeTypeMap.set(id, type);
+      s.nodeCache.set(id, { type, name: id, properties: {} });
+      s.bm25Index.addDocument(id, `${id} ${type}`, { name: id });
+    };
+    const seedSource = (id: string) => {
+      s.sourceCache.set(id, {
+        compressed: new Uint8Array(),
+        path: id.split('/').slice(2).join('/'),
+      });
+      s.sourceSnippets.set(id, `// source of ${id}`);
+      s.flushedSourceIds.add(id);
+    };
+
+    // Repo A
+    seedNode(aRepo, 'Repository');
+    seedNode(`${aRepo}/src`, 'Directory');
+    seedNode(`${aRepo}/src/app.ts`, 'File');
+    seedNode(`${aRepo}/src/app.ts::App`, 'Class');
+    seedNode(`_meta:index:${aRepo}`, 'IndexMetadata');
+    seedSource(`${aRepo}/src/app.ts`);
+
+    // Repo B (must survive)
+    seedNode(bRepo, 'Repository');
+    seedNode(`${bRepo}/lib/util.ts`, 'File');
+    seedNode(`_meta:index:${bRepo}`, 'IndexMetadata');
+    seedSource(`${bRepo}/lib/util.ts`);
+
+    // Shared global Dependency (must survive, plus its flushedPackageIds guard)
+    seedNode('pkg:npm:lodash', 'Dependency');
+    s.flushedPackageIds.add('pkg:npm:lodash');
+
+    // Pending buffers contain entries for both repos.
+    s.pendingNodes = [
+      { id: `${aRepo}/src/new.ts`, type: 'File', name: 'new.ts' },
+      { id: `${bRepo}/lib/util.ts`, type: 'File', name: 'util.ts' },
+    ];
+    s.pendingRels = [
+      {
+        id: 'rel-a',
+        type: 'DEFINES',
+        source_id: aRepo,
+        target_id: `${aRepo}/src/new.ts`,
+      },
+      {
+        id: 'rel-b',
+        type: 'DEFINES',
+        source_id: bRepo,
+        target_id: `${bRepo}/lib/util.ts`,
+      },
+    ];
+    s.totalNodesBuffered = 2;
+    s.totalRelsBuffered = 2;
+
+    await store.deleteRepo(aRepo);
+
+    // Repo A state gone
+    for (const id of [
+      aRepo,
+      `${aRepo}/src`,
+      `${aRepo}/src/app.ts`,
+      `${aRepo}/src/app.ts::App`,
+      `_meta:index:${aRepo}`,
+    ]) {
+      expect(s.nodeTypeMap.has(id)).toBe(false);
+      expect(s.nodeCache.has(id)).toBe(false);
+    }
+    expect(s.sourceCache.has(`${aRepo}/src/app.ts`)).toBe(false);
+    expect(s.sourceSnippets.has(`${aRepo}/src/app.ts`)).toBe(false);
+    expect(s.flushedSourceIds.has(`${aRepo}/src/app.ts`)).toBe(false);
+
+    // BM25 forgot repo A's docs but kept repo B's.
+    expect(s.bm25Index.search('alice').length).toBe(0);
+    expect(s.bm25Index.search('bob').length).toBeGreaterThan(0);
+
+    // Repo B intact
+    expect(s.nodeTypeMap.has(bRepo)).toBe(true);
+    expect(s.nodeTypeMap.has(`${bRepo}/lib/util.ts`)).toBe(true);
+    expect(s.nodeTypeMap.has(`_meta:index:${bRepo}`)).toBe(true);
+    expect(s.sourceCache.has(`${bRepo}/lib/util.ts`)).toBe(true);
+
+    // Shared Dependency and its guard untouched
+    expect(s.nodeTypeMap.has('pkg:npm:lodash')).toBe(true);
+    expect(s.flushedPackageIds.has('pkg:npm:lodash')).toBe(true);
+
+    // Pending buffers filtered to only repo B's entries.
+    expect(s.pendingNodes).toEqual([
+      { id: `${bRepo}/lib/util.ts`, type: 'File', name: 'util.ts' },
+    ]);
+    expect(s.pendingRels).toEqual([
+      {
+        id: 'rel-b',
+        type: 'DEFINES',
+        source_id: bRepo,
+        target_id: `${bRepo}/lib/util.ts`,
+      },
+    ]);
+    expect(s.totalNodesBuffered).toBe(1);
+    expect(s.totalRelsBuffered).toBe(1);
+  });
+
+  it('does not bump the generation counter', async () => {
+    const { store, s } = makeStoreWithMockConn();
+
+    expect(s.generation).toBe(0);
+    await store.deleteRepo('alice/foo');
+    expect(s.generation).toBe(0);
+  });
+
+  it('is a no-op for an empty repoId', async () => {
+    const { store, connQuery } = makeStoreWithMockConn();
+
+    await store.deleteRepo('');
+    expect(connQuery).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds flushedPackageIds from surviving Dependency rows', async () => {
+    // The set guards COPY FROM against PK collisions on global Dependency
+    // rows. deleteRepo leaves Dependencies intact (they're shared across
+    // repos), but the in-memory set may be stale if we were populated from
+    // one subset of repos and a later reindex needs to see the full
+    // ground truth. The guard only works if the set matches the DB.
+    const { store, s, connQuery } = makeStoreWithMockConn();
+    connQuery.mockImplementation(async (cypher: string) => ({
+      getAllObjects: async () =>
+        cypher.includes('(n:Dependency)') && cypher.includes('RETURN n.id')
+          ? [
+              { id: 'pkg:npm:lodash' },
+              { id: 'pkg:npm:react' },
+              { id: 'pkg:pypi:requests' },
+            ]
+          : [],
+      close: async () => {},
+    }));
+
+    // Seed a stale set that disagrees with the DB (missing one entry,
+    // with an extra ghost entry left over from a deleted repo).
+    s.flushedPackageIds.add('pkg:npm:lodash');
+    s.flushedPackageIds.add('pkg:npm:ghost-from-deleted-repo');
+
+    await store.deleteRepo('alice/foo');
+
+    // Set matches what the mock returned: no ghost entries, all three
+    // real rows present.
+    expect([...s.flushedPackageIds].sort()).toEqual([
+      'pkg:npm:lodash',
+      'pkg:npm:react',
+      'pkg:pypi:requests',
+    ]);
+  });
+});

--- a/ui/src/store/__tests__/ladybugStore.test.ts
+++ b/ui/src/store/__tests__/ladybugStore.test.ts
@@ -169,7 +169,8 @@ describe('LadybugGraphStore deleteRepo', () => {
     // rebuild.)
     expect(
       cyphers.some(
-        (c: string) => c.includes('MATCH (n:Dependency)') && c.includes('DELETE n'),
+        (c: string) =>
+          c.includes('MATCH (n:Dependency)') && c.includes('DELETE n'),
       ),
     ).toBe(false);
   });

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -1503,6 +1503,136 @@ export class LadybugGraphStore implements GraphStore {
     this.totalRelsBuffered = 0;
   }
 
+  /** Remove all data scoped to a single repo: the Repository node itself,
+   *  every node whose ID starts with `${repoId}/` (Directory, File, Class,
+   *  Function, Variable, PullRequest, SourceText, NodeVector), the
+   *  IndexMetadata row, and every RELATES edge touching them. Only
+   *  Dependency nodes are truly global (`pkg:registry:name`) and survive.
+   *  Derived JS-side indexes are pruned in lockstep.
+   *
+   *  Unlike clearGraph() this does NOT bump the generation counter: other
+   *  repos' in-flight queries remain valid. The store's serialization queue
+   *  ensures our deletes run between neighboring queries. */
+  async deleteRepo(repoId: string): Promise<void> {
+    if (!repoId) return;
+    await this.ensureReady();
+
+    const prefix = `${repoId}/`;
+    const metaId = `_meta:index:${repoId}`;
+    const matches = (id: string): boolean =>
+      id === repoId || id.startsWith(prefix) || id === metaId;
+
+    // Drop any buffered writes that would re-create this repo's rows on the
+    // next flush — they'd collide with the deletions we're about to do.
+    if (this.pendingNodes.length) {
+      const before = this.pendingNodes.length;
+      this.pendingNodes = this.pendingNodes.filter((n) => !matches(n.id));
+      this.totalNodesBuffered -= before - this.pendingNodes.length;
+    }
+    if (this.pendingRels.length) {
+      const before = this.pendingRels.length;
+      this.pendingRels = this.pendingRels.filter(
+        (r) => !matches(r.source_id) && !matches(r.target_id),
+      );
+      this.totalRelsBuffered -= before - this.pendingRels.length;
+    }
+
+    // Build single-quoted Cypher literals using the shared `esc` helper
+    // (backslash + apostrophe escaping). Realistic repoIds are "owner/repo"
+    // and contain none of these characters, but we escape anyway so this
+    // path matches the rest of the file's Cypher-building call sites.
+    const repoIdLit = `'${esc(repoId)}'`;
+    const prefixLit = `'${esc(prefix)}'`;
+    const metaLit = `'${esc(metaId)}'`;
+    const matchClause = (alias: string) =>
+      `${alias}.id = ${repoIdLit} OR ${alias}.id STARTS WITH ${prefixLit} OR ${alias}.id = ${metaLit}`;
+
+    // Relationships first — Kuzu requires edges gone before their endpoint
+    // nodes can be dropped. The RELATES group holds every rel type.
+    await this.exec(
+      `MATCH (s)-[r:RELATES]->(t) WHERE ${matchClause('s')} OR ${matchClause('t')} DELETE r`,
+    );
+
+    // Repo-scoped node tables. Dependency is the only global table and is
+    // omitted. Variable IDs are `{scope_id}::{name}` where scope_id is a
+    // File/Class/Function — all repo-prefixed, so they match the predicate.
+    // SourceText is repo-scoped (file-id keyed). NodeVector shadows every
+    // node, so the same id predicate prunes it.
+    const REPO_SCOPED_TABLES: readonly string[] = [
+      'Repository',
+      'Directory',
+      'File',
+      'Class',
+      'Function',
+      'Variable',
+      'PullRequest',
+      'IndexMetadata',
+      'SourceText',
+    ];
+    for (const table of REPO_SCOPED_TABLES) {
+      await this.exec(`MATCH (n:${table}) WHERE ${matchClause('n')} DELETE n`);
+    }
+    try {
+      await this.exec(
+        `MATCH (n:NodeVector) WHERE ${matchClause('n')} DELETE n`,
+      );
+    } catch (err) {
+      // NodeVector table may be absent if the VECTOR extension failed to
+      // load. Log rather than silently swallow so an unrelated failure
+      // (OOM, query-shape regression) is diagnosable from the console
+      // instead of leaking orphan NodeVector rows invisibly.
+      console.warn(
+        '[LadybugStore.deleteRepo] NodeVector cleanup skipped:',
+        err,
+      );
+    }
+
+    // Prune derived in-memory state keyed by node id.
+    for (const id of [...this.nodeTypeMap.keys()]) {
+      if (matches(id)) {
+        this.nodeTypeMap.delete(id);
+        this.bm25Index.removeDocument(id);
+      }
+    }
+    for (const id of [...this.nodeCache.keys()]) {
+      if (matches(id)) this.nodeCache.delete(id);
+    }
+    for (const id of [...this.sourceCache.keys()]) {
+      if (matches(id)) this.sourceCache.delete(id);
+    }
+    for (const id of [...this.sourceSnippets.keys()]) {
+      if (matches(id)) this.sourceSnippets.delete(id);
+    }
+    for (const id of [...this.flushedSourceIds]) {
+      if (matches(id)) this.flushedSourceIds.delete(id);
+    }
+
+    await this.rebuildPackageDedupIndex();
+  }
+
+  /** Rebuild `flushedPackageIds` from the current Dependency rows.
+   *
+   *  The set is the store's in-memory guard against COPY FROM PK
+   *  violations: Dependency nodes are global (shared across repos), so
+   *  the same id can arrive from multiple pipeline runs and we skip
+   *  anything we've already written. That guard works as long as the
+   *  set reflects what's actually in the DB. Two code paths break that
+   *  invariant by mutating Dependency rows behind importBatch's back:
+   *    - `deleteRepo` keeps Dependency rows (they're global) but wipes
+   *      repo-scoped rows, and we may be called after a page reload
+   *      where the set is empty while the table persists.
+   *    - `importDatabase` COPYs Dependency rows directly from Parquet,
+   *      never touching the set.
+   *  Both call this afterwards to bring the set back in sync. Cheap —
+   *  one id column, bounded by package count, not repo count. */
+  private async rebuildPackageDedupIndex(): Promise<void> {
+    this.flushedPackageIds.clear();
+    const depRows = (await this.query(
+      `MATCH (n:Dependency) RETURN n.id AS id`,
+    )) as { id: string }[];
+    for (const row of depRows) this.flushedPackageIds.add(row.id);
+  }
+
   async importDatabase(
     data: Uint8Array,
     onProgress?: (msg: string) => void,
@@ -1754,6 +1884,12 @@ export class LadybugGraphStore implements GraphStore {
     // Rebuild FTS index on SourceText (whether from import or empty)
     onProgress?.('Rebuilding search indexes');
     await this.rebuildSourceFTS();
+
+    // The import COPY'd Dependency rows directly into the DB without
+    // going through `importBatch`, so `flushedPackageIds` is still
+    // empty. Without this, the next pipeline run that emits any of the
+    // imported package ids would fail with a PK uniqueness error.
+    await this.rebuildPackageDedupIndex();
 
     console.log(
       `[LadybugStore] importDatabase complete: ${totalNodes} nodes, ${totalRels} rels`,

--- a/ui/src/store/types.ts
+++ b/ui/src/store/types.ts
@@ -105,6 +105,10 @@ export interface GraphStore {
   fetchStats(): Promise<GraphStats>;
   fetchMetadata(): Promise<IndexMetadata[]>;
   clearGraph(): Promise<void>;
+  /** Remove all data scoped to a single repo (nodes whose IDs start with the
+   *  repoId, plus their relationships). Global nodes like Dependency survive.
+   *  Optional: ServerGraphStore is read-only and omits this. */
+  deleteRepo?(repoId: string): Promise<void>;
   setLimits?(maxNodes: number, maxEdges: number): Promise<void>;
   importBatch(batch: ImportBatchRequest): Promise<ImportBatchResponse>;
   /** Flush any buffered writes to the backing store. No-op if unbuffered. */


### PR DESCRIPTION
## Add single-repo reindexing and fix import PK collisions
🆕 **New Feature** · ✨ **Improvement** · 🐛 **Bug Fix** · 🧪 **Tests**

Adds a `reindex-repo` job type to rebuild a single repository's graph without wiping the entire store. 

Fixes a latent bug where importing a database led to primary-key collisions on shared dependency nodes during subsequent indexing runs.

### Complexity
🟡 Moderate · `5 files changed, 416 insertions(+), 1 deletion(-)`

This PR modifies the core state management logic in `LadybugGraphStore`, requiring precise synchronization between the WASM-based database and multiple in-memory caches (BM25, LRU caches, source snippets). It introduces a targeted deletion strategy that must respect database referential integrity while navigating the project's node ID conventions.

### Tests
🧪 Includes thorough unit tests verifying Cypher query ordering, repo-scoped filtering, and in-memory state pruning.

### Review focus
Pay particular attention to the following areas:

- **Deletion Ordering** — verify that `RELATES` edges are dropped before node tables to satisfy database referential integrity.
- **ID Predicates** — confirm the `MATCH` clauses correctly isolate repo-scoped nodes from global `Dependency` nodes and other repos.
- **State Pruning** — ensure all JS-side indexes and buffers are correctly filtered to prevent stale data from leaking into the new index.

---

<details>
<summary><strong>Additional details</strong></summary>

### Approach
The re-index capability is implemented via a new `deleteRepo` method on the `GraphStore` interface.

**Repo Isolation**
The logic relies on the convention that repository-scoped nodes use IDs prefixed with `${repoId}/` (e.g., `owner/repo/path/to/file`). The `deleteRepo` method uses Cypher predicates to target these IDs and the repository node itself, while specifically excluding `Dependency` nodes which are global (`pkg:registry:name`) and shared across repositories.

**Synchronization**
Unlike `clearGraph`, `deleteRepo` does not bump the `generation` counter. This allows queries for other repositories to remain valid while one repo is being cleared. The store's internal serialization queue ensures the deletion completes before new writes for that repo begin.

**Fix for Import Collisions**
The `importDatabase` path previously skipped updating `flushedPackageIds` because it performed a bulk `COPY FROM` from Parquet. This led to uniqueness failures if a subsequent index job tried to re-emit the same package nodes. Both `deleteRepo` and `importDatabase` now invoke `rebuildPackageDedupIndex` to reconcile the in-memory guard with ground-truth DB rows.

</details>
<!-- opentrace:jid=j-9c918c30-f7b1-4822-acf6-c2a5507b8d15|sha=e2ca772b02106a3f4f4ecac45cfdcd841100b5fc -->