### PR TITLE
OT-1702 Fix/orphan dep sweep

### DIFF
--- a/agent/tests/opentrace_agent/pipeline/test_pipeline.py
+++ b/agent/tests/opentrace_agent/pipeline/test_pipeline.py
@@ -183,15 +183,9 @@ def test_dependency_nodes_are_never_orphaned(tmp_path: Path) -> None:
     # also imports numpy, which is not declared in requirements.txt.
     # This covers all three possible Dependency provenances in one
     # fixture: manifest-only, import-only, and both.
-    (tmp_path / "requirements.txt").write_text(
-        "requests==2.31.0\npyyaml==6.0\nclick==8.1.7\n"
-    )
+    (tmp_path / "requirements.txt").write_text("requests==2.31.0\npyyaml==6.0\nclick==8.1.7\n")
     (tmp_path / "app.py").write_text(
-        "import requests\n"
-        "import numpy\n"
-        "\n"
-        "def fetch():\n"
-        "    return requests.get('https://example.com')\n"
+        "import requests\nimport numpy\n\ndef fetch():\n    return requests.get('https://example.com')\n"
     )
 
     inp = PipelineInput(path=str(tmp_path), repo_id="test/deps")

--- a/agent/tests/opentrace_agent/pipeline/test_pipeline.py
+++ b/agent/tests/opentrace_agent/pipeline/test_pipeline.py
@@ -163,3 +163,49 @@ def test_pipeline_repo_id_defaults_to_dir_name(tmp_path: Path) -> None:
     repo_nodes = [n for n in nodes if n.type == "Repository"]
     assert len(repo_nodes) == 1
     assert repo_nodes[0].id == tmp_path.name
+
+
+def test_dependency_nodes_are_never_orphaned(tmp_path: Path) -> None:
+    """Invariant: every Dependency node has at least one incoming edge.
+
+    Both Dependency-creation paths — manifest parsing in `scanning.py`
+    (emits Repository -[DEPENDS_ON]-> Dependency) and external-import
+    analysis in `processing.py` (emits File -[IMPORTS]-> Dependency) —
+    must create the edge in the same step as the node. The UI-side
+    orphan sweep in `deleteRepo` relies on this: a Dependency with no
+    incoming edges after a repo's rels are removed must have been
+    exclusively referenced by that repo. If a third creation path ever
+    emits an orphan Dependency, the sweep would wrongly delete
+    legitimately-shared packages on repo removal.
+    """
+    # requirements.txt declares packages; one of them (requests) is
+    # also imported by code, the other two are manifest-only. The code
+    # also imports numpy, which is not declared in requirements.txt.
+    # This covers all three possible Dependency provenances in one
+    # fixture: manifest-only, import-only, and both.
+    (tmp_path / "requirements.txt").write_text(
+        "requests==2.31.0\npyyaml==6.0\nclick==8.1.7\n"
+    )
+    (tmp_path / "app.py").write_text(
+        "import requests\n"
+        "import numpy\n"
+        "\n"
+        "def fetch():\n"
+        "    return requests.get('https://example.com')\n"
+    )
+
+    inp = PipelineInput(path=str(tmp_path), repo_id="test/deps")
+    _, nodes, rels = collect_pipeline(inp)
+
+    dep_nodes = [n for n in nodes if n.type == "Dependency"]
+    # Fixture sanity: make sure the pipeline actually produced Dependency
+    # nodes; otherwise the invariant check below is vacuous.
+    assert dep_nodes, "Expected Dependency nodes from fixture but got none"
+
+    rel_targets = {r.target_id for r in rels}
+    orphans = sorted(n.id for n in dep_nodes if n.id not in rel_targets)
+    assert orphans == [], (
+        f"Found orphan Dependency nodes with no incoming edges: {orphans}. "
+        "This breaks the UI-side deleteRepo orphan sweep — see "
+        "ui/src/store/ladybugStore.ts sweepOrphanedDependencies."
+    )

--- a/ui/src/store/__tests__/ladybugStore.test.ts
+++ b/ui/src/store/__tests__/ladybugStore.test.ts
@@ -178,14 +178,17 @@ describe('LadybugGraphStore deleteRepo', () => {
   it('prunes in-memory state keyed by the repo but spares other repos', async () => {
     const { store, s, connQuery } = makeStoreWithMockConn();
 
-    // The post-delete pass queries surviving Dependency rows to rebuild
-    // the in-memory dedup set. Make the mock return the shared package
-    // so the assertion below sees a set populated from DB ground truth.
+    // The post-delete pass runs two Dependency reads in order: the
+    // orphan-sweep query (distinguished by `count(r)`) which should see
+    // no orphans here because lodash is still referenced by bob/bar, and
+    // the dedup-set rebuild which returns surviving rows.
     connQuery.mockImplementation(async (cypher: string) => ({
-      getAllObjects: async () =>
-        cypher.includes('(n:Dependency)') && cypher.includes('RETURN n.id')
-          ? [{ id: 'pkg:npm:lodash' }]
-          : [],
+      getAllObjects: async () => {
+        if (!cypher.includes('(n:Dependency)')) return [];
+        if (cypher.includes('count(r)')) return []; // orphan sweep
+        if (cypher.includes('RETURN n.id')) return [{ id: 'pkg:npm:lodash' }];
+        return [];
+      },
       close: async () => {},
     }));
 
@@ -317,14 +320,20 @@ describe('LadybugGraphStore deleteRepo', () => {
     // ground truth. The guard only works if the set matches the DB.
     const { store, s, connQuery } = makeStoreWithMockConn();
     connQuery.mockImplementation(async (cypher: string) => ({
-      getAllObjects: async () =>
-        cypher.includes('(n:Dependency)') && cypher.includes('RETURN n.id')
-          ? [
-              { id: 'pkg:npm:lodash' },
-              { id: 'pkg:npm:react' },
-              { id: 'pkg:pypi:requests' },
-            ]
-          : [],
+      getAllObjects: async () => {
+        if (!cypher.includes('(n:Dependency)')) return [];
+        // Orphan sweep (distinguished by `count(r)`): none here — the
+        // focus of this test is the rebuild path, not the sweep.
+        if (cypher.includes('count(r)')) return [];
+        if (cypher.includes('RETURN n.id')) {
+          return [
+            { id: 'pkg:npm:lodash' },
+            { id: 'pkg:npm:react' },
+            { id: 'pkg:pypi:requests' },
+          ];
+        }
+        return [];
+      },
       close: async () => {},
     }));
 
@@ -342,5 +351,96 @@ describe('LadybugGraphStore deleteRepo', () => {
       'pkg:npm:react',
       'pkg:pypi:requests',
     ]);
+  });
+
+  it('sweeps Dependency nodes left orphaned by the deleted repo', async () => {
+    // After deleteRepo's RELATES sweep removes this repo's DEPENDS_ON /
+    // IMPORTS edges, any Dependency with zero remaining incoming edges
+    // was exclusively owned by this repo (Dependencies are only ever
+    // created paired with an edge) and is safe to delete. Shared
+    // dependencies still have edges from other repos and must survive.
+    const { store, connQuery } = makeStoreWithMockConn();
+    connQuery.mockImplementation(async (cypher: string) => ({
+      getAllObjects: async () => {
+        if (!cypher.includes('(n:Dependency)')) return [];
+        // Orphan sweep: one package exclusively used by alice/foo.
+        if (cypher.includes('count(r)')) {
+          return [{ id: 'pkg:npm:only-used-by-alice' }];
+        }
+        // Dedup rebuild (runs after the sweep): the shared survivor.
+        if (cypher.includes('RETURN n.id')) {
+          return [{ id: 'pkg:npm:lodash' }];
+        }
+        return [];
+      },
+      close: async () => {},
+    }));
+
+    await store.deleteRepo('alice/foo');
+
+    const cyphers = connQuery.mock.calls.map((c: [string]) => c[0]);
+
+    // The orphan-detection query ran.
+    expect(
+      cyphers.some(
+        (c: string) =>
+          c.includes('MATCH (n:Dependency)') && c.includes('count(r)'),
+      ),
+    ).toBe(true);
+
+    // A Dependency DELETE was issued, targeting the orphan id.
+    const depDelete = cyphers.find(
+      (c: string) =>
+        c.startsWith('MATCH (n:Dependency)') && c.includes('DELETE n'),
+    );
+    expect(depDelete).toBeDefined();
+    expect(depDelete).toContain("'pkg:npm:only-used-by-alice'");
+    // The survivor is not in the DELETE target list.
+    expect(depDelete).not.toContain("'pkg:npm:lodash'");
+    // The DELETE predicate is an id-list, not a repo-prefix clause.
+    expect(depDelete).not.toContain("'alice/foo'");
+
+    // Ordering: sweep must run before rebuildPackageDedupIndex. If the
+    // rebuild ran first it would populate flushedPackageIds from rows
+    // that the sweep then deletes, leaving stale ids in the guard — a
+    // later re-index of the same repo would skip the COPY for those
+    // packages and leave rels pointing at non-existent Dependencies.
+    const orphanQueryIdx = cyphers.findIndex(
+      (c: string) =>
+        c.includes('MATCH (n:Dependency)') && c.includes('count(r)'),
+    );
+    const orphanDeleteIdx = cyphers.findIndex(
+      (c: string) =>
+        c.startsWith('MATCH (n:Dependency)') && c.includes('DELETE n'),
+    );
+    const rebuildIdx = cyphers.findIndex(
+      (c: string) =>
+        c.startsWith('MATCH (n:Dependency)') &&
+        c.includes('RETURN n.id') &&
+        !c.includes('count(r)'),
+    );
+    expect(orphanQueryIdx).toBeGreaterThanOrEqual(0);
+    expect(orphanDeleteIdx).toBeGreaterThanOrEqual(0);
+    expect(rebuildIdx).toBeGreaterThanOrEqual(0);
+    expect(orphanQueryIdx).toBeLessThan(rebuildIdx);
+    expect(orphanDeleteIdx).toBeLessThan(rebuildIdx);
+  });
+
+  it('skips the Dependency DELETE when no orphans exist', async () => {
+    // When the orphan query returns zero rows, sweepOrphanedDependencies
+    // returns early and never issues the DELETE. Guards against
+    // accidentally running `DELETE n ... WHERE n.id IN []` which some
+    // Cypher engines either reject or interpret unfavorably.
+    const { store, connQuery } = makeStoreWithMockConn();
+
+    await store.deleteRepo('alice/foo');
+
+    const cyphers = connQuery.mock.calls.map((c: [string]) => c[0]);
+    expect(
+      cyphers.some(
+        (c: string) =>
+          c.startsWith('MATCH (n:Dependency)') && c.includes('DELETE n'),
+      ),
+    ).toBe(false);
   });
 });

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -1607,7 +1607,31 @@ export class LadybugGraphStore implements GraphStore {
       if (matches(id)) this.flushedSourceIds.delete(id);
     }
 
+    await this.sweepOrphanedDependencies();
     await this.rebuildPackageDedupIndex();
+  }
+
+  /** Delete Dependency nodes left with no incoming edges after
+   *  deleteRepo's RELATES sweep. Safe because Dependency nodes are only
+   *  ever created paired with an edge (DEPENDS_ON from Repository during
+   *  manifest parsing, IMPORTS from File during import analysis), so zero
+   *  incoming edges means the node was exclusively referenced by the
+   *  just-deleted repo. MUST run after the RELATES sweep, and before
+   *  rebuildPackageDedupIndex so flushedPackageIds resyncs from the
+   *  surviving rows. */
+  private async sweepOrphanedDependencies(): Promise<void> {
+    const orphans = (await this.query(
+      `MATCH (n:Dependency) ` +
+        `OPTIONAL MATCH ()-[r:RELATES]->(n) ` +
+        `WITH n, count(r) AS refs ` +
+        `WHERE refs = 0 ` +
+        `RETURN n.id AS id`,
+    )) as { id: string }[];
+    if (orphans.length === 0) return;
+    const idList = orphans.map((o) => `'${esc(o.id)}'`).join(', ');
+    await this.exec(
+      `MATCH (n:Dependency) WHERE n.id IN [${idList}] DELETE n`,
+    );
   }
 
   /** Rebuild `flushedPackageIds` from the current Dependency rows.

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -1629,9 +1629,7 @@ export class LadybugGraphStore implements GraphStore {
     )) as { id: string }[];
     if (orphans.length === 0) return;
     const idList = orphans.map((o) => `'${esc(o.id)}'`).join(', ');
-    await this.exec(
-      `MATCH (n:Dependency) WHERE n.id IN [${idList}] DELETE n`,
-    );
+    await this.exec(`MATCH (n:Dependency) WHERE n.id IN [${idList}] DELETE n`);
   }
 
   /** Rebuild `flushedPackageIds` from the current Dependency rows.


### PR DESCRIPTION
## Sweep orphan Dependency nodes on repository deletion
🐛 **Bug Fix** · ✨ **Improvement** · 🧪 **Tests**

Cleans up `Dependency` nodes that are no longer referenced by any repository or file after a repo is deleted. This prevents the database from accumulating orphan package nodes that were exclusively owned by a deleted repository.

### Complexity
🟢 Low · `3 files changed, 177 insertions(+), 15 deletions(-)`

The change is a targeted addition to the repository deletion logic, isolated to a single store class and verified by specific tests for both the logic and its underlying data invariants.

### Tests
🧪 Includes a new invariant test in the Python pipeline and comprehensive UI store tests covering deletion order and edge cases.

### Review focus
Pay particular attention to the following areas:

- **Cache synchronization** — check if identified orphans should also be evicted from `nodeTypeMap` and `nodeCache` to avoid stale in-memory state.
- **Deduplication guard** — confirm the sweep runs before `rebuildPackageDedupIndex` so the in-memory set correctly reflects the post-deletion state.
<!-- opentrace:jid=e3ccd4ff-eabb-44d7-ba61-32d221e3e72d|sha=729f384f98157f73a76d882336d01ed30d572d74 -->