### PR TITLE
fix(ui): flip 3D mouse controls — left-drag rotates, right-drag pans

### DIFF
--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -1763,7 +1763,7 @@ export class PixiRenderer {
     let lastPointerX = 0;
     let lastPointerY = 0;
 
-    // Suppress the browser's right-click menu so right-drag can rotate in 3D mode.
+    // Suppress the browser's right-click menu so right-drag can pan in 3D mode.
     canvas.addEventListener(
       'contextmenu',
       (e) => {
@@ -1782,7 +1782,7 @@ export class PixiRenderer {
         lastPointerY = e.clientY;
         this.pointerDownPos = { x: e.clientX, y: e.clientY };
 
-        // Hit test — only left button drags nodes; right button rotates in 3D.
+        // Hit test — only left button drags nodes; left-drag on empty area rotates in 3D.
         if (e.button === 0) {
           const rect = canvas.getBoundingClientRect();
           const screenX = e.clientX - rect.left;
@@ -1852,8 +1852,8 @@ export class PixiRenderer {
             }
             this.callbacks.onNodeDragMove?.(this.dragNode.id, world.x, world.y);
             this.redrawDragEdges(this.dragNode);
-          } else if (this.mode3d && pointerDownButton === 2) {
-            // 3D mode + right-drag: rotate the camera
+          } else if (this.mode3d && pointerDownButton === 0) {
+            // 3D mode + left-drag on empty area: rotate the camera
             const rotateDx = e.clientX - lastPointerX;
             const rotateDy = e.clientY - lastPointerY;
             // Horizontal drag → Y-axis rotation


### PR DESCRIPTION
## Summary
- In 3D mode, left-drag on empty area now rotates the camera and right-drag pans. This reverses the mapping introduced in #346.
- Left-click drag on a node still drags the node; 2D mode behavior is unchanged.

## Test plan
- [x] Open a graph in 3D mode and confirm left-drag on empty space rotates the camera (Y-axis on horizontal, tilt on vertical, auto-rotate pauses).
- [x] Confirm right-drag pans the viewport without opening the browser context menu.
- [x] Confirm left-click on a node still drags the node.
- [x] Confirm 2D mode pan/drag behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)