### PR TITLE
feat(ui): resizable graph panels — horizontal, vertical, corner (OT-1716)

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -533,33 +533,6 @@
   padding-top: 64px;
 }
 
-/* Drag handle on the left edge */
-.chat-panel-drag-handle {
-  position: absolute;
-  top: 0;
-  left: -3px;
-  bottom: 0;
-  width: 6px;
-  cursor: col-resize;
-  z-index: 20;
-}
-
-.chat-panel-drag-handle::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 2px;
-  bottom: 0;
-  width: 2px;
-  background: transparent;
-  transition: background 0.15s;
-}
-
-.chat-panel-drag-handle:hover::after,
-.chat-panel-drag-handle:active::after {
-  background: var(--primary);
-}
-
 @keyframes slideInRight {
   from {
     transform: translateX(100%);
@@ -1608,10 +1581,6 @@
     border-top: 1px solid var(--border);
     padding-top: 0;
     padding-bottom: max(0px, env(safe-area-inset-bottom));
-  }
-
-  .chat-panel-drag-handle {
-    display: none;
   }
 
   .chat-input-area {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -531,6 +531,10 @@
   z-index: 10;
   position: relative;
   padding-top: 64px;
+  /* Clamp so a stored width wider than the current viewport can't hide the
+   * left-edge resize handle. The stored value persists — CSS renders the
+   * clamped size until there's room again. */
+  max-width: 100%;
 }
 
 @keyframes slideInRight {

--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -106,12 +106,14 @@ export default function ChatPanel({
 }: Props) {
   const { store } = useStore();
 
+  const panelRef = useRef<HTMLDivElement>(null);
   const { width: panelWidth, handleMouseDown } = useResizablePanel({
     storageKey: 'ot_chat_panel_width',
     defaultWidth: 480,
     minWidth: 320,
     maxWidth: 800,
     side: 'left',
+    panelRef,
   });
 
   // Notify parent of width changes so graph canvas can adjust
@@ -894,6 +896,7 @@ export default function ChatPanel({
 
   return (
     <div
+      ref={panelRef}
       className="chat-panel"
       style={{ width: panelWidth }}
       onDragOver={handleDragOver}

--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -56,6 +56,7 @@ import type { AIMessageChunk } from '@langchain/core/messages';
 import { useStore } from '../store';
 import { PRClient, parseRepoUrl } from '../pr/client';
 import { useResizablePanel } from '../hooks/useResizablePanel';
+import { PanelResizeHandle } from '@opentrace/components';
 import { useConversation } from '../chat/useConversation';
 import PRListPanel from './PRListPanel';
 import './ChatPanel.css';
@@ -899,7 +900,7 @@ export default function ChatPanel({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <div className="chat-panel-drag-handle" onMouseDown={handleMouseDown} />
+      <PanelResizeHandle side="left" onMouseDown={handleMouseDown} />
       {dragOver && (
         <div className="image-drop-overlay">
           <div className="image-drop-overlay-content">

--- a/ui/src/appComponents/HelpDrawer.css
+++ b/ui/src/appComponents/HelpDrawer.css
@@ -17,6 +17,7 @@
 .help-drawer {
   flex-shrink: 0;
   width: var(--help-drawer-width, 380px);
+  max-width: 100%;
   background: var(--background);
   border-left: 1px solid color-mix(in oklch, var(--border) 40%, transparent);
   display: flex;

--- a/ui/src/appComponents/HelpDrawer.css
+++ b/ui/src/appComponents/HelpDrawer.css
@@ -16,7 +16,7 @@
 
 .help-drawer {
   flex-shrink: 0;
-  width: 380px;
+  width: var(--help-drawer-width, 380px);
   background: var(--background);
   border-left: 1px solid color-mix(in oklch, var(--border) 40%, transparent);
   display: flex;

--- a/ui/src/appComponents/HelpDrawer.tsx
+++ b/ui/src/appComponents/HelpDrawer.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useRef } from 'react';
 import { PanelResizeHandle } from '@opentrace/components';
 import { useResizablePanel } from '../hooks/useResizablePanel';
 import './HelpDrawer.css';
@@ -31,16 +32,19 @@ export default function HelpDrawer({
   onOpenChat,
   onOpenSettings,
 }: HelpDrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
   const { width: panelWidth, handleMouseDown } = useResizablePanel({
     storageKey: 'ot_help_drawer_width',
     defaultWidth: 380,
     minWidth: 320,
     maxWidth: 640,
     side: 'left',
+    panelRef,
   });
 
   return (
     <div
+      ref={panelRef}
       className="help-drawer"
       style={
         { '--help-drawer-width': `${panelWidth}px` } as React.CSSProperties

--- a/ui/src/appComponents/HelpDrawer.tsx
+++ b/ui/src/appComponents/HelpDrawer.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { PanelResizeHandle } from '@opentrace/components';
+import { useResizablePanel } from '../hooks/useResizablePanel';
 import './HelpDrawer.css';
 
 interface HelpDrawerProps {
@@ -29,8 +31,22 @@ export default function HelpDrawer({
   onOpenChat,
   onOpenSettings,
 }: HelpDrawerProps) {
+  const { width: panelWidth, handleMouseDown } = useResizablePanel({
+    storageKey: 'ot_help_drawer_width',
+    defaultWidth: 380,
+    minWidth: 320,
+    maxWidth: 640,
+    side: 'left',
+  });
+
   return (
-    <div className="help-drawer">
+    <div
+      className="help-drawer"
+      style={
+        { '--help-drawer-width': `${panelWidth}px` } as React.CSSProperties
+      }
+    >
+      <PanelResizeHandle side="left" onMouseDown={handleMouseDown} />
       <div className="panel-header">
         <h3>Getting Started</h3>
         <button className="close-btn" onClick={onClose}>

--- a/ui/src/appComponents/SettingsDrawer.css
+++ b/ui/src/appComponents/SettingsDrawer.css
@@ -20,6 +20,7 @@
   right: 0;
   bottom: 0;
   width: var(--settings-drawer-width, 420px);
+  max-width: 100%;
   padding-top: 68px;
   background: var(--background);
   border-left: 1px solid color-mix(in oklch, var(--border) 40%, transparent);

--- a/ui/src/appComponents/SettingsDrawer.css
+++ b/ui/src/appComponents/SettingsDrawer.css
@@ -19,7 +19,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  width: 420px;
+  width: var(--settings-drawer-width, 420px);
   padding-top: 68px;
   background: var(--background);
   border-left: 1px solid color-mix(in oklch, var(--border) 40%, transparent);

--- a/ui/src/appComponents/SettingsDrawer.tsx
+++ b/ui/src/appComponents/SettingsDrawer.tsx
@@ -27,7 +27,9 @@ import {
   type AnimationSettings,
 } from '../config/animation';
 import type { SummarizationStrategyType } from '@opentrace/components/pipeline';
+import { PanelResizeHandle } from '@opentrace/components';
 import { useStore } from '../store';
+import { useResizablePanel } from '../hooks/useResizablePanel';
 import './SettingsDrawer.css';
 
 const DEFAULT_MAX_NODES = 20000;
@@ -56,6 +58,13 @@ export default function SettingsDrawer({
   onAnimationSettingsChanged,
 }: SettingsDrawerProps) {
   const { store } = useStore();
+  const { width: panelWidth, handleMouseDown } = useResizablePanel({
+    storageKey: 'ot_settings_drawer_width',
+    defaultWidth: 420,
+    minWidth: 360,
+    maxWidth: 700,
+    side: 'left',
+  });
   const [clearing, setClearing] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -135,7 +144,13 @@ export default function SettingsDrawer({
   };
 
   return (
-    <div className="settings-drawer">
+    <div
+      className="settings-drawer"
+      style={
+        { '--settings-drawer-width': `${panelWidth}px` } as React.CSSProperties
+      }
+    >
+      <PanelResizeHandle side="left" onMouseDown={handleMouseDown} />
       <div className="panel-header">
         <h3>Settings</h3>
         <button className="close-btn" onClick={onClose}>

--- a/ui/src/appComponents/SettingsDrawer.tsx
+++ b/ui/src/appComponents/SettingsDrawer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   loadSummarizerStrategy,
   saveSummarizerStrategy,
@@ -58,12 +58,14 @@ export default function SettingsDrawer({
   onAnimationSettingsChanged,
 }: SettingsDrawerProps) {
   const { store } = useStore();
+  const panelRef = useRef<HTMLDivElement>(null);
   const { width: panelWidth, handleMouseDown } = useResizablePanel({
     storageKey: 'ot_settings_drawer_width',
     defaultWidth: 420,
     minWidth: 360,
     maxWidth: 700,
     side: 'left',
+    panelRef,
   });
   const [clearing, setClearing] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -145,6 +147,7 @@ export default function SettingsDrawer({
 
   return (
     <div
+      ref={panelRef}
       className="settings-drawer"
       style={
         { '--settings-drawer-width': `${panelWidth}px` } as React.CSSProperties

--- a/ui/src/appComponents/SidePanel.css
+++ b/ui/src/appComponents/SidePanel.css
@@ -21,6 +21,11 @@
   top: 0;
   left: 0;
   bottom: 0;
+  /* Height: auto by default so `top` + `bottom` anchors compute the height
+   * (lets consumers like insight-ui inset the panel via `!top-3 !bottom-3`).
+   * Once the user drags the bottom edge, this var is set and `height` wins
+   * over `bottom` per CSS abs-positioning rules. */
+  height: var(--side-panel-height, auto);
   width: 220px;
   z-index: 5;
   background: color-mix(in oklch, var(--background) 60%, transparent);
@@ -30,33 +35,6 @@
   padding-top: 64px;
   display: flex;
   flex-direction: column;
-}
-
-/* Drag handle on the right edge */
-.side-panel-drag-handle {
-  position: absolute;
-  top: 0;
-  right: -3px;
-  bottom: 0;
-  width: 6px;
-  cursor: col-resize;
-  z-index: 10;
-}
-
-.side-panel-drag-handle::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 2px;
-  bottom: 0;
-  width: 2px;
-  background: transparent;
-  transition: background 0.15s;
-}
-
-.side-panel-drag-handle:hover::after,
-.side-panel-drag-handle:active::after {
-  background: var(--primary);
 }
 
 /* Tab bar — only rendered when a node is selected */

--- a/ui/src/appComponents/SidePanel.css
+++ b/ui/src/appComponents/SidePanel.css
@@ -27,6 +27,12 @@
    * over `bottom` per CSS abs-positioning rules. */
   height: var(--side-panel-height, auto);
   width: 220px;
+  /* Clamp to the containing block so a stored width/height bigger than the
+   * current viewport can't push the panel (and its bottom/right resize
+   * handles) off-screen. The stored value survives — CSS just renders the
+   * clamped size until there's room again. */
+  max-width: 100%;
+  max-height: 100%;
   z-index: 5;
   background: color-mix(in oklch, var(--background) 60%, transparent);
   backdrop-filter: blur(16px);

--- a/ui/src/appComponents/SidePanel.css
+++ b/ui/src/appComponents/SidePanel.css
@@ -21,27 +21,17 @@
   top: 0;
   left: 0;
   bottom: 0;
-  /* Default corner-arc radius (overridden at runtime by JS that reads
-   * the panel's actual computed border-radius — covers consumers that
-   * inject their own radius via Tailwind, e.g. insight-ui's
-   * `rounded-lg` floating-mode override). */
-  --ot-panel-corner-radius: 8px;
   /* Height: auto by default so `top` + `bottom` anchors compute the height
    * (lets consumers like insight-ui inset the panel via `!top-3 !bottom-3`).
    * Once the user drags the bottom edge, this var is set and `height` wins
    * over `bottom` per CSS abs-positioning rules. */
   height: var(--side-panel-height, auto);
   width: 220px;
-  /* Clamp to the containing block so a stored width/height bigger than the
-   * current viewport can't push the panel (and its bottom/right resize
-   * handles) off-screen. Leave 4 px breathing room on each axis so the
-   * handle's outer 3 px (it sits at `bottom: -3px` / `right: -3px`) stays
-   * inside the parent — otherwise overflow:hidden on the parent
-   * (insight-ui's graph-viewport) clips half the hit-area. The stored
-   * value survives — CSS just renders the clamped size until there's
-   * room again. */
-  max-width: calc(100% - 4px);
-  max-height: calc(100% - 4px);
+  /* Hard cap at the parent's size — the precise clamp (which accounts
+   * for handle bleed and consumer-applied insets) lives in
+   * useResizablePanel's ResizeObserver. */
+  max-width: 100%;
+  max-height: 100%;
   z-index: 5;
   background: color-mix(in oklch, var(--background) 60%, transparent);
   backdrop-filter: blur(16px);

--- a/ui/src/appComponents/SidePanel.css
+++ b/ui/src/appComponents/SidePanel.css
@@ -21,6 +21,11 @@
   top: 0;
   left: 0;
   bottom: 0;
+  /* Default corner-arc radius (overridden at runtime by JS that reads
+   * the panel's actual computed border-radius — covers consumers that
+   * inject their own radius via Tailwind, e.g. insight-ui's
+   * `rounded-lg` floating-mode override). */
+  --ot-panel-corner-radius: 8px;
   /* Height: auto by default so `top` + `bottom` anchors compute the height
    * (lets consumers like insight-ui inset the panel via `!top-3 !bottom-3`).
    * Once the user drags the bottom edge, this var is set and `height` wins
@@ -29,10 +34,14 @@
   width: 220px;
   /* Clamp to the containing block so a stored width/height bigger than the
    * current viewport can't push the panel (and its bottom/right resize
-   * handles) off-screen. The stored value survives — CSS just renders the
-   * clamped size until there's room again. */
-  max-width: 100%;
-  max-height: 100%;
+   * handles) off-screen. Leave 4 px breathing room on each axis so the
+   * handle's outer 3 px (it sits at `bottom: -3px` / `right: -3px`) stays
+   * inside the parent — otherwise overflow:hidden on the parent
+   * (insight-ui's graph-viewport) clips half the hit-area. The stored
+   * value survives — CSS just renders the clamped size until there's
+   * room again. */
+  max-width: calc(100% - 4px);
+  max-height: calc(100% - 4px);
   z-index: 5;
   background: color-mix(in oklch, var(--background) 60%, transparent);
   backdrop-filter: blur(16px);

--- a/ui/src/appComponents/SidePanel.tsx
+++ b/ui/src/appComponents/SidePanel.tsx
@@ -125,12 +125,14 @@ export default function SidePanel({
 
   const hasSelection = selectedNode !== null || selectedLink !== null;
 
+  const panelRef = useRef<HTMLDivElement>(null);
   const { width: panelWidth, handleMouseDown } = useResizablePanel({
     storageKey: 'ot_side_panel_width',
     defaultWidth: 360,
     minWidth: 220,
     maxWidth: 900,
     side: 'right',
+    panelRef,
   });
   const { height: panelHeight, handleMouseDown: onHeightDrag } =
     useResizablePanelHeight({
@@ -138,6 +140,7 @@ export default function SidePanel({
       minHeight: 320,
       maxHeight: 1400,
       side: 'bottom',
+      panelRef,
     });
 
   // Auto-switch to details when node or edge is selected
@@ -172,6 +175,7 @@ export default function SidePanel({
 
   return (
     <div
+      ref={panelRef}
       className={`side-panel${isMobileOpen ? ' side-panel--mobile-open' : ''}`}
       style={
         {
@@ -283,8 +287,8 @@ export default function SidePanel({
       <PanelResizeHandle
         side="bottom-right"
         onMouseDown={(e) => {
-          handleMouseDown(e);
-          onHeightDrag(e);
+          handleMouseDown(e, 'nwse-resize');
+          onHeightDrag(e, 'nwse-resize');
         }}
       />
     </div>

--- a/ui/src/appComponents/SidePanel.tsx
+++ b/ui/src/appComponents/SidePanel.tsx
@@ -16,10 +16,17 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { SelectedNode, SelectedEdge } from '@opentrace/components/utils';
-import { FilterPanel, type FilterPanelProps } from '@opentrace/components';
+import {
+  FilterPanel,
+  PanelResizeHandle,
+  type FilterPanelProps,
+} from '@opentrace/components';
 import type { NodeSourceResponse } from '../store/types';
 import { useStore } from '../store/context';
-import { useResizablePanel } from '../hooks/useResizablePanel';
+import {
+  useResizablePanel,
+  useResizablePanelHeight,
+} from '../hooks/useResizablePanel';
 import DiscoverPanelContainer from './DiscoverPanelContainer';
 import { createStoreDataProvider } from './storeDataProvider';
 import NodeDetailsPanel, { type NodeEdge } from './NodeDetailsPanel';
@@ -117,18 +124,21 @@ export default function SidePanel({
   const effectiveTab = mobileActiveTab ?? activeTab;
 
   const hasSelection = selectedNode !== null || selectedLink !== null;
-  const expanded =
-    hasSelection || effectiveTab === 'discover' || effectiveTab === 'history';
 
   const { width: panelWidth, handleMouseDown } = useResizablePanel({
-    storageKey: expanded
-      ? 'ot_side_panel_expanded_width'
-      : 'ot_side_panel_width',
-    defaultWidth: expanded ? 480 : 220,
-    minWidth: 180,
-    maxWidth: 700,
+    storageKey: 'ot_side_panel_width',
+    defaultWidth: 360,
+    minWidth: 220,
+    maxWidth: 900,
     side: 'right',
   });
+  const { height: panelHeight, handleMouseDown: onHeightDrag } =
+    useResizablePanelHeight({
+      storageKey: 'ot_side_panel_height',
+      minHeight: 320,
+      maxHeight: 1400,
+      side: 'bottom',
+    });
 
   // Auto-switch to details when node or edge is selected
   useEffect(() => {
@@ -163,7 +173,14 @@ export default function SidePanel({
   return (
     <div
       className={`side-panel${isMobileOpen ? ' side-panel--mobile-open' : ''}`}
-      style={{ width: isMobileOpen ? undefined : panelWidth }}
+      style={
+        {
+          width: panelWidth,
+          ...(panelHeight != null
+            ? { '--side-panel-height': `${panelHeight}px` }
+            : {}),
+        } as React.CSSProperties
+      }
     >
       <div className="side-panel-tabs">
         <button
@@ -261,9 +278,15 @@ export default function SidePanel({
           ) : null}
         </div>
       )}
-      {!isMobileOpen && (
-        <div className="side-panel-drag-handle" onMouseDown={handleMouseDown} />
-      )}
+      <PanelResizeHandle side="right" onMouseDown={handleMouseDown} />
+      <PanelResizeHandle side="bottom" onMouseDown={onHeightDrag} />
+      <PanelResizeHandle
+        side="bottom-right"
+        onMouseDown={(e) => {
+          handleMouseDown(e);
+          onHeightDrag(e);
+        }}
+      />
     </div>
   );
 }

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -143,6 +143,7 @@ export {
   GraphToolbar,
   DiscoverPanel,
   PhysicsPanel,
+  PanelResizeHandle,
   useDiscoverTree,
 } from './panels';
 export type {

--- a/ui/src/components/panels/DiscoverPanel.tsx
+++ b/ui/src/components/panels/DiscoverPanel.tsx
@@ -189,7 +189,7 @@ function TreeRow({
         className="discover-tree-placeholder"
         style={{
           ...style,
-          paddingLeft: `${12 + depth * 16}px`,
+          paddingLeft: `${8 + depth * 12}px`,
         }}
       >
         Loading...
@@ -218,7 +218,7 @@ function TreeRow({
 
   const rowStyle: React.CSSProperties = {
     ...style,
-    paddingLeft: `${12 + depth * 16}px`,
+    paddingLeft: `${8 + depth * 12}px`,
     ...(!isSelected && hopHighlight !== undefined
       ? ({ '--hop-intensity': hopHighlight } as React.CSSProperties)
       : {}),

--- a/ui/src/components/panels/PanelResizeHandle.css
+++ b/ui/src/components/panels/PanelResizeHandle.css
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Shared drag handle for every resizable panel. A faint bar is always visible
+ * so users can discover the handle without hovering first.
+ *
+ * The bar is inset 10px from each end so it tucks inside panels with rounded
+ * corners (≤ 10px radius) and doesn't overshoot. Panels that want a different
+ * inset can set `--ot-panel-resize-inset` on the panel root. */
+
+.ot-panel-resize-handle {
+  position: absolute;
+  z-index: 20;
+  --ot-panel-resize-inset: 10px;
+}
+
+/* ── Edges ───────────────────────────────────────────────────────────── */
+
+/* Vertical edges — horizontal drag */
+.ot-panel-resize-handle--left,
+.ot-panel-resize-handle--right {
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  cursor: col-resize;
+}
+
+.ot-panel-resize-handle--left {
+  left: -3px;
+}
+
+.ot-panel-resize-handle--right {
+  right: -3px;
+}
+
+/* Horizontal edges — vertical drag */
+.ot-panel-resize-handle--top,
+.ot-panel-resize-handle--bottom {
+  left: 0;
+  right: 0;
+  height: 6px;
+  cursor: row-resize;
+}
+
+.ot-panel-resize-handle--top {
+  top: -3px;
+}
+
+.ot-panel-resize-handle--bottom {
+  bottom: -3px;
+}
+
+/* ── Corners ─────────────────────────────────────────────────────────── */
+
+.ot-panel-resize-handle--top-left,
+.ot-panel-resize-handle--top-right,
+.ot-panel-resize-handle--bottom-left,
+.ot-panel-resize-handle--bottom-right {
+  width: 14px;
+  height: 14px;
+  z-index: 21;
+}
+
+.ot-panel-resize-handle--top-left {
+  top: -3px;
+  left: -3px;
+  cursor: nwse-resize;
+}
+
+.ot-panel-resize-handle--top-right {
+  top: -3px;
+  right: -3px;
+  cursor: nesw-resize;
+}
+
+.ot-panel-resize-handle--bottom-left {
+  bottom: -3px;
+  left: -3px;
+  cursor: nesw-resize;
+}
+
+.ot-panel-resize-handle--bottom-right {
+  bottom: -3px;
+  right: -3px;
+  cursor: nwse-resize;
+}
+
+/* ── Edge indicator bars ─────────────────────────────────────────────── */
+
+.ot-panel-resize-handle--left::after,
+.ot-panel-resize-handle--right::after,
+.ot-panel-resize-handle--top::after,
+.ot-panel-resize-handle--bottom::after {
+  content: '';
+  position: absolute;
+  background: color-mix(in oklch, var(--border) 60%, transparent);
+  transition:
+    background 0.15s,
+    width 0.15s,
+    height 0.15s;
+}
+
+.ot-panel-resize-handle--left::after,
+.ot-panel-resize-handle--right::after {
+  top: var(--ot-panel-resize-inset);
+  bottom: var(--ot-panel-resize-inset);
+  width: 2px;
+}
+
+.ot-panel-resize-handle--left::after {
+  right: 2px;
+}
+
+.ot-panel-resize-handle--right::after {
+  left: 2px;
+}
+
+.ot-panel-resize-handle--top::after,
+.ot-panel-resize-handle--bottom::after {
+  left: var(--ot-panel-resize-inset);
+  right: var(--ot-panel-resize-inset);
+  height: 2px;
+}
+
+.ot-panel-resize-handle--top::after {
+  bottom: 2px;
+}
+
+.ot-panel-resize-handle--bottom::after {
+  top: 2px;
+}
+
+/* ── Corner indicator dots ───────────────────────────────────────────── */
+
+.ot-panel-resize-handle--top-left::after,
+.ot-panel-resize-handle--top-right::after,
+.ot-panel-resize-handle--bottom-left::after,
+.ot-panel-resize-handle--bottom-right::after {
+  content: '';
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 1px;
+  background: color-mix(in oklch, var(--border) 60%, transparent);
+  transition: background 0.15s;
+}
+
+.ot-panel-resize-handle--top-left::after {
+  top: 4px;
+  left: 4px;
+}
+
+.ot-panel-resize-handle--top-right::after {
+  top: 4px;
+  right: 4px;
+}
+
+.ot-panel-resize-handle--bottom-left::after {
+  bottom: 4px;
+  left: 4px;
+}
+
+.ot-panel-resize-handle--bottom-right::after {
+  bottom: 4px;
+  right: 4px;
+}
+
+/* ── Hover / active state ────────────────────────────────────────────── */
+
+.ot-panel-resize-handle:hover::after,
+.ot-panel-resize-handle:active::after {
+  background: var(--primary);
+}
+
+.ot-panel-resize-handle--left:hover::after,
+.ot-panel-resize-handle--left:active::after,
+.ot-panel-resize-handle--right:hover::after,
+.ot-panel-resize-handle--right:active::after {
+  width: 3px;
+}
+
+.ot-panel-resize-handle--top:hover::after,
+.ot-panel-resize-handle--top:active::after,
+.ot-panel-resize-handle--bottom:hover::after,
+.ot-panel-resize-handle--bottom:active::after {
+  height: 3px;
+}
+
+/* ── Corner hover/drag cascades to its two adjacent edge bars ────────── */
+
+/* Right edge brightens when a right-side corner is hovered/active */
+:has(> .ot-panel-resize-handle--top-right:is(:hover, :active))
+  > .ot-panel-resize-handle--right::after,
+:has(> .ot-panel-resize-handle--bottom-right:is(:hover, :active))
+  > .ot-panel-resize-handle--right::after {
+  background: var(--primary);
+  width: 3px;
+}
+
+/* Left edge brightens when a left-side corner is hovered/active */
+:has(> .ot-panel-resize-handle--top-left:is(:hover, :active))
+  > .ot-panel-resize-handle--left::after,
+:has(> .ot-panel-resize-handle--bottom-left:is(:hover, :active))
+  > .ot-panel-resize-handle--left::after {
+  background: var(--primary);
+  width: 3px;
+}
+
+/* Top edge brightens when a top-side corner is hovered/active */
+:has(> .ot-panel-resize-handle--top-left:is(:hover, :active))
+  > .ot-panel-resize-handle--top::after,
+:has(> .ot-panel-resize-handle--top-right:is(:hover, :active))
+  > .ot-panel-resize-handle--top::after {
+  background: var(--primary);
+  height: 3px;
+}
+
+/* Bottom edge brightens when a bottom-side corner is hovered/active */
+:has(> .ot-panel-resize-handle--bottom-left:is(:hover, :active))
+  > .ot-panel-resize-handle--bottom::after,
+:has(> .ot-panel-resize-handle--bottom-right:is(:hover, :active))
+  > .ot-panel-resize-handle--bottom::after {
+  background: var(--primary);
+  height: 3px;
+}
+
+/* ── Touch-first layouts: hide handles ───────────────────────────────── */
+
+@media (max-width: 1024px) {
+  .ot-panel-resize-handle {
+    display: none;
+  }
+}

--- a/ui/src/components/panels/PanelResizeHandle.css
+++ b/ui/src/components/panels/PanelResizeHandle.css
@@ -27,12 +27,6 @@
    * overshoots their corner curve. Override per-panel if your radius is
    * unusually large. */
   --ot-panel-resize-inset: 12px;
-  /* `--ot-panel-corner-radius` is intentionally NOT defined here — it
-   * cascades down from the parent panel (each panel sets it to its own
-   * border-radius). Defining it here would override the cascade for
-   * every handle and freeze the arc at one value. The `var()` calls
-   * below carry their own fallback so corner panels still render if a
-   * consumer forgot to set the var. */
 }
 
 /* ── Edges ───────────────────────────────────────────────────────────── */
@@ -172,63 +166,6 @@
 .ot-panel-resize-handle--bottom:hover::after,
 .ot-panel-resize-handle--bottom:active::after {
   height: 3px;
-}
-
-/* ── Corner hover/drag cascades to its two adjacent edge bars ────────── */
-/*    The cascade is class-driven: the PanelResizeHandle component tags the
- *    parent panel with a marker class while a corner is hovered/pressed, so
- *    the bars brighten and shed their corner-inset on the shared end. We
- *    avoided a `:has()`-only rule here because some stacking contexts
- *    suppress it for sibling combinations during pointer drag. */
-
-/* Right edge — brightens + extends when right-side corner is active.
- * Bars stop at the panel's corner radius so they meet the corner arc
- * (rendered by the corner handle's `::after`) cleanly along the curve. */
-.ot-panel--corner-active-tr > .ot-panel-resize-handle--right::after {
-  background: var(--primary);
-  width: 3px;
-  top: var(--ot-panel-corner-radius, 10px);
-}
-.ot-panel--corner-active-br > .ot-panel-resize-handle--right::after {
-  background: var(--primary);
-  width: 3px;
-  bottom: var(--ot-panel-corner-radius, 10px);
-}
-
-/* Left edge — left-side corner */
-.ot-panel--corner-active-tl > .ot-panel-resize-handle--left::after {
-  background: var(--primary);
-  width: 3px;
-  top: var(--ot-panel-corner-radius, 10px);
-}
-.ot-panel--corner-active-bl > .ot-panel-resize-handle--left::after {
-  background: var(--primary);
-  width: 3px;
-  bottom: var(--ot-panel-corner-radius, 10px);
-}
-
-/* Top edge — top-side corner */
-.ot-panel--corner-active-tl > .ot-panel-resize-handle--top::after {
-  background: var(--primary);
-  height: 3px;
-  left: var(--ot-panel-corner-radius, 10px);
-}
-.ot-panel--corner-active-tr > .ot-panel-resize-handle--top::after {
-  background: var(--primary);
-  height: 3px;
-  right: var(--ot-panel-corner-radius, 10px);
-}
-
-/* Bottom edge — bottom-side corner */
-.ot-panel--corner-active-bl > .ot-panel-resize-handle--bottom::after {
-  background: var(--primary);
-  height: 3px;
-  left: var(--ot-panel-corner-radius, 10px);
-}
-.ot-panel--corner-active-br > .ot-panel-resize-handle--bottom::after {
-  background: var(--primary);
-  height: 3px;
-  right: var(--ot-panel-corner-radius, 10px);
 }
 
 /* ── Cascade outline drawn ON THE PANEL ITSELF ──────────────────────── */

--- a/ui/src/components/panels/PanelResizeHandle.css
+++ b/ui/src/components/panels/PanelResizeHandle.css
@@ -23,7 +23,16 @@
 .ot-panel-resize-handle {
   position: absolute;
   z-index: 20;
-  --ot-panel-resize-inset: 10px;
+  /* Inset from each end so the bar tucks inside rounded panels and never
+   * overshoots their corner curve. Override per-panel if your radius is
+   * unusually large. */
+  --ot-panel-resize-inset: 12px;
+  /* `--ot-panel-corner-radius` is intentionally NOT defined here — it
+   * cascades down from the parent panel (each panel sets it to its own
+   * border-radius). Defining it here would override the cascade for
+   * every handle and freeze the arc at one value. The `var()` calls
+   * below carry their own fallback so corner panels still render if a
+   * consumer forgot to set the var. */
 }
 
 /* ── Edges ───────────────────────────────────────────────────────────── */
@@ -172,52 +181,107 @@
  *    avoided a `:has()`-only rule here because some stacking contexts
  *    suppress it for sibling combinations during pointer drag. */
 
-/* Right edge — brightens + extends when right-side corner is active */
+/* Right edge — brightens + extends when right-side corner is active.
+ * Bars stop at the panel's corner radius so they meet the corner arc
+ * (rendered by the corner handle's `::after`) cleanly along the curve. */
 .ot-panel--corner-active-tr > .ot-panel-resize-handle--right::after {
   background: var(--primary);
   width: 3px;
-  top: 0;
+  top: var(--ot-panel-corner-radius, 10px);
 }
 .ot-panel--corner-active-br > .ot-panel-resize-handle--right::after {
   background: var(--primary);
   width: 3px;
-  bottom: 0;
+  bottom: var(--ot-panel-corner-radius, 10px);
 }
 
 /* Left edge — left-side corner */
 .ot-panel--corner-active-tl > .ot-panel-resize-handle--left::after {
   background: var(--primary);
   width: 3px;
-  top: 0;
+  top: var(--ot-panel-corner-radius, 10px);
 }
 .ot-panel--corner-active-bl > .ot-panel-resize-handle--left::after {
   background: var(--primary);
   width: 3px;
-  bottom: 0;
+  bottom: var(--ot-panel-corner-radius, 10px);
 }
 
 /* Top edge — top-side corner */
 .ot-panel--corner-active-tl > .ot-panel-resize-handle--top::after {
   background: var(--primary);
   height: 3px;
-  left: 0;
+  left: var(--ot-panel-corner-radius, 10px);
 }
 .ot-panel--corner-active-tr > .ot-panel-resize-handle--top::after {
   background: var(--primary);
   height: 3px;
-  right: 0;
+  right: var(--ot-panel-corner-radius, 10px);
 }
 
 /* Bottom edge — bottom-side corner */
 .ot-panel--corner-active-bl > .ot-panel-resize-handle--bottom::after {
   background: var(--primary);
   height: 3px;
-  left: 0;
+  left: var(--ot-panel-corner-radius, 10px);
 }
 .ot-panel--corner-active-br > .ot-panel-resize-handle--bottom::after {
   background: var(--primary);
   height: 3px;
-  right: 0;
+  right: var(--ot-panel-corner-radius, 10px);
+}
+
+/* ── Cascade outline drawn ON THE PANEL ITSELF ──────────────────────── */
+/*    A pseudo-element on the panel inherits the panel's border-radius
+ *    and traces the rounded edge directly — no offset math, no per-
+ *    handle arc, the curve is always exactly the panel's curve.
+ *    Activated by the corner-active class added by the JS handler. */
+
+.ot-panel--corner-active-tl::after,
+.ot-panel--corner-active-tr::after,
+.ot-panel--corner-active-bl::after,
+.ot-panel--corner-active-br::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 3px solid transparent;
+  border-radius: inherit;
+  box-sizing: border-box;
+  pointer-events: none;
+  /* Sit above the edge handles so the cascade reads as a single
+   * continuous outline. */
+  z-index: 22;
+}
+
+.ot-panel--corner-active-tl::after {
+  border-top-color: var(--primary);
+  border-left-color: var(--primary);
+}
+.ot-panel--corner-active-tr::after {
+  border-top-color: var(--primary);
+  border-right-color: var(--primary);
+}
+.ot-panel--corner-active-bl::after {
+  border-bottom-color: var(--primary);
+  border-left-color: var(--primary);
+}
+.ot-panel--corner-active-br::after {
+  border-bottom-color: var(--primary);
+  border-right-color: var(--primary);
+}
+
+/* While a corner is active, hide the edge-handle bars on the two
+ * adjacent edges — the panel outline above replaces them so we don't
+ * paint two parallel primary lines. */
+.ot-panel--corner-active-tl > .ot-panel-resize-handle--top::after,
+.ot-panel--corner-active-tl > .ot-panel-resize-handle--left::after,
+.ot-panel--corner-active-tr > .ot-panel-resize-handle--top::after,
+.ot-panel--corner-active-tr > .ot-panel-resize-handle--right::after,
+.ot-panel--corner-active-bl > .ot-panel-resize-handle--bottom::after,
+.ot-panel--corner-active-bl > .ot-panel-resize-handle--left::after,
+.ot-panel--corner-active-br > .ot-panel-resize-handle--bottom::after,
+.ot-panel--corner-active-br > .ot-panel-resize-handle--right::after {
+  display: none;
 }
 
 /* ── Touch-first layouts: hide handles ───────────────────────────────── */

--- a/ui/src/components/panels/PanelResizeHandle.css
+++ b/ui/src/components/panels/PanelResizeHandle.css
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-/* Shared drag handle for every resizable panel. A faint bar is always visible
- * so users can discover the handle without hovering first.
- *
- * The bar is inset 10px from each end so it tucks inside panels with rounded
- * corners (≤ 10px radius) and doesn't overshoot. Panels that want a different
- * inset can set `--ot-panel-resize-inset` on the panel root. */
+/* Shared drag handle for every resizable panel. A faint bar is always
+ * visible on edges so users can discover them without hovering first.
+ * Corners are hit-only zones — on hover/drag the two adjacent edge bars
+ * thicken and extend all the way to the corner so the two bars meet
+ * seamlessly into an L (no separate "corner button"). */
 
 .ot-panel-resize-handle {
   position: absolute;
@@ -29,7 +28,6 @@
 
 /* ── Edges ───────────────────────────────────────────────────────────── */
 
-/* Vertical edges — horizontal drag */
 .ot-panel-resize-handle--left,
 .ot-panel-resize-handle--right {
   top: 0;
@@ -46,7 +44,6 @@
   right: -3px;
 }
 
-/* Horizontal edges — vertical drag */
 .ot-panel-resize-handle--top,
 .ot-panel-resize-handle--bottom {
   left: 0;
@@ -63,7 +60,7 @@
   bottom: -3px;
 }
 
-/* ── Corners ─────────────────────────────────────────────────────────── */
+/* ── Corners (hit zones only, no own visual) ─────────────────────────── */
 
 .ot-panel-resize-handle--top-left,
 .ot-panel-resize-handle--top-right,
@@ -98,7 +95,7 @@
   cursor: nwse-resize;
 }
 
-/* ── Edge indicator bars ─────────────────────────────────────────────── */
+/* ── Edge indicator bar (only the four edge variants render one) ─────── */
 
 .ot-panel-resize-handle--left::after,
 .ot-panel-resize-handle--right::after,
@@ -110,7 +107,11 @@
   transition:
     background 0.15s,
     width 0.15s,
-    height 0.15s;
+    height 0.15s,
+    top 0.15s,
+    right 0.15s,
+    bottom 0.15s,
+    left 0.15s;
 }
 
 .ot-panel-resize-handle--left::after,
@@ -143,42 +144,7 @@
   top: 2px;
 }
 
-/* ── Corner indicator dots ───────────────────────────────────────────── */
-
-.ot-panel-resize-handle--top-left::after,
-.ot-panel-resize-handle--top-right::after,
-.ot-panel-resize-handle--bottom-left::after,
-.ot-panel-resize-handle--bottom-right::after {
-  content: '';
-  position: absolute;
-  width: 6px;
-  height: 6px;
-  border-radius: 1px;
-  background: color-mix(in oklch, var(--border) 60%, transparent);
-  transition: background 0.15s;
-}
-
-.ot-panel-resize-handle--top-left::after {
-  top: 4px;
-  left: 4px;
-}
-
-.ot-panel-resize-handle--top-right::after {
-  top: 4px;
-  right: 4px;
-}
-
-.ot-panel-resize-handle--bottom-left::after {
-  bottom: 4px;
-  left: 4px;
-}
-
-.ot-panel-resize-handle--bottom-right::after {
-  bottom: 4px;
-  right: 4px;
-}
-
-/* ── Hover / active state ────────────────────────────────────────────── */
+/* ── Hover / active on edges ─────────────────────────────────────────── */
 
 .ot-panel-resize-handle:hover::after,
 .ot-panel-resize-handle:active::after {
@@ -200,41 +166,58 @@
 }
 
 /* ── Corner hover/drag cascades to its two adjacent edge bars ────────── */
+/*    The cascade is class-driven: the PanelResizeHandle component tags the
+ *    parent panel with a marker class while a corner is hovered/pressed, so
+ *    the bars brighten and shed their corner-inset on the shared end. We
+ *    avoided a `:has()`-only rule here because some stacking contexts
+ *    suppress it for sibling combinations during pointer drag. */
 
-/* Right edge brightens when a right-side corner is hovered/active */
-:has(> .ot-panel-resize-handle--top-right:is(:hover, :active))
-  > .ot-panel-resize-handle--right::after,
-:has(> .ot-panel-resize-handle--bottom-right:is(:hover, :active))
-  > .ot-panel-resize-handle--right::after {
+/* Right edge — brightens + extends when right-side corner is active */
+.ot-panel--corner-active-tr > .ot-panel-resize-handle--right::after {
   background: var(--primary);
   width: 3px;
+  top: 0;
 }
-
-/* Left edge brightens when a left-side corner is hovered/active */
-:has(> .ot-panel-resize-handle--top-left:is(:hover, :active))
-  > .ot-panel-resize-handle--left::after,
-:has(> .ot-panel-resize-handle--bottom-left:is(:hover, :active))
-  > .ot-panel-resize-handle--left::after {
+.ot-panel--corner-active-br > .ot-panel-resize-handle--right::after {
   background: var(--primary);
   width: 3px;
+  bottom: 0;
 }
 
-/* Top edge brightens when a top-side corner is hovered/active */
-:has(> .ot-panel-resize-handle--top-left:is(:hover, :active))
-  > .ot-panel-resize-handle--top::after,
-:has(> .ot-panel-resize-handle--top-right:is(:hover, :active))
-  > .ot-panel-resize-handle--top::after {
+/* Left edge — left-side corner */
+.ot-panel--corner-active-tl > .ot-panel-resize-handle--left::after {
   background: var(--primary);
-  height: 3px;
+  width: 3px;
+  top: 0;
+}
+.ot-panel--corner-active-bl > .ot-panel-resize-handle--left::after {
+  background: var(--primary);
+  width: 3px;
+  bottom: 0;
 }
 
-/* Bottom edge brightens when a bottom-side corner is hovered/active */
-:has(> .ot-panel-resize-handle--bottom-left:is(:hover, :active))
-  > .ot-panel-resize-handle--bottom::after,
-:has(> .ot-panel-resize-handle--bottom-right:is(:hover, :active))
-  > .ot-panel-resize-handle--bottom::after {
+/* Top edge — top-side corner */
+.ot-panel--corner-active-tl > .ot-panel-resize-handle--top::after {
   background: var(--primary);
   height: 3px;
+  left: 0;
+}
+.ot-panel--corner-active-tr > .ot-panel-resize-handle--top::after {
+  background: var(--primary);
+  height: 3px;
+  right: 0;
+}
+
+/* Bottom edge — bottom-side corner */
+.ot-panel--corner-active-bl > .ot-panel-resize-handle--bottom::after {
+  background: var(--primary);
+  height: 3px;
+  left: 0;
+}
+.ot-panel--corner-active-br > .ot-panel-resize-handle--bottom::after {
+  background: var(--primary);
+  height: 3px;
+  right: 0;
 }
 
 /* ── Touch-first layouts: hide handles ───────────────────────────────── */

--- a/ui/src/components/panels/PanelResizeHandle.tsx
+++ b/ui/src/components/panels/PanelResizeHandle.tsx
@@ -65,6 +65,22 @@ export default function PanelResizeHandle({
     if (!panel) return;
     const cls = CORNER_CLASS[side as CornerSide];
     panel.classList.add(cls);
+    // Pull the actual panel's border-radius so the arc curve matches
+    // the panel's outer rounded edge, regardless of theme/consumer.
+    const cs = window.getComputedStyle(panel);
+    const radius =
+      side === 'top-left'
+        ? cs.borderTopLeftRadius
+        : side === 'top-right'
+          ? cs.borderTopRightRadius
+          : side === 'bottom-left'
+            ? cs.borderBottomLeftRadius
+            : cs.borderBottomRightRadius;
+    if (radius && radius !== '0px') {
+      // Set on the panel so both the corner handle's arc AND the adjacent
+      // edge bars (siblings) pick up the same radius value.
+      panel.style.setProperty('--ot-panel-corner-radius', radius);
+    }
   }, [corner, side]);
 
   const untagPanel = useCallback(() => {

--- a/ui/src/components/panels/PanelResizeHandle.tsx
+++ b/ui/src/components/panels/PanelResizeHandle.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './PanelResizeHandle.css';
+
+type EdgeSide = 'left' | 'right' | 'top' | 'bottom';
+type CornerSide = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+export type PanelResizeHandleSide = EdgeSide | CornerSide;
+
+interface PanelResizeHandleProps {
+  /** Which edge (or corner) of the parent panel the handle sits on. */
+  side: PanelResizeHandleSide;
+  onMouseDown: (e: React.MouseEvent) => void;
+  /** Optional a11y label. */
+  'aria-label'?: string;
+}
+
+const CORNER_SIDES: readonly CornerSide[] = [
+  'top-left',
+  'top-right',
+  'bottom-left',
+  'bottom-right',
+];
+
+/**
+ * Shared drag strip for every resizable panel. Pair with `useResizablePanel`
+ * (left/right) or `useResizablePanelHeight` (top/bottom) and feed that hook's
+ * `handleMouseDown` straight through. For corners, compose both hooks'
+ * mousedowns into one handler so the drag resizes both axes simultaneously.
+ *
+ * A faint bar is always visible so users can discover the handle without
+ * hovering first.
+ */
+export default function PanelResizeHandle({
+  side,
+  onMouseDown,
+  'aria-label': ariaLabel = 'Resize panel',
+}: PanelResizeHandleProps) {
+  const isCorner = (CORNER_SIDES as readonly string[]).includes(side);
+  const orientation =
+    side === 'top' || side === 'bottom' ? 'horizontal' : 'vertical';
+  return (
+    <div
+      className={`ot-panel-resize-handle ot-panel-resize-handle--${side}`}
+      onMouseDown={onMouseDown}
+      role="separator"
+      aria-label={ariaLabel}
+      aria-orientation={isCorner ? undefined : orientation}
+    />
+  );
+}

--- a/ui/src/components/panels/PanelResizeHandle.tsx
+++ b/ui/src/components/panels/PanelResizeHandle.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useCallback, useEffect, useRef } from 'react';
 import './PanelResizeHandle.css';
 
 type EdgeSide = 'left' | 'right' | 'top' | 'bottom';
@@ -28,37 +29,96 @@ interface PanelResizeHandleProps {
   'aria-label'?: string;
 }
 
-const CORNER_SIDES: readonly CornerSide[] = [
-  'top-left',
-  'top-right',
-  'bottom-left',
-  'bottom-right',
-];
+const CORNER_CLASS: Record<CornerSide, string> = {
+  'top-left': 'ot-panel--corner-active-tl',
+  'top-right': 'ot-panel--corner-active-tr',
+  'bottom-left': 'ot-panel--corner-active-bl',
+  'bottom-right': 'ot-panel--corner-active-br',
+};
+
+function isCorner(side: PanelResizeHandleSide): side is CornerSide {
+  return side in CORNER_CLASS;
+}
 
 /**
- * Shared drag strip for every resizable panel. Pair with `useResizablePanel`
- * (left/right) or `useResizablePanelHeight` (top/bottom) and feed that hook's
- * `handleMouseDown` straight through. For corners, compose both hooks'
- * mousedowns into one handler so the drag resizes both axes simultaneously.
- *
- * A faint bar is always visible so users can discover the handle without
- * hovering first.
+ * Shared drag strip for every resizable panel. For corners we additionally
+ * tag the parent panel with a marker class while the corner is hovered or
+ * pressed — the class lets sibling edge bars cascade-highlight without
+ * relying on `:has()` quirks (which we've seen flake under specific stacking
+ * contexts). The release-listener is registered on `window` so the class
+ * still gets removed when the user drags off the panel.
  */
 export default function PanelResizeHandle({
   side,
   onMouseDown,
   'aria-label': ariaLabel = 'Resize panel',
 }: PanelResizeHandleProps) {
-  const isCorner = (CORNER_SIDES as readonly string[]).includes(side);
+  const corner = isCorner(side);
   const orientation =
     side === 'top' || side === 'bottom' ? 'horizontal' : 'vertical';
+  const ref = useRef<HTMLDivElement>(null);
+  const releaseRef = useRef<(() => void) | null>(null);
+
+  const tagPanel = useCallback(() => {
+    if (!corner) return;
+    const panel = ref.current?.parentElement;
+    if (!panel) return;
+    const cls = CORNER_CLASS[side as CornerSide];
+    panel.classList.add(cls);
+  }, [corner, side]);
+
+  const untagPanel = useCallback(() => {
+    if (!corner) return;
+    const panel = ref.current?.parentElement;
+    if (!panel) return;
+    panel.classList.remove(CORNER_CLASS[side as CornerSide]);
+  }, [corner, side]);
+
+  const handleMouseEnter = useCallback(() => {
+    tagPanel();
+  }, [tagPanel]);
+
+  const handleMouseLeave = useCallback(() => {
+    // Don't strip the class while a drag is in progress — wait for mouseup.
+    if (!releaseRef.current) untagPanel();
+  }, [untagPanel]);
+
+  const wrappedMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      onMouseDown(e);
+      if (!corner) return;
+      tagPanel();
+      const onRelease = () => {
+        untagPanel();
+        window.removeEventListener('mouseup', onRelease);
+        releaseRef.current = null;
+      };
+      releaseRef.current = onRelease;
+      window.addEventListener('mouseup', onRelease);
+    },
+    [onMouseDown, corner, tagPanel, untagPanel],
+  );
+
+  // Clean up any pending mouseup listener if the handle unmounts mid-drag.
+  useEffect(() => {
+    return () => {
+      if (releaseRef.current) {
+        window.removeEventListener('mouseup', releaseRef.current);
+        releaseRef.current = null;
+      }
+    };
+  }, []);
+
   return (
     <div
+      ref={ref}
       className={`ot-panel-resize-handle ot-panel-resize-handle--${side}`}
-      onMouseDown={onMouseDown}
+      onMouseDown={wrappedMouseDown}
+      onMouseEnter={corner ? handleMouseEnter : undefined}
+      onMouseLeave={corner ? handleMouseLeave : undefined}
       role="separator"
       aria-label={ariaLabel}
-      aria-orientation={isCorner ? undefined : orientation}
+      aria-orientation={corner ? undefined : orientation}
     />
   );
 }

--- a/ui/src/components/panels/PanelResizeHandle.tsx
+++ b/ui/src/components/panels/PanelResizeHandle.tsx
@@ -63,24 +63,7 @@ export default function PanelResizeHandle({
     if (!corner) return;
     const panel = ref.current?.parentElement;
     if (!panel) return;
-    const cls = CORNER_CLASS[side as CornerSide];
-    panel.classList.add(cls);
-    // Pull the actual panel's border-radius so the arc curve matches
-    // the panel's outer rounded edge, regardless of theme/consumer.
-    const cs = window.getComputedStyle(panel);
-    const radius =
-      side === 'top-left'
-        ? cs.borderTopLeftRadius
-        : side === 'top-right'
-          ? cs.borderTopRightRadius
-          : side === 'bottom-left'
-            ? cs.borderBottomLeftRadius
-            : cs.borderBottomRightRadius;
-    if (radius && radius !== '0px') {
-      // Set on the panel so both the corner handle's arc AND the adjacent
-      // edge bars (siblings) pick up the same radius value.
-      panel.style.setProperty('--ot-panel-corner-radius', radius);
-    }
+    panel.classList.add(CORNER_CLASS[side as CornerSide]);
   }, [corner, side]);
 
   const untagPanel = useCallback(() => {

--- a/ui/src/components/panels/PhysicsPanel.css
+++ b/ui/src/components/panels/PhysicsPanel.css
@@ -20,6 +20,9 @@
   bottom: 20px;
   right: 68px;
   z-index: 10;
+  /* Keep the corner-arc radius in sync with the panel's own border
+   * radius so the cascade L curves along the panel edge. */
+  --ot-panel-corner-radius: calc(var(--radius) + 4px);
   width: var(--physics-panel-width, 240px);
   /* Height: auto until the user drags the top edge, then an explicit pixel
    * height. Cap at 80vh so the default content-height never overflows the
@@ -31,7 +34,12 @@
    * off-screen. */
   max-width: calc(100vw - 76px);
   max-height: min(80vh, calc(100vh - 28px));
-  overflow-y: auto;
+  /* Overflow stays VISIBLE on the panel root so the resize handles
+   * (which sit at top:-3 / left:-3 / right:-3 / bottom:-3, outside the
+   * box) aren't clipped — clipping handles also clips their pointer-event
+   * target, which silently kills hover/drag. Scrolling lives on the inner
+   * `.physics-panel-scroll` div instead. */
+  overflow: visible;
   background: color-mix(in oklch, var(--background) 85%, transparent);
   backdrop-filter: blur(12px);
   border: 1px solid color-mix(in oklch, var(--border) 25%, transparent);
@@ -39,8 +47,18 @@
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
   animation: physicsPanelIn 0.15s ease-out;
+}
+
+/* Inner scrollable container — owns the overflow so the panel root can
+ * keep its handles unclipped. Inherits the flex stack from the panel. */
+.physics-panel-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 @keyframes physicsPanelIn {

--- a/ui/src/components/panels/PhysicsPanel.css
+++ b/ui/src/components/panels/PhysicsPanel.css
@@ -20,9 +20,6 @@
   bottom: 20px;
   right: 68px;
   z-index: 10;
-  /* Keep the corner-arc radius in sync with the panel's own border
-   * radius so the cascade L curves along the panel edge. */
-  --ot-panel-corner-radius: calc(var(--radius) + 4px);
   width: var(--physics-panel-width, 240px);
   /* Height: auto until the user drags the top edge, then an explicit pixel
    * height. Cap at 80vh so the default content-height never overflows the

--- a/ui/src/components/panels/PhysicsPanel.css
+++ b/ui/src/components/panels/PhysicsPanel.css
@@ -20,7 +20,13 @@
   bottom: 20px;
   right: 68px;
   z-index: 10;
-  width: 240px;
+  width: var(--physics-panel-width, 240px);
+  /* Height: auto until the user drags the top edge, then an explicit pixel
+   * height. Cap at 80vh so the default content-height never overflows the
+   * viewport on short screens. */
+  height: var(--physics-panel-height, auto);
+  max-height: 80vh;
+  overflow-y: auto;
   background: color-mix(in oklch, var(--background) 85%, transparent);
   backdrop-filter: blur(12px);
   border: 1px solid color-mix(in oklch, var(--border) 25%, transparent);

--- a/ui/src/components/panels/PhysicsPanel.css
+++ b/ui/src/components/panels/PhysicsPanel.css
@@ -25,7 +25,12 @@
    * height. Cap at 80vh so the default content-height never overflows the
    * viewport on short screens. */
   height: var(--physics-panel-height, auto);
-  max-height: 80vh;
+  /* Clamp against the viewport, accounting for the `right: 68px` and
+   * `bottom: 20px` anchors — so a stored width/height bigger than what
+   * currently fits can't push the panel (and its top/left handles)
+   * off-screen. */
+  max-width: calc(100vw - 76px);
+  max-height: min(80vh, calc(100vh - 28px));
   overflow-y: auto;
   background: color-mix(in oklch, var(--background) 85%, transparent);
   backdrop-filter: blur(12px);

--- a/ui/src/components/panels/PhysicsPanel.tsx
+++ b/ui/src/components/panels/PhysicsPanel.tsx
@@ -184,324 +184,340 @@ export default function PhysicsPanel({
           onHeightDrag(e, 'nwse-resize');
         }}
       />
-      <h4 className="physics-panel-title">Display</h4>
+      <div className="physics-panel-scroll">
+        <h4 className="physics-panel-title">Display</h4>
 
-      <div
-        className="physics-toggle-row"
-        onClick={() =>
-          onColorModeChange(colorMode === 'type' ? 'community' : 'type')
-        }
-      >
-        <span className="physics-toggle-label">Community colors</span>
-        <div
-          className={`physics-toggle-track${colorMode === 'community' ? ' on' : ''}`}
-        >
-          <div className="physics-toggle-thumb" />
-        </div>
-      </div>
-
-      <div
-        className="physics-toggle-row"
-        onClick={() => onLabelsVisibleChange(!labelsVisible)}
-      >
-        <span className="physics-toggle-label">Show labels</span>
-        <div className={`physics-toggle-track${labelsVisible ? ' on' : ''}`}>
-          <div className="physics-toggle-thumb" />
-        </div>
-      </div>
-
-      {/* Pixi: layout mode toggle (spread vs compact) */}
-      {pixiMode && onLayoutModeChange && (
         <div
           className="physics-toggle-row"
           onClick={() =>
-            onLayoutModeChange(layoutMode === 'spread' ? 'compact' : 'spread')
+            onColorModeChange(colorMode === 'type' ? 'community' : 'type')
           }
         >
-          <span className="physics-toggle-label">Community clusters</span>
+          <span className="physics-toggle-label">Community colors</span>
           <div
-            className={`physics-toggle-track${layoutMode === 'compact' ? ' on' : ''}`}
+            className={`physics-toggle-track${colorMode === 'community' ? ' on' : ''}`}
           >
             <div className="physics-toggle-thumb" />
           </div>
         </div>
-      )}
 
-      {/* Pixi: 3D rotation toggle + controls */}
-      {pixiMode && onMode3dChange && (
-        <>
+        <div
+          className="physics-toggle-row"
+          onClick={() => onLabelsVisibleChange(!labelsVisible)}
+        >
+          <span className="physics-toggle-label">Show labels</span>
+          <div className={`physics-toggle-track${labelsVisible ? ' on' : ''}`}>
+            <div className="physics-toggle-thumb" />
+          </div>
+        </div>
+
+        {/* Pixi: layout mode toggle (spread vs compact) */}
+        {pixiMode && onLayoutModeChange && (
           <div
             className="physics-toggle-row"
-            onClick={() => onMode3dChange(!mode3d)}
+            onClick={() =>
+              onLayoutModeChange(layoutMode === 'spread' ? 'compact' : 'spread')
+            }
           >
-            <span className="physics-toggle-label">3D rotation</span>
-            <div className={`physics-toggle-track${mode3d ? ' on' : ''}`}>
+            <span className="physics-toggle-label">Community clusters</span>
+            <div
+              className={`physics-toggle-track${layoutMode === 'compact' ? ' on' : ''}`}
+            >
               <div className="physics-toggle-thumb" />
             </div>
           </div>
-          {mode3d && onMode3dAutoRotateChange && (
+        )}
+
+        {/* Pixi: 3D rotation toggle + controls */}
+        {pixiMode && onMode3dChange && (
+          <>
             <div
               className="physics-toggle-row"
-              onClick={() => onMode3dAutoRotateChange(!mode3dAutoRotate)}
-              style={{ paddingLeft: 8 }}
+              onClick={() => onMode3dChange(!mode3d)}
             >
-              <span className="physics-toggle-label">Auto-rotate</span>
-              <div
-                className={`physics-toggle-track${mode3dAutoRotate ? ' on' : ''}`}
-              >
+              <span className="physics-toggle-label">3D rotation</span>
+              <div className={`physics-toggle-track${mode3d ? ' on' : ''}`}>
                 <div className="physics-toggle-thumb" />
               </div>
             </div>
-          )}
-          {mode3d && onMode3dSpeedChange && (
-            <div className="physics-slider-row">
-              <div className="physics-slider-label">
-                <span>Rotation speed</span>
-                <span className="physics-slider-value">{mode3dSpeed}%</span>
+            {mode3d && onMode3dAutoRotateChange && (
+              <div
+                className="physics-toggle-row"
+                onClick={() => onMode3dAutoRotateChange(!mode3dAutoRotate)}
+                style={{ paddingLeft: 8 }}
+              >
+                <span className="physics-toggle-label">Auto-rotate</span>
+                <div
+                  className={`physics-toggle-track${mode3dAutoRotate ? ' on' : ''}`}
+                >
+                  <div className="physics-toggle-thumb" />
+                </div>
               </div>
-              <input
-                type="range"
-                min={0}
-                max={100}
-                value={mode3dSpeed}
-                onInput={(e) =>
-                  onMode3dSpeedChange(Number(e.currentTarget.value))
-                }
-              />
-            </div>
-          )}
-          {mode3d && onMode3dTiltChange && (
-            <div className="physics-slider-row">
-              <div className="physics-slider-label">
-                <span>Camera tilt</span>
-                <span className="physics-slider-value">{mode3dTilt}%</span>
+            )}
+            {mode3d && onMode3dSpeedChange && (
+              <div className="physics-slider-row">
+                <div className="physics-slider-label">
+                  <span>Rotation speed</span>
+                  <span className="physics-slider-value">{mode3dSpeed}%</span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={mode3dSpeed}
+                  onInput={(e) =>
+                    onMode3dSpeedChange(Number(e.currentTarget.value))
+                  }
+                />
               </div>
-              <input
-                type="range"
-                min={0}
-                max={100}
-                value={mode3dTilt}
-                onInput={(e) =>
-                  onMode3dTiltChange(Number(e.currentTarget.value))
-                }
-              />
-            </div>
-          )}
-        </>
-      )}
+            )}
+            {mode3d && onMode3dTiltChange && (
+              <div className="physics-slider-row">
+                <div className="physics-slider-label">
+                  <span>Camera tilt</span>
+                  <span className="physics-slider-value">{mode3dTilt}%</span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={mode3dTilt}
+                  onInput={(e) =>
+                    onMode3dTiltChange(Number(e.currentTarget.value))
+                  }
+                />
+              </div>
+            )}
+          </>
+        )}
 
-      <div className="physics-divider" />
+        <div className="physics-divider" />
 
-      <h4 className="physics-panel-title">Physics</h4>
+        <h4 className="physics-panel-title">Physics</h4>
 
-      <div className="physics-slider-row">
-        <div className="physics-slider-label">
-          <span>Repulsion</span>
-          <span className="physics-slider-value">{repulsion}</span>
-        </div>
-        <input
-          type="range"
-          min={10}
-          max={500}
-          step={10}
-          defaultValue={repulsion}
-          onInput={handleRepulsionInput}
-        />
-      </div>
-
-      {/* Link distance — both modes */}
-      {pixiMode && onLinkDistanceChange && (
         <div className="physics-slider-row">
           <div className="physics-slider-label">
-            <span>Link distance</span>
-            <span className="physics-slider-value">{linkDistance}</span>
-          </div>
-          <input
-            type="range"
-            min={5}
-            max={500}
-            value={linkDistance}
-            onInput={(e) => onLinkDistanceChange(Number(e.currentTarget.value))}
-          />
-        </div>
-      )}
-
-      {/* Spread-only: center pull */}
-      {pixiMode && layoutMode === 'spread' && onCenterStrengthChange && (
-        <div className="physics-slider-row">
-          <div className="physics-slider-label">
-            <span>Center pull</span>
-            <span className="physics-slider-value">
-              {Math.round(centerStrength * 100)}%
-            </span>
-          </div>
-          <input
-            type="range"
-            min={1}
-            max={100}
-            value={Math.round(centerStrength * 100)}
-            onInput={(e) =>
-              onCenterStrengthChange(Number(e.currentTarget.value) / 100)
-            }
-          />
-        </div>
-      )}
-
-      {/* Compact-only: radial pull */}
-      {pixiMode && layoutMode === 'compact' && onRadialStrengthChange && (
-        <div className="physics-slider-row">
-          <div className="physics-slider-label">
-            <span>Radial pull</span>
-            <span className="physics-slider-value">{radialStrength}%</span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={50}
-            value={radialStrength}
-            onInput={(e) =>
-              onRadialStrengthChange(Number(e.currentTarget.value))
-            }
-          />
-        </div>
-      )}
-
-      {/* Compact-only: community pull */}
-      {pixiMode && layoutMode === 'compact' && onCommunityPullChange && (
-        <div className="physics-slider-row">
-          <div className="physics-slider-label">
-            <span>Community pull</span>
-            <span className="physics-slider-value">{communityPull}%</span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={50}
-            value={communityPull}
-            onInput={(e) =>
-              onCommunityPullChange(Number(e.currentTarget.value))
-            }
-          />
-        </div>
-      )}
-
-      {/* Compact-only: circle radius */}
-      {pixiMode && layoutMode === 'compact' && onCircleRadiusChange && (
-        <div className="physics-slider-row">
-          <div className="physics-slider-label">
-            <span>Circle size</span>
-            <span className="physics-slider-value">{circleRadius}</span>
-          </div>
-          <input
-            type="range"
-            min={8}
-            max={80}
-            value={circleRadius}
-            onInput={(e) => onCircleRadiusChange(Number(e.currentTarget.value))}
-          />
-        </div>
-      )}
-
-      {/* Compact-only: centering strength */}
-      {pixiMode && layoutMode === 'compact' && onCenteringStrengthChange && (
-        <div className="physics-slider-row">
-          <div className="physics-slider-label">
-            <span>Centering</span>
-            <span className="physics-slider-value">{centeringStrength}%</span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={30}
-            value={centeringStrength}
-            onInput={(e) =>
-              onCenteringStrengthChange(Number(e.currentTarget.value))
-            }
-          />
-        </div>
-      )}
-
-      {/* Pixi: zoom-size exponent slider */}
-      {pixiMode && onZoomSizeExponentChange && (
-        <div className="physics-slider-row">
-          <div className="physics-slider-label">
-            <span>Zoom scaling</span>
-            <span className="physics-slider-value">
-              {Math.round(zoomSizeExponent * 100)}%
-            </span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={100}
-            value={Math.round(zoomSizeExponent * 100)}
-            onInput={(e) =>
-              onZoomSizeExponentChange(Number(e.currentTarget.value) / 100)
-            }
-          />
-        </div>
-      )}
-
-      {/* Label scale — independent of node size */}
-      {pixiMode && onLabelScaleChange && (
-        <div className="physics-slider-row">
-          <div className="physics-slider-label">
-            <span>Label size</span>
-            <span className="physics-slider-value">{labelScale}%</span>
+            <span>Repulsion</span>
+            <span className="physics-slider-value">{repulsion}</span>
           </div>
           <input
             type="range"
             min={10}
-            max={300}
-            value={labelScale}
-            onInput={(e) => onLabelScaleChange(Number(e.currentTarget.value))}
+            max={500}
+            step={10}
+            defaultValue={repulsion}
+            onInput={handleRepulsionInput}
           />
         </div>
-      )}
 
-      <div className="physics-divider" />
-
-      {/* Pixi: reheat + fit buttons */}
-      {pixiMode && onReheat && onFitToScreen && (
-        <div style={{ display: 'flex', gap: 6, marginBottom: 4 }}>
-          <button
-            className="physics-action-btn"
-            style={{ flex: 1 }}
-            onClick={onReheat}
-          >
-            Reheat
-          </button>
-          <button
-            className="physics-action-btn"
-            style={{ flex: 1 }}
-            onClick={onFitToScreen}
-          >
-            Fit to screen
-          </button>
-        </div>
-      )}
-
-      <button
-        className="physics-action-btn"
-        onClick={isPhysicsRunning ? onStopPhysics : onStartPhysics}
-      >
-        {isPhysicsRunning ? (
-          <>
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-              <rect x="6" y="4" width="4" height="16" rx="1" />
-              <rect x="14" y="4" width="4" height="16" rx="1" />
-            </svg>
-            Stop Physics
-          </>
-        ) : (
-          <>
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-              <polygon points="5,3 19,12 5,21" />
-            </svg>
-            Start Physics
-          </>
+        {/* Link distance — both modes */}
+        {pixiMode && onLinkDistanceChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Link distance</span>
+              <span className="physics-slider-value">{linkDistance}</span>
+            </div>
+            <input
+              type="range"
+              min={5}
+              max={500}
+              value={linkDistance}
+              onInput={(e) =>
+                onLinkDistanceChange(Number(e.currentTarget.value))
+              }
+            />
+          </div>
         )}
-      </button>
+
+        {/* Spread-only: center pull */}
+        {pixiMode && layoutMode === 'spread' && onCenterStrengthChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Center pull</span>
+              <span className="physics-slider-value">
+                {Math.round(centerStrength * 100)}%
+              </span>
+            </div>
+            <input
+              type="range"
+              min={1}
+              max={100}
+              value={Math.round(centerStrength * 100)}
+              onInput={(e) =>
+                onCenterStrengthChange(Number(e.currentTarget.value) / 100)
+              }
+            />
+          </div>
+        )}
+
+        {/* Compact-only: radial pull */}
+        {pixiMode && layoutMode === 'compact' && onRadialStrengthChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Radial pull</span>
+              <span className="physics-slider-value">{radialStrength}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={50}
+              value={radialStrength}
+              onInput={(e) =>
+                onRadialStrengthChange(Number(e.currentTarget.value))
+              }
+            />
+          </div>
+        )}
+
+        {/* Compact-only: community pull */}
+        {pixiMode && layoutMode === 'compact' && onCommunityPullChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Community pull</span>
+              <span className="physics-slider-value">{communityPull}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={50}
+              value={communityPull}
+              onInput={(e) =>
+                onCommunityPullChange(Number(e.currentTarget.value))
+              }
+            />
+          </div>
+        )}
+
+        {/* Compact-only: circle radius */}
+        {pixiMode && layoutMode === 'compact' && onCircleRadiusChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Circle size</span>
+              <span className="physics-slider-value">{circleRadius}</span>
+            </div>
+            <input
+              type="range"
+              min={8}
+              max={80}
+              value={circleRadius}
+              onInput={(e) =>
+                onCircleRadiusChange(Number(e.currentTarget.value))
+              }
+            />
+          </div>
+        )}
+
+        {/* Compact-only: centering strength */}
+        {pixiMode && layoutMode === 'compact' && onCenteringStrengthChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Centering</span>
+              <span className="physics-slider-value">{centeringStrength}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={30}
+              value={centeringStrength}
+              onInput={(e) =>
+                onCenteringStrengthChange(Number(e.currentTarget.value))
+              }
+            />
+          </div>
+        )}
+
+        {/* Pixi: zoom-size exponent slider */}
+        {pixiMode && onZoomSizeExponentChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Zoom scaling</span>
+              <span className="physics-slider-value">
+                {Math.round(zoomSizeExponent * 100)}%
+              </span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={Math.round(zoomSizeExponent * 100)}
+              onInput={(e) =>
+                onZoomSizeExponentChange(Number(e.currentTarget.value) / 100)
+              }
+            />
+          </div>
+        )}
+
+        {/* Label scale — independent of node size */}
+        {pixiMode && onLabelScaleChange && (
+          <div className="physics-slider-row">
+            <div className="physics-slider-label">
+              <span>Label size</span>
+              <span className="physics-slider-value">{labelScale}%</span>
+            </div>
+            <input
+              type="range"
+              min={10}
+              max={300}
+              value={labelScale}
+              onInput={(e) => onLabelScaleChange(Number(e.currentTarget.value))}
+            />
+          </div>
+        )}
+
+        <div className="physics-divider" />
+
+        {/* Pixi: reheat + fit buttons */}
+        {pixiMode && onReheat && onFitToScreen && (
+          <div style={{ display: 'flex', gap: 6, marginBottom: 4 }}>
+            <button
+              className="physics-action-btn"
+              style={{ flex: 1 }}
+              onClick={onReheat}
+            >
+              Reheat
+            </button>
+            <button
+              className="physics-action-btn"
+              style={{ flex: 1 }}
+              onClick={onFitToScreen}
+            >
+              Fit to screen
+            </button>
+          </div>
+        )}
+
+        <button
+          className="physics-action-btn"
+          onClick={isPhysicsRunning ? onStopPhysics : onStartPhysics}
+        >
+          {isPhysicsRunning ? (
+            <>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <rect x="6" y="4" width="4" height="16" rx="1" />
+                <rect x="14" y="4" width="4" height="16" rx="1" />
+              </svg>
+              Stop Physics
+            </>
+          ) : (
+            <>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <polygon points="5,3 19,12 5,21" />
+              </svg>
+              Start Physics
+            </>
+          )}
+        </button>
+      </div>
     </div>
   );
 }

--- a/ui/src/components/panels/PhysicsPanel.tsx
+++ b/ui/src/components/panels/PhysicsPanel.tsx
@@ -113,12 +113,14 @@ export default function PhysicsPanel({
   mode3dTilt = 35,
   onMode3dTiltChange,
 }: PhysicsPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
   const { width: panelWidth, handleMouseDown } = useResizablePanel({
     storageKey: 'ot_physics_panel_width',
     defaultWidth: 240,
     minWidth: 220,
     maxWidth: 420,
     side: 'left',
+    panelRef,
   });
   const { height: panelHeight, handleMouseDown: onHeightDrag } =
     useResizablePanelHeight({
@@ -126,6 +128,7 @@ export default function PhysicsPanel({
       minHeight: 240,
       maxHeight: 900,
       side: 'top',
+      panelRef,
     });
 
   // Debounce repulsion slider changes (200ms)
@@ -161,6 +164,7 @@ export default function PhysicsPanel({
 
   return (
     <div
+      ref={panelRef}
       className="physics-panel"
       style={
         {
@@ -176,8 +180,8 @@ export default function PhysicsPanel({
       <PanelResizeHandle
         side="top-left"
         onMouseDown={(e) => {
-          handleMouseDown(e);
-          onHeightDrag(e);
+          handleMouseDown(e, 'nwse-resize');
+          onHeightDrag(e, 'nwse-resize');
         }}
       />
       <h4 className="physics-panel-title">Display</h4>

--- a/ui/src/components/panels/PhysicsPanel.tsx
+++ b/ui/src/components/panels/PhysicsPanel.tsx
@@ -15,6 +15,11 @@
  */
 
 import { useCallback, useRef, useEffect } from 'react';
+import {
+  useResizablePanel,
+  useResizablePanelHeight,
+} from '../../hooks/useResizablePanel';
+import PanelResizeHandle from './PanelResizeHandle';
 import './PhysicsPanel.css';
 
 interface PhysicsPanelProps {
@@ -108,6 +113,21 @@ export default function PhysicsPanel({
   mode3dTilt = 35,
   onMode3dTiltChange,
 }: PhysicsPanelProps) {
+  const { width: panelWidth, handleMouseDown } = useResizablePanel({
+    storageKey: 'ot_physics_panel_width',
+    defaultWidth: 240,
+    minWidth: 220,
+    maxWidth: 420,
+    side: 'left',
+  });
+  const { height: panelHeight, handleMouseDown: onHeightDrag } =
+    useResizablePanelHeight({
+      storageKey: 'ot_physics_panel_height',
+      minHeight: 240,
+      maxHeight: 900,
+      side: 'top',
+    });
+
   // Debounce repulsion slider changes (200ms)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const localRef = useRef(repulsion);
@@ -140,7 +160,26 @@ export default function PhysicsPanel({
   }, []);
 
   return (
-    <div className="physics-panel">
+    <div
+      className="physics-panel"
+      style={
+        {
+          '--physics-panel-width': `${panelWidth}px`,
+          ...(panelHeight != null
+            ? { '--physics-panel-height': `${panelHeight}px` }
+            : {}),
+        } as React.CSSProperties
+      }
+    >
+      <PanelResizeHandle side="left" onMouseDown={handleMouseDown} />
+      <PanelResizeHandle side="top" onMouseDown={onHeightDrag} />
+      <PanelResizeHandle
+        side="top-left"
+        onMouseDown={(e) => {
+          handleMouseDown(e);
+          onHeightDrag(e);
+        }}
+      />
       <h4 className="physics-panel-title">Display</h4>
 
       <div

--- a/ui/src/components/panels/index.ts
+++ b/ui/src/components/panels/index.ts
@@ -20,6 +20,7 @@ export { default as GraphLegend } from './GraphLegend';
 export { default as GraphToolbar } from './GraphToolbar';
 export { default as DiscoverPanel } from './DiscoverPanel';
 export { default as PhysicsPanel } from './PhysicsPanel';
+export { default as PanelResizeHandle } from './PanelResizeHandle';
 export { useDiscoverTree } from './useDiscoverTree';
 
 export type {

--- a/ui/src/hooks/useResizablePanel.ts
+++ b/ui/src/hooks/useResizablePanel.ts
@@ -101,9 +101,19 @@ export function useResizablePanel({
 
     const flush = () => {
       rafId = null;
-      if (pending != null && panelRef.current) {
-        panelRef.current.style.width = `${pending}px`;
+      const panel = panelRef.current;
+      if (pending == null || !panel) return;
+      // Clamp pending to whatever the parent currently allows so the
+      // drag stops cleanly at the available limit (and doesn't fight the
+      // ResizeObserver's clamp on every frame).
+      const parent = panel.parentElement;
+      if (parent) {
+        const panelRect = panel.getBoundingClientRect();
+        const parentRect = parent.getBoundingClientRect();
+        const available = parentRect.right - panelRect.left - 4;
+        if (available > 0 && pending > available) pending = available;
       }
+      panel.style.width = `${pending}px`;
     };
 
     const handleMouseMove = (e: MouseEvent) => {
@@ -146,27 +156,45 @@ export function useResizablePanel({
     localStorage.setItem(storageKey, String(width));
   }, [storageKey, width]);
 
-  // Belt-and-braces auto-shrink: when the parent's width changes, force the
-  // panel's inline `style.width` down to whatever the parent can actually
-  // accommodate. CSS `max-width: 100%` should already do this, but
-  // consumers (e.g. insight-ui) sometimes wrap the panel in a containing
-  // block that doesn't propagate, so this guarantees the right edge handle
-  // is always reachable.
+  // Belt-and-braces auto-shrink: when the parent's width changes — OR the
+  // panel itself becomes visible at a stored width that exceeds the
+  // parent — force the panel's inline `style.width` down to whatever the
+  // parent can actually accommodate. CSS `max-width: 100%` should already
+  // do this, but consumers (e.g. insight-ui) sometimes wrap the panel in
+  // a containing block that doesn't propagate cleanly, and observing just
+  // the parent misses the hidden-to-visible transition (display:none →
+  // display:flex). So we observe both.
   useEffect(() => {
     const panel = panelRef.current;
     const parent = panel?.parentElement;
     if (!panel || !parent || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(() => {
-      const available = parent.clientWidth;
+    const clamp = () => {
+      // Skip while the user is dragging — the drag's own `flush` handles
+      // clamping and running this in parallel creates a feedback loop.
+      if (isDragging.current) return;
+      // Compute the actual available width FROM the panel's rendered
+      // left edge TO the parent's right inner edge. This adapts to any
+      // top/left inset the consumer applied (e.g. insight-ui's `!left-3`
+      // floating offset) instead of assuming the panel starts at parent
+      // origin. 4 px buffer keeps the right-edge handle (which extrudes
+      // 3 px outside) inside an overflow:hidden parent.
+      const panelRect = panel.getBoundingClientRect();
+      const parentRect = parent.getBoundingClientRect();
+      const available = parentRect.right - panelRect.left - 4;
       if (available > 0 && panel.offsetWidth > available) {
-        panel.style.width = `${available}px`;
-      } else if (!isDragging.current) {
-        // Restore React state width if there's room again (drag also writes
-        // to inline style, so don't clobber it mid-drag).
-        panel.style.width = `${width}px`;
+        const next = `${available}px`;
+        if (panel.style.width !== next) panel.style.width = next;
+      } else if (width <= available) {
+        // Only restore to state width when it actually fits — otherwise
+        // the clamp would oscillate (set to state → too big → clamp →
+        // set to state again).
+        const next = `${width}px`;
+        if (panel.style.width !== next) panel.style.width = next;
       }
-    });
+    };
+    const observer = new ResizeObserver(clamp);
     observer.observe(parent);
+    observer.observe(panel);
     return () => observer.disconnect();
   }, [panelRef, width]);
 
@@ -239,9 +267,20 @@ export function useResizablePanelHeight({
 
     const flush = () => {
       rafId = null;
-      if (pending != null && panelRef.current) {
-        panelRef.current.style.height = `${pending}px`;
+      const panel = panelRef.current;
+      if (pending == null || !panel) return;
+      // Clamp pending to whatever the parent currently allows so the drag
+      // stops cleanly at the available limit instead of fighting the
+      // ResizeObserver below (which would otherwise observe-and-clamp on
+      // every frame, causing twitch).
+      const parent = panel.parentElement;
+      if (parent) {
+        const panelRect = panel.getBoundingClientRect();
+        const parentRect = parent.getBoundingClientRect();
+        const available = parentRect.bottom - panelRect.top - 4;
+        if (available > 0 && pending > available) pending = available;
       }
+      panel.style.height = `${pending}px`;
     };
 
     const handleMouseMove = (e: MouseEvent) => {
@@ -285,22 +324,43 @@ export function useResizablePanelHeight({
 
   // Belt-and-braces auto-shrink: clamp the panel's inline `style.height`
   // down whenever the parent shrinks below it, so the bottom edge handle
-  // never falls off-screen. CSS `max-height: 100%` should already do this
-  // but we've seen consumers wrap the panel in containing blocks that
-  // don't propagate the height correctly.
+  // never falls off-screen. We observe both the panel AND the parent so
+  // we also catch the hidden-to-visible transition (display:none →
+  // display:flex when a toolbar tab opens the panel) — that doesn't
+  // change the parent's size, but it does change the panel's.
   useEffect(() => {
     const panel = panelRef.current;
     const parent = panel?.parentElement;
     if (!panel || !parent || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(() => {
-      const available = parent.clientHeight;
+    const clamp = () => {
+      // Skip while the user is dragging — the drag's own `flush` does the
+      // clamp, and running it here too creates a feedback loop (drag sets
+      // height → ResizeObserver fires → clamps to a slightly different
+      // value → twitch).
+      if (isDragging.current) return;
+      // Compute available height FROM the panel's rendered top edge TO
+      // the parent's bottom inner edge — adapts to any top inset the
+      // consumer applies (e.g. insight-ui's `!top-3` floating offset).
+      // 4 px buffer keeps the bottom-edge handle (extrudes 3 px outside)
+      // inside an overflow:hidden parent.
+      const panelRect = panel.getBoundingClientRect();
+      const parentRect = parent.getBoundingClientRect();
+      const available = parentRect.bottom - panelRect.top - 4;
       if (available > 0 && panel.offsetHeight > available) {
-        panel.style.height = `${available}px`;
-      } else if (!isDragging.current && height != null) {
-        panel.style.height = `${height}px`;
+        const next = `${available}px`;
+        if (panel.style.height !== next) panel.style.height = next;
+      } else if (height != null && height <= available) {
+        // Only restore to state height when it actually fits — otherwise
+        // we'd write `state.height (bigger) → clamp branch shrinks it →
+        // we restore again` ad infinitum and the panel flickers after the
+        // window stops resizing.
+        const next = `${height}px`;
+        if (panel.style.height !== next) panel.style.height = next;
       }
-    });
+    };
+    const observer = new ResizeObserver(clamp);
     observer.observe(parent);
+    observer.observe(panel);
     return () => observer.disconnect();
   }, [panelRef, height]);
 

--- a/ui/src/hooks/useResizablePanel.ts
+++ b/ui/src/hooks/useResizablePanel.ts
@@ -14,7 +14,20 @@
  * limitations under the License.
  */
 
+import type { RefObject } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Signature for the drag-start handler returned by the resize hooks. The
+ * second argument is an optional cursor override — used by corner handles to
+ * force `nwse-resize` / `nesw-resize` on the body so the cursor reads
+ * diagonal while the drag is in flight, instead of defaulting to the
+ * hook's primary-axis cursor.
+ */
+export type PanelResizeMouseDown = (
+  e: React.MouseEvent,
+  cursorOverride?: string,
+) => void;
 
 interface UseResizablePanelOptions {
   /** localStorage key for persisting width */
@@ -27,15 +40,18 @@ interface UseResizablePanelOptions {
   maxWidth: number;
   /** Which side of the panel the handle is on — determines drag direction */
   side: 'left' | 'right';
+  /** Ref to the panel element being resized (so mousemove can mutate its
+   * `style.width` directly without walking the DOM). */
+  panelRef: RefObject<HTMLElement | null>;
 }
 
 /**
- * Horizontal resize. During a drag, the panel's inline `style.width` is
- * updated directly on the DOM node (via the handle's parent element) so
- * mousemove doesn't trigger a React re-render of the panel's subtree — this
- * matters a lot on panels with heavy children (Discover's virtualized tree,
- * filter lists). The final width is committed back to React state on
- * mouseup so it persists across re-renders and makes it into localStorage.
+ * Horizontal resize. During a drag, the panel's `style.width` is updated
+ * directly via the supplied ref so mousemove doesn't trigger a React
+ * re-render of the panel's subtree — matters a lot on panels with heavy
+ * children (Discover's virtualized tree, filter lists). The final width is
+ * committed back to React state on mouseup so it persists across re-renders
+ * and makes it into localStorage.
  */
 export function useResizablePanel({
   storageKey,
@@ -43,7 +59,11 @@ export function useResizablePanel({
   minWidth,
   maxWidth,
   side,
-}: UseResizablePanelOptions) {
+  panelRef,
+}: UseResizablePanelOptions): {
+  width: number;
+  handleMouseDown: PanelResizeMouseDown;
+} {
   const [width, setWidth] = useState(() => {
     const stored = localStorage.getItem(storageKey);
     if (stored) {
@@ -57,16 +77,14 @@ export function useResizablePanel({
   const isDragging = useRef(false);
   const startX = useRef(0);
   const startWidth = useRef(0);
-  const panelEl = useRef<HTMLElement | null>(null);
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  const handleMouseDown = useCallback<PanelResizeMouseDown>(
+    (e, cursorOverride) => {
       e.preventDefault();
       isDragging.current = true;
       startX.current = e.clientX;
       startWidth.current = width;
-      panelEl.current = (e.currentTarget as HTMLElement).parentElement;
-      document.body.style.cursor = 'col-resize';
+      document.body.style.cursor = cursorOverride ?? 'col-resize';
       document.body.style.userSelect = 'none';
     },
     [width],
@@ -78,8 +96,8 @@ export function useResizablePanel({
 
     const flush = () => {
       rafId = null;
-      if (pending != null && panelEl.current) {
-        panelEl.current.style.width = `${pending}px`;
+      if (pending != null && panelRef.current) {
+        panelRef.current.style.width = `${pending}px`;
       }
     };
 
@@ -107,7 +125,6 @@ export function useResizablePanel({
         setWidth(pending);
         pending = null;
       }
-      panelEl.current = null;
     };
 
     window.addEventListener('mousemove', handleMouseMove);
@@ -117,7 +134,7 @@ export function useResizablePanel({
       window.removeEventListener('mouseup', handleMouseUp);
       if (rafId != null) cancelAnimationFrame(rafId);
     };
-  }, [minWidth, maxWidth, side]);
+  }, [minWidth, maxWidth, side, panelRef]);
 
   // Persist to localStorage on change (only fires on mouseup commit)
   useEffect(() => {
@@ -136,22 +153,28 @@ interface UseResizablePanelHeightOptions {
   maxHeight: number;
   /** Which edge of the panel the handle sits on — determines drag direction */
   side: 'top' | 'bottom';
+  /** Ref to the panel element being resized. */
+  panelRef: RefObject<HTMLElement | null>;
 }
 
 /**
- * Vertical companion to `useResizablePanel`. Returns `null` until the user has
- * dragged at least once, so callers can keep whatever height CSS gives them
- * by default (e.g. full-height or content-based) and only switch to an
+ * Vertical companion to `useResizablePanel`. Returns `null` until the user
+ * has dragged at least once, so callers can keep whatever height CSS gives
+ * them by default (e.g. full-height or content-based) and only switch to an
  * explicit pixel height once the user opts in. Like the horizontal hook, the
- * drag applies `style.height` directly to the panel element so mousemove
- * never triggers a React re-render — only mouseup commits to React state.
+ * drag applies `style.height` directly to the panel element via the supplied
+ * ref so mousemove never triggers a React re-render — only mouseup commits.
  */
 export function useResizablePanelHeight({
   storageKey,
   minHeight,
   maxHeight,
   side,
-}: UseResizablePanelHeightOptions) {
+  panelRef,
+}: UseResizablePanelHeightOptions): {
+  height: number | null;
+  handleMouseDown: PanelResizeMouseDown;
+} {
   const [height, setHeight] = useState<number | null>(() => {
     const stored = localStorage.getItem(storageKey);
     if (stored) {
@@ -165,23 +188,20 @@ export function useResizablePanelHeight({
   const isDragging = useRef(false);
   const startY = useRef(0);
   const startHeight = useRef(0);
-  const panelEl = useRef<HTMLElement | null>(null);
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  const handleMouseDown = useCallback<PanelResizeMouseDown>(
+    (e, cursorOverride) => {
       e.preventDefault();
       isDragging.current = true;
       startY.current = e.clientY;
       // Anchor the drag to whatever height the panel is ACTUALLY rendering —
       // this matters most before first drag when `height` is still null.
-      const panel = (e.currentTarget as HTMLElement).parentElement;
-      panelEl.current = panel;
-      const rendered = panel?.getBoundingClientRect().height ?? 0;
+      const rendered = panelRef.current?.getBoundingClientRect().height ?? 0;
       startHeight.current = height ?? Math.round(rendered);
-      document.body.style.cursor = 'row-resize';
+      document.body.style.cursor = cursorOverride ?? 'row-resize';
       document.body.style.userSelect = 'none';
     },
-    [height],
+    [height, panelRef],
   );
 
   useEffect(() => {
@@ -190,8 +210,8 @@ export function useResizablePanelHeight({
 
     const flush = () => {
       rafId = null;
-      if (pending != null && panelEl.current) {
-        panelEl.current.style.height = `${pending}px`;
+      if (pending != null && panelRef.current) {
+        panelRef.current.style.height = `${pending}px`;
       }
     };
 
@@ -219,7 +239,6 @@ export function useResizablePanelHeight({
         setHeight(pending);
         pending = null;
       }
-      panelEl.current = null;
     };
 
     window.addEventListener('mousemove', handleMouseMove);
@@ -229,7 +248,7 @@ export function useResizablePanelHeight({
       window.removeEventListener('mouseup', handleMouseUp);
       if (rafId != null) cancelAnimationFrame(rafId);
     };
-  }, [minHeight, maxHeight, side]);
+  }, [minHeight, maxHeight, side, panelRef]);
 
   useEffect(() => {
     if (height != null) localStorage.setItem(storageKey, String(height));

--- a/ui/src/hooks/useResizablePanel.ts
+++ b/ui/src/hooks/useResizablePanel.ts
@@ -83,11 +83,16 @@ export function useResizablePanel({
       e.preventDefault();
       isDragging.current = true;
       startX.current = e.clientX;
-      startWidth.current = width;
+      // Anchor the drag to whatever width the panel is ACTUALLY rendering —
+      // if a `max-width` CSS clamp has pinned the panel smaller than the
+      // stored React state (e.g. the viewport shrank since last drag), this
+      // keeps the drag feeling continuous with what's on screen.
+      const rendered = panelRef.current?.getBoundingClientRect().width;
+      startWidth.current = rendered ? Math.round(rendered) : width;
       document.body.style.cursor = cursorOverride ?? 'col-resize';
       document.body.style.userSelect = 'none';
     },
-    [width],
+    [width, panelRef],
   );
 
   useEffect(() => {
@@ -140,6 +145,30 @@ export function useResizablePanel({
   useEffect(() => {
     localStorage.setItem(storageKey, String(width));
   }, [storageKey, width]);
+
+  // Belt-and-braces auto-shrink: when the parent's width changes, force the
+  // panel's inline `style.width` down to whatever the parent can actually
+  // accommodate. CSS `max-width: 100%` should already do this, but
+  // consumers (e.g. insight-ui) sometimes wrap the panel in a containing
+  // block that doesn't propagate, so this guarantees the right edge handle
+  // is always reachable.
+  useEffect(() => {
+    const panel = panelRef.current;
+    const parent = panel?.parentElement;
+    if (!panel || !parent || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => {
+      const available = parent.clientWidth;
+      if (available > 0 && panel.offsetWidth > available) {
+        panel.style.width = `${available}px`;
+      } else if (!isDragging.current) {
+        // Restore React state width if there's room again (drag also writes
+        // to inline style, so don't clobber it mid-drag).
+        panel.style.width = `${width}px`;
+      }
+    });
+    observer.observe(parent);
+    return () => observer.disconnect();
+  }, [panelRef, width]);
 
   return { width, handleMouseDown };
 }
@@ -253,6 +282,27 @@ export function useResizablePanelHeight({
   useEffect(() => {
     if (height != null) localStorage.setItem(storageKey, String(height));
   }, [storageKey, height]);
+
+  // Belt-and-braces auto-shrink: clamp the panel's inline `style.height`
+  // down whenever the parent shrinks below it, so the bottom edge handle
+  // never falls off-screen. CSS `max-height: 100%` should already do this
+  // but we've seen consumers wrap the panel in containing blocks that
+  // don't propagate the height correctly.
+  useEffect(() => {
+    const panel = panelRef.current;
+    const parent = panel?.parentElement;
+    if (!panel || !parent || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => {
+      const available = parent.clientHeight;
+      if (available > 0 && panel.offsetHeight > available) {
+        panel.style.height = `${available}px`;
+      } else if (!isDragging.current && height != null) {
+        panel.style.height = `${height}px`;
+      }
+    });
+    observer.observe(parent);
+    return () => observer.disconnect();
+  }, [panelRef, height]);
 
   return { height, handleMouseDown };
 }

--- a/ui/src/hooks/useResizablePanel.ts
+++ b/ui/src/hooks/useResizablePanel.ts
@@ -29,6 +29,14 @@ interface UseResizablePanelOptions {
   side: 'left' | 'right';
 }
 
+/**
+ * Horizontal resize. During a drag, the panel's inline `style.width` is
+ * updated directly on the DOM node (via the handle's parent element) so
+ * mousemove doesn't trigger a React re-render of the panel's subtree — this
+ * matters a lot on panels with heavy children (Discover's virtualized tree,
+ * filter lists). The final width is committed back to React state on
+ * mouseup so it persists across re-renders and makes it into localStorage.
+ */
 export function useResizablePanel({
   storageKey,
   defaultWidth,
@@ -49,6 +57,7 @@ export function useResizablePanel({
   const isDragging = useRef(false);
   const startX = useRef(0);
   const startWidth = useRef(0);
+  const panelEl = useRef<HTMLElement | null>(null);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -56,6 +65,7 @@ export function useResizablePanel({
       isDragging.current = true;
       startX.current = e.clientX;
       startWidth.current = width;
+      panelEl.current = (e.currentTarget as HTMLElement).parentElement;
       document.body.style.cursor = 'col-resize';
       document.body.style.userSelect = 'none';
     },
@@ -63,16 +73,25 @@ export function useResizablePanel({
   );
 
   useEffect(() => {
+    let pending: number | null = null;
+    let rafId: number | null = null;
+
+    const flush = () => {
+      rafId = null;
+      if (pending != null && panelEl.current) {
+        panelEl.current.style.width = `${pending}px`;
+      }
+    };
+
     const handleMouseMove = (e: MouseEvent) => {
       if (!isDragging.current) return;
       const delta = e.clientX - startX.current;
-      // For a right-side handle, dragging right = wider; for left-side, dragging left = wider
       const newWidth =
         side === 'right'
           ? startWidth.current + delta
           : startWidth.current - delta;
-      const clamped = Math.max(minWidth, Math.min(maxWidth, newWidth));
-      setWidth(clamped);
+      pending = Math.max(minWidth, Math.min(maxWidth, newWidth));
+      if (rafId == null) rafId = requestAnimationFrame(flush);
     };
 
     const handleMouseUp = () => {
@@ -80,6 +99,15 @@ export function useResizablePanel({
       isDragging.current = false;
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
+      if (rafId != null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      if (pending != null) {
+        setWidth(pending);
+        pending = null;
+      }
+      panelEl.current = null;
     };
 
     window.addEventListener('mousemove', handleMouseMove);
@@ -87,13 +115,125 @@ export function useResizablePanel({
     return () => {
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
+      if (rafId != null) cancelAnimationFrame(rafId);
     };
   }, [minWidth, maxWidth, side]);
 
-  // Persist to localStorage on change (debounced via the mouseup ending the drag)
+  // Persist to localStorage on change (only fires on mouseup commit)
   useEffect(() => {
     localStorage.setItem(storageKey, String(width));
   }, [storageKey, width]);
 
   return { width, handleMouseDown };
+}
+
+interface UseResizablePanelHeightOptions {
+  /** localStorage key for persisting height */
+  storageKey: string;
+  /** Minimum allowed height */
+  minHeight: number;
+  /** Maximum allowed height */
+  maxHeight: number;
+  /** Which edge of the panel the handle sits on — determines drag direction */
+  side: 'top' | 'bottom';
+}
+
+/**
+ * Vertical companion to `useResizablePanel`. Returns `null` until the user has
+ * dragged at least once, so callers can keep whatever height CSS gives them
+ * by default (e.g. full-height or content-based) and only switch to an
+ * explicit pixel height once the user opts in. Like the horizontal hook, the
+ * drag applies `style.height` directly to the panel element so mousemove
+ * never triggers a React re-render — only mouseup commits to React state.
+ */
+export function useResizablePanelHeight({
+  storageKey,
+  minHeight,
+  maxHeight,
+  side,
+}: UseResizablePanelHeightOptions) {
+  const [height, setHeight] = useState<number | null>(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!isNaN(parsed) && parsed >= minHeight && parsed <= maxHeight)
+        return parsed;
+    }
+    return null;
+  });
+
+  const isDragging = useRef(false);
+  const startY = useRef(0);
+  const startHeight = useRef(0);
+  const panelEl = useRef<HTMLElement | null>(null);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      isDragging.current = true;
+      startY.current = e.clientY;
+      // Anchor the drag to whatever height the panel is ACTUALLY rendering —
+      // this matters most before first drag when `height` is still null.
+      const panel = (e.currentTarget as HTMLElement).parentElement;
+      panelEl.current = panel;
+      const rendered = panel?.getBoundingClientRect().height ?? 0;
+      startHeight.current = height ?? Math.round(rendered);
+      document.body.style.cursor = 'row-resize';
+      document.body.style.userSelect = 'none';
+    },
+    [height],
+  );
+
+  useEffect(() => {
+    let pending: number | null = null;
+    let rafId: number | null = null;
+
+    const flush = () => {
+      rafId = null;
+      if (pending != null && panelEl.current) {
+        panelEl.current.style.height = `${pending}px`;
+      }
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      const delta = e.clientY - startY.current;
+      const newHeight =
+        side === 'bottom'
+          ? startHeight.current + delta
+          : startHeight.current - delta;
+      pending = Math.max(minHeight, Math.min(maxHeight, newHeight));
+      if (rafId == null) rafId = requestAnimationFrame(flush);
+    };
+
+    const handleMouseUp = () => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      if (rafId != null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      if (pending != null) {
+        setHeight(pending);
+        pending = null;
+      }
+      panelEl.current = null;
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+      if (rafId != null) cancelAnimationFrame(rafId);
+    };
+  }, [minHeight, maxHeight, side]);
+
+  useEffect(() => {
+    if (height != null) localStorage.setItem(storageKey, String(height));
+  }, [storageKey, height]);
+
+  return { height, handleMouseDown };
 }


### PR DESCRIPTION
## Unified resizable panels with horizontal, vertical, and corner handles
🆕 **New Feature** · ✨ **Improvement** · ♻️ **Refactor** · ⚡ **Performance**

Consolidates bespoke panel resizing into a shared `PanelResizeHandle` component and high-performance hooks. 

Adds vertical and corner resizing to several panels while optimizing drag interactions to maintain responsiveness in heavy virtualized trees.

### Complexity
🟡 Moderate · `16 files changed, 584 insertions(+), 85 deletions(-)`

This PR introduces a new shared architectural pattern for UI interactions across the entire application. It moves away from standard React state updates for real-time resizing in favour of a performance-optimised approach using direct DOM manipulation and `requestAnimationFrame`. 

While the change is contained to the UI layer, it touches almost every major panel component and establishes foundational primitives (`PanelResizeHandle` and the companion hooks) that future panels will build on.

### Tests
🧪 Manual verification is required for drag interactions across different viewport sizes as these changes bypass standard React state during the interaction.

### Review focus
Pay particular attention to the following areas:

- **Direct DOM manipulation** — ensure `useResizablePanel` correctly commits the final width/height to React state on `mouseup` and clears all references to avoid memory leaks.
- **CSS `:has()` compatibility** — verify that the project's browser support targets allow the `:has()` selector used for cascading hover effects on corners.
- **Z-index and layout** — check that the new 10px insets on resize handles don't interfere with inner panel content or create clickable dead zones.
<!-- opentrace:jid=fabcb01e-8613-4e47-9766-c10ff452a282|sha=ac3cfe57be730434abf1646b3b18d0c4b8c63bb0 -->