### PR TITLE
feat(ui): fit graph on chat submit, clear highlights on done (OT-1717)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -314,6 +314,9 @@ function App({
                   graphViewerRef.current?.triggerPing(newIds);
                 }
               }}
+              onQuestionSubmit={() => {
+                graphViewerRef.current?.zoomToFit();
+              }}
               onGraphChange={async (focusNodeId) => {
                 // Reload scoped to the PR node — 2 hops shows PR → Files → their neighbors
                 await graphViewerRef.current?.reload(focusNodeId, 2);

--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -87,6 +87,8 @@ interface Props {
   onGraphChange?: (focusNodeId?: string) => Promise<void>;
   /** Called with accumulated highlight set and the new IDs to ping */
   onChatHighlight?: (allNodeIds: Set<string>, newNodeIds: string[]) => void;
+  /** Fired once per accepted question submission so the graph can re-frame. */
+  onQuestionSubmit?: () => void;
   repoUrl?: string;
   onWidthChange?: (width: number) => void;
   /** Optional content rendered at the bottom of the settings view (e.g. managed provider UI). */
@@ -99,6 +101,7 @@ export default function ChatPanel({
   onNodeSelect,
   onGraphChange,
   onChatHighlight,
+  onQuestionSubmit,
   repoUrl,
   onWidthChange,
   settingsFooter,
@@ -366,6 +369,11 @@ export default function ChatPanel({
       streamingRef.current
     )
       return;
+
+    onQuestionSubmit?.();
+    // Ensure graph highlights are on for this turn — we auto-disable them at
+    // stream end, so each new submit needs to turn them back on.
+    setHighlightEnabled(true);
 
     // Abort any previous request
     abortRef.current?.abort();
@@ -731,6 +739,11 @@ export default function ChatPanel({
           modelId,
           Array.from(chatFoundNodesRef.current),
         );
+        // Turn off graph highlights now that the full answer has arrived —
+        // the sync effect on `highlightEnabled` clears chatHighlightNodes in
+        // App, so the whole graph becomes visible again. Skipped on abort so
+        // a partial response doesn't dim-and-clear unexpectedly.
+        setHighlightEnabled(false);
       }
     }
   };

--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -360,6 +360,7 @@ export interface GraphViewerHandle {
   reload: (query?: string, hops?: number) => Promise<void>;
   triggerPing: (nodeIds: Iterable<string>) => void;
   resetCamera: () => void;
+  zoomToFit: (duration?: number) => void;
 }
 
 export interface GraphViewerProps {
@@ -954,6 +955,9 @@ const GraphViewer = memo(
           },
           resetCamera: () => {
             canvasRef.current?.resetCamera();
+          },
+          zoomToFit: (duration?: number) => {
+            canvasRef.current?.zoomToFit(duration);
           },
         }),
         [graphData, loadGraph, onNodeClick],


### PR DESCRIPTION
## Auto-fit graph and clear highlights on chat submit
🆕 **New Feature** · ✨ **Improvement**

Refines graph behavior during chat interactions to ensure the visualization remains framed and visible. 

It automatically zooms the graph to fit on question submission and restores full visibility by clearing dimmed highlights once the AI finishes its response.

### Complexity
🟢 Low · `3 files changed, 20 insertions(+)`

The change is narrow in scope, coordinating state between the Chat and Graph components using existing patterns and imperative handles. It introduces simple callbacks without altering foundational architecture.

### Review focus
Pay particular attention to the following areas:

- **Highlight Reset** — Verify the `finally` block logic correctly clears highlights on success/error while preserving them during manual aborts.
- **Camera State** — Confirm that using `zoomToFit` (instead of `resetCamera`) correctly avoids re-triggering auto-fit logic during background indexing.
<!-- opentrace:jid=a38c82b1-3dab-4815-bd65-33ffb6a39517|sha=eb2e0c8280d4e8daadda05e8c0903bc0144c3dd4 -->