### PR TITLE
fix(ui): disable already-indexed example repos in AddRepoModal (OT-1699)

### DIFF
--- a/ui/src/appComponents/__tests__/AddRepoModal.test.tsx
+++ b/ui/src/appComponents/__tests__/AddRepoModal.test.tsx
@@ -74,6 +74,25 @@ describe('AddRepoModal', () => {
     expect(getByText('Podinfo')).toBeDefined();
   });
 
+  it('disables example repo chips whose URL onValidate rejects', () => {
+    const onValidate = (url: string) =>
+      url === 'https://github.com/stefanprodan/podinfo'
+        ? 'Podinfo is already indexed'
+        : null;
+    const { getByTestId } = render(
+      React.createElement(AddRepoModal, { ...defaultProps, onValidate }),
+    );
+    const podinfo = getByTestId(
+      'example-repo-chip-Podinfo',
+    ) as HTMLButtonElement;
+    const express = getByTestId(
+      'example-repo-chip-Express.js',
+    ) as HTMLButtonElement;
+    expect(podinfo.disabled).toBe(true);
+    expect(podinfo.title).toBe('Podinfo is already indexed');
+    expect(express.disabled).toBe(false);
+  });
+
   it('submits index-repo message with URL', () => {
     const onSubmit = vi.fn();
     const { getByTestId, getByText } = render(

--- a/ui/src/components/indexing/AddRepoModal.css
+++ b/ui/src/components/indexing/AddRepoModal.css
@@ -332,10 +332,15 @@
   transition: all 0.15s;
 }
 
-.example-repo-chip:hover {
+.example-repo-chip:hover:not(:disabled) {
   color: var(--primary);
   border-color: color-mix(in oklch, var(--primary) 40%, transparent);
   background: color-mix(in oklch, var(--primary) 8%, transparent);
+}
+
+.example-repo-chip:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
 }
 
 .example-repo-size {

--- a/ui/src/components/indexing/AddRepoModal.tsx
+++ b/ui/src/components/indexing/AddRepoModal.tsx
@@ -368,6 +368,16 @@ export default function AddRepoModal({
     return onValidate(repoUrl);
   }, [source, repoUrl, onValidate]);
 
+  // Flag example repos already indexed by the consumer so we can disable
+  // them in the picker — clicking one would just land on the duplicate
+  // warning, so short-circuit that with a non-interactive chip.
+  const exampleRepoReasons = useMemo(() => {
+    if (!onValidate) return {} as Record<string, string | null>;
+    return Object.fromEntries(
+      EXAMPLE_REPOS.map((repo) => [repo.url, onValidate(repo.url)]),
+    );
+  }, [onValidate]);
+
   // Derive directory name from FileList
   const directoryName =
     selectedFiles?.[0]?.webkitRelativePath?.split('/')[0] ?? '';
@@ -715,22 +725,27 @@ export default function AddRepoModal({
                 {!provider && (
                   <div className="example-repos">
                     <span className="example-repos-label">Examples:</span>
-                    {EXAMPLE_REPOS.map((repo) => (
-                      <button
-                        key={repo.url}
-                        type="button"
-                        className="example-repo-chip"
-                        onClick={() => setRepoUrl(repo.url)}
-                        title={repo.description}
-                      >
-                        {repo.name}
-                        <span
-                          className={`example-repo-size example-repo-size--${repo.size.toLowerCase()}`}
+                    {EXAMPLE_REPOS.map((repo) => {
+                      const reason = exampleRepoReasons[repo.url];
+                      return (
+                        <button
+                          key={repo.url}
+                          type="button"
+                          className="example-repo-chip"
+                          onClick={() => setRepoUrl(repo.url)}
+                          disabled={!!reason}
+                          title={reason || repo.description}
+                          data-testid={`example-repo-chip-${repo.name}`}
                         >
-                          {repo.size}
-                        </span>
-                      </button>
-                    ))}
+                          {repo.name}
+                          <span
+                            className={`example-repo-size example-repo-size--${repo.size.toLowerCase()}`}
+                          >
+                            {repo.size}
+                          </span>
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
 


### PR DESCRIPTION
## Disable already-indexed example repos in AddRepoModal
✨ **Improvement** · 🧪 **Tests**

Disables example repository chips in the add-repo modal if they are already indexed. 

Provides immediate visual feedback through a disabled state and displays the validation reason in the chip's tooltip.

### Complexity
🟢 Trivial · `3 files changed, 55 insertions(+), 16 deletions(-)`

Narrow UI change in a single component with corresponding CSS and unit tests.

### Tests
🧪 Adds a new test case to AddRepoModal.test.tsx to verify that chips correctly reflect validation status and tooltips.
<!-- opentrace:jid=j-9d09725b-ebb3-437c-8784-3c077c83a2cf|sha=b0ad2502530ed587b3eb064db1fa97462eb01f5c -->