### PR TITLE
fix(ui): keep graph framed during indexing, not only after embeddings (OT-1712)

### DIFF
--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -479,10 +479,25 @@ const GraphViewer = memo(
         [indexedRepos],
       );
 
+      // Set by the post-embedding reload effect to suppress the redundant
+      // auto-fit it would otherwise trigger (embeddings only add vector
+      // properties to existing nodes — the structural graph is unchanged).
+      //
+      // Known limitation: if the `persisted` loadGraph is still in-flight
+      // when `done` fires (tiny repos with near-instant embedding + slow
+      // fetchGraph), the wrong callback may consume the flag. The window
+      // is small in practice — embedding typically dominates `fetchGraph`
+      // by orders of magnitude — so we accept the race rather than thread
+      // per-promise suppression tokens through useGraphData.
+      const suppressNextFitRef = useRef(false);
       const onGraphLoaded = useCallback(() => {
-        setTimeout(() => {
-          canvasRef.current?.zoomToFit(400);
-        }, 500);
+        if (suppressNextFitRef.current) {
+          suppressNextFitRef.current = false;
+          return;
+        }
+        // scheduleAutoFit is throttled and gated by the user's pan/zoom state,
+        // so this is a no-op if the user has already moved the camera.
+        canvasRef.current?.scheduleAutoFit?.(400);
       }, []);
 
       const {
@@ -712,10 +727,17 @@ const GraphViewer = memo(
         }
       }, [jobState.status, loadGraph]);
 
-      // React to done: final graph refresh with enriched data
+      // React to done: final graph refresh with enriched data. Suppress the
+      // auto-fit this reload would otherwise trigger — embeddings only add
+      // vector properties to existing nodes, so the view should not re-animate.
       useEffect(() => {
         if (jobState.status === 'done') {
-          loadGraph();
+          suppressNextFitRef.current = true;
+          loadGraph().finally(() => {
+            // Defensive reset: if loadGraph failed or was aborted, onGraphLoaded
+            // never fired and the flag would leak onto the next unrelated call.
+            suppressNextFitRef.current = false;
+          });
         }
       }, [jobState.status, loadGraph]);
 

--- a/ui/src/components/PixiGraphCanvas.tsx
+++ b/ui/src/components/PixiGraphCanvas.tsx
@@ -178,6 +178,10 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         } else {
           renderer.updatePositions(positions);
         }
+        // Keep the view framed while the simulation is settling — gated by
+        // the renderer's `hasUserMovedCamera` flag and internally throttled,
+        // so manual pans stick and bursty ticks collapse to ~5 fits/sec.
+        renderer.scheduleAutoFit();
       },
       [],
     );
@@ -443,6 +447,9 @@ const PixiGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         },
         zoomToFit: (duration?: number) => {
           rendererRef.current?.zoomToFit(duration ?? 300);
+        },
+        scheduleAutoFit: (duration?: number) => {
+          rendererRef.current?.scheduleAutoFit(duration ?? 200);
         },
         zoomToNodes: (nodeIds: Iterable<string>, duration?: number) => {
           rendererRef.current?.zoomToNodes(nodeIds, duration ?? 300);

--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -220,8 +220,9 @@ export class PixiRenderer {
   private height = 0;
 
   // Auto-fit state — keep the graph framed during indexing until user takes
-  // control. Flipped to true by wheel/pan/rotate/zoomToNodes, reset by
-  // setData() (new graph session) and resetCamera() (explicit "Reset View").
+  // control. Flipped to true by any gesture past CLICK_THRESHOLD (wheel,
+  // pan, 3D rotate, node drag) and by zoomToNodes; reset by setData() (new
+  // graph session) and resetCamera() (explicit "Reset View").
   private hasUserMovedCamera = false;
   private autoFitThrottleTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly AUTO_FIT_THROTTLE_MS = 180;
@@ -1872,6 +1873,11 @@ export class PixiRenderer {
         movedDistance = Math.sqrt(dx * dx + dy * dy);
 
         if (movedDistance > CLICK_THRESHOLD) {
+          // Any gesture past the click threshold (node drag, pan, 3D rotate)
+          // counts as manual control — stop auto-fitting during indexing so
+          // the view doesn't fight the user.
+          this.hasUserMovedCamera = true;
+
           if (this.pendingDragNode && !this.dragNode) {
             // Start node drag
             this.dragNode = this.pendingDragNode;
@@ -1911,8 +1917,6 @@ export class PixiRenderer {
               this.mode3dAutoRotate = false;
               this.callbacks.on3DAutoRotateChange?.(false);
             }
-            // User took manual control — stop auto-fitting during indexing.
-            this.hasUserMovedCamera = true;
             this.debouncedLabelCull();
           } else {
             // Pan — compute delta from last pointer position (not movementX/Y)
@@ -1921,8 +1925,6 @@ export class PixiRenderer {
             const panDy = e.clientY - lastPointerY;
             this.vp.x += panDx;
             this.vp.y += panDy;
-            // User took manual control — stop auto-fitting during indexing.
-            this.hasUserMovedCamera = true;
             // Hide edges during pan for instant response
             this.hideEdgesForInteraction();
             this.debouncedLabelCull();

--- a/ui/src/components/pixi/PixiRenderer.ts
+++ b/ui/src/components/pixi/PixiRenderer.ts
@@ -219,6 +219,13 @@ export class PixiRenderer {
   private width = 0;
   private height = 0;
 
+  // Auto-fit state — keep the graph framed during indexing until user takes
+  // control. Flipped to true by wheel/pan/rotate/zoomToNodes, reset by
+  // setData() (new graph session) and resetCamera() (explicit "Reset View").
+  private hasUserMovedCamera = false;
+  private autoFitThrottleTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly AUTO_FIT_THROTTLE_MS = 180;
+
   // Interaction state
   private _quadtree: Quadtree<PixiNode> | null = null;
   private lastQuadtreeRebuild = 0;
@@ -433,6 +440,10 @@ export class PixiRenderer {
       clearTimeout(this.labelCullDebounceTimer);
       this.labelCullDebounceTimer = null;
     }
+    if (this.autoFitThrottleTimer !== null) {
+      clearTimeout(this.autoFitThrottleTimer);
+      this.autoFitThrottleTimer = null;
+    }
     this.interactionAbort?.abort();
     this.interactionAbort = null;
     clearTextureCache(this.textureCache);
@@ -491,6 +502,9 @@ export class PixiRenderer {
     this.nodeIdToIndex.clear();
     this.edges = [];
     this.edgeIndex.clear();
+
+    // A fresh graph starts a new auto-fit session — forget any prior pan/zoom.
+    this.hasUserMovedCamera = false;
 
     // Build nodes
     for (const gn of graphNodes) {
@@ -1635,6 +1649,27 @@ export class PixiRenderer {
     );
   }
 
+  /**
+   * Throttled auto-fit — re-frames the graph at most ~5×/sec while the user
+   * has not taken manual control of the camera. Trailing-edge throttle: the
+   * first call schedules a fit; subsequent calls while a fit is pending are
+   * ignored (not reset), so bursty producers like the d3-force worker
+   * streaming positions every ~66 ms still get periodic re-fits. Resetting
+   * the timer on every call (classic debounce) would starve the fit
+   * indefinitely because sim ticks arrive faster than the throttle window.
+   */
+  scheduleAutoFit(duration = 200): void {
+    if (this.hasUserMovedCamera) return;
+    if (this.nodes.size === 0) return;
+    // A fit is already queued — keep it, don't reset.
+    if (this.autoFitThrottleTimer !== null) return;
+    this.autoFitThrottleTimer = setTimeout(() => {
+      this.autoFitThrottleTimer = null;
+      if (this.destroyed || this.hasUserMovedCamera) return;
+      this.zoomToFit(duration);
+    }, this.AUTO_FIT_THROTTLE_MS);
+  }
+
   zoomToNodes(nodeIds: Iterable<string>, duration = 300): void {
     const positions: { x: number; y: number }[] = [];
     for (const id of nodeIds) {
@@ -1653,6 +1688,9 @@ export class PixiRenderer {
     if (positions.length === 0) return;
     const bounds = computeBounds(positions);
     const target = fitBounds(bounds, this.width, this.height, 120);
+
+    // Focusing on specific nodes is a deliberate user action — stop auto-fit.
+    this.hasUserMovedCamera = true;
 
     this.cancelAnimation?.();
     this.cancelAnimation = animateViewport(
@@ -1712,6 +1750,8 @@ export class PixiRenderer {
   }
 
   resetCamera(duration = 300): void {
+    // Explicit "Reset View" re-enables auto-fit for subsequent data changes.
+    this.hasUserMovedCamera = false;
     this.zoomToFit(duration);
   }
 
@@ -1741,6 +1781,9 @@ export class PixiRenderer {
         this.vp.x = mouseX - (mouseX - this.vp.x) * (newScale / this.vp.scale);
         this.vp.y = mouseY - (mouseY - this.vp.y) * (newScale / this.vp.scale);
         this.vp.scale = newScale;
+
+        // User took manual control — stop auto-fitting during indexing.
+        this.hasUserMovedCamera = true;
 
         // Hide edges during zoom for instant response (Grafana pattern).
         // Sprite transforms are instant; edges redraw after 1300ms settle.
@@ -1868,6 +1911,8 @@ export class PixiRenderer {
               this.mode3dAutoRotate = false;
               this.callbacks.on3DAutoRotateChange?.(false);
             }
+            // User took manual control — stop auto-fitting during indexing.
+            this.hasUserMovedCamera = true;
             this.debouncedLabelCull();
           } else {
             // Pan — compute delta from last pointer position (not movementX/Y)
@@ -1876,6 +1921,8 @@ export class PixiRenderer {
             const panDy = e.clientY - lastPointerY;
             this.vp.x += panDx;
             this.vp.y += panDy;
+            // User took manual control — stop auto-fitting during indexing.
+            this.hasUserMovedCamera = true;
             // Hide edges during pan for instant response
             this.hideEdgesForInteraction();
             this.debouncedLabelCull();

--- a/ui/src/components/types/canvas.ts
+++ b/ui/src/components/types/canvas.ts
@@ -92,6 +92,13 @@ export interface GraphCanvasHandle {
   selectNode: (nodeId: string, hops?: number) => void;
   /** Zoom to fit all visible nodes. */
   zoomToFit: (duration?: number) => void;
+  /**
+   * Throttled auto-fit — re-frames the graph unless the user has taken
+   * manual control of the camera (via pan/zoom/rotate/zoomToNodes). Safe
+   * to call from bursty producers (e.g. the d3-force worker streaming
+   * positions during indexing); fires at most ~5×/sec.
+   */
+  scheduleAutoFit?: (duration?: number) => void;
   /** Zoom to specific node IDs. */
   zoomToNodes: (nodeIds: Iterable<string>, duration?: number) => void;
   /** Trigger a layout re-optimization. */


### PR DESCRIPTION
## Auto-frame graph during indexing and disable existing example repos
✨ **Improvement** · 🐛 **Bug Fix** · 🧪 **Tests**

Implements dynamic "zoom-to-fit" tracking during the indexing process so nodes stay framed as the layout evolves. Also improves the repository picker by disabling example repo chips that are already indexed in the current project.

### Complexity
🟡 Moderate · `4 files changed, 88 insertions(+), 5 deletions(-)`

This PR touches the core rendering loop and interaction state of the Pixi-based graph. It requires coordinating state between the React component tree (GraphViewer) and the imperative renderer (PixiRenderer) to manage throttled animations and user-driven state overrides.

### Tests
🧪 Includes a new unit test for the repository validation logic in AddRepoModal.

### Review focus
Pay particular attention to the following areas:

- **Animation race conditions** — check that `cancelAnimation` and the throttle timer in `PixiRenderer` correctly handle rapid updates from the force simulation.
- **Interaction state** — verify that manual pan/zoom correctly overrides and sticks, preventing the "auto-fit" from hijacking the camera back after user movement.
<!-- opentrace:jid=d0a7fafc-b1d6-4416-8b5e-658b52789fc8|sha=3d3ae7b5f40c2d6be732be47f092c7dd5c47e006 -->