### PR TITLE
feat(agent): add MCP tools for source access, search, usages, impact, and remote indexing

### DIFF
--- a/agent/src/opentrace_agent/benchmarks/graph_accuracy.py
+++ b/agent/src/opentrace_agent/benchmarks/graph_accuracy.py
@@ -23,7 +23,7 @@ Task format (JSON):
         "id": "find_database_class",
         "category": "symbol_discovery",
         "description": "Search should find the Database class",
-        "tool": "search_graph",
+        "tool": "keyword_search",
         "tool_args": {"query": "Database", "nodeTypes": "Class"},
         "assertions": [
             {"type": "min_count", "value": 1},

--- a/agent/src/opentrace_agent/benchmarks/tasks/level1_smoke.json
+++ b/agent/src/opentrace_agent/benchmarks/tasks/level1_smoke.json
@@ -29,7 +29,7 @@
       "id": "find_app_py",
       "category": "symbol_discovery",
       "description": "Search should find app.py",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "app.py", "nodeTypes": "File"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -40,7 +40,7 @@
       "id": "find_calculator_class",
       "category": "symbol_discovery",
       "description": "Search should find the Calculator class",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "Calculator", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -71,7 +71,7 @@
       "id": "search_no_results",
       "category": "search_quality",
       "description": "Searching for nonsense should return empty",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "zzz_nonexistent_zzz"},
       "assertions": [
         {"type": "exact_count", "value": 0}
@@ -81,7 +81,7 @@
       "id": "search_type_filter",
       "category": "search_quality",
       "description": "Searching for 'app' with File filter should only return Files",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "app", "nodeTypes": "File"},
       "assertions": [
         {"type": "min_count", "value": 1},

--- a/agent/src/opentrace_agent/benchmarks/tasks/level2_multifile.json
+++ b/agent/src/opentrace_agent/benchmarks/tasks/level2_multifile.json
@@ -53,7 +53,7 @@
       "id": "find_user_class",
       "category": "symbol_discovery",
       "description": "Search should find the User class",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "User", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -64,7 +64,7 @@
       "id": "find_user_service_class",
       "category": "symbol_discovery",
       "description": "Search should find the UserService class",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "UserService", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -75,7 +75,7 @@
       "id": "find_validate_email",
       "category": "symbol_discovery",
       "description": "Search should find validate_email function",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "validate_email", "nodeTypes": "Function"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -86,7 +86,7 @@
       "id": "find_validate_name",
       "category": "symbol_discovery",
       "description": "Search should find validate_name function",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "validate_name", "nodeTypes": "Function"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -159,7 +159,7 @@
       "id": "search_type_filter",
       "category": "search_quality",
       "description": "Searching for 'User' with Class filter should only return Classes",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "User", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -170,7 +170,7 @@
       "id": "search_no_results",
       "category": "search_quality",
       "description": "Searching for nonsense should return empty",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "zzz_nonexistent_zzz"},
       "assertions": [
         {"type": "exact_count", "value": 0}

--- a/agent/src/opentrace_agent/benchmarks/tasks/level3_polyglot.json
+++ b/agent/src/opentrace_agent/benchmarks/tasks/level3_polyglot.json
@@ -39,7 +39,7 @@
       "id": "find_go_files",
       "category": "structure",
       "description": "Should index all Go files",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": ".go", "nodeTypes": "File"},
       "assertions": [
         {"type": "min_count", "value": 3},
@@ -52,7 +52,7 @@
       "id": "find_python_files",
       "category": "structure",
       "description": "Should index all Python files",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": ".py", "nodeTypes": "File"},
       "assertions": [
         {"type": "min_count", "value": 2},
@@ -64,7 +64,7 @@
       "id": "find_handler_struct",
       "category": "symbol_discovery",
       "description": "Search should find the Handler struct",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "Handler", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -75,7 +75,7 @@
       "id": "find_store_struct",
       "category": "symbol_discovery",
       "description": "Search should find the Store struct",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "Store", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -86,7 +86,7 @@
       "id": "find_base_model",
       "category": "symbol_discovery",
       "description": "Search should find the BaseModel class",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "BaseModel", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -97,7 +97,7 @@
       "id": "find_user_model",
       "category": "symbol_discovery",
       "description": "Search should find the UserModel class",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "UserModel", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -108,7 +108,7 @@
       "id": "find_new_handler",
       "category": "symbol_discovery",
       "description": "Search should find the NewHandler function",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "NewHandler", "nodeTypes": "Function"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -119,7 +119,7 @@
       "id": "find_new_store",
       "category": "symbol_discovery",
       "description": "Search should find the NewStore function",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "NewStore", "nodeTypes": "Function"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -250,7 +250,7 @@
       "id": "search_inheritance",
       "category": "symbol_discovery",
       "description": "Search for 'Model' should find both BaseModel and UserModel",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "Model", "nodeTypes": "Class"},
       "assertions": [
         {"type": "min_count", "value": 2},
@@ -262,7 +262,7 @@
       "id": "search_type_filter",
       "category": "search_quality",
       "description": "File type filter should restrict results",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "handler", "nodeTypes": "File"},
       "assertions": [
         {"type": "min_count", "value": 1},
@@ -273,7 +273,7 @@
       "id": "search_no_results",
       "category": "search_quality",
       "description": "Searching for nonsense should return empty",
-      "tool": "search_graph",
+      "tool": "keyword_search",
       "tool_args": {"query": "zzz_nonexistent_zzz"},
       "assertions": [
         {"type": "exact_count", "value": 0}

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -523,7 +523,7 @@ def mcp_cmd(db_path: str | None, verbose: bool) -> None:
     signal.signal(signal.SIGTERM, _shutdown)
 
     try:
-        server = create_mcp_server(reloadable)
+        server = create_mcp_server(reloadable, db_path=resolved_db)
         log.debug("MCP server running on stdio")
         server.run(transport="stdio")
     except KeyboardInterrupt:
@@ -1085,6 +1085,153 @@ def impact(file_path: str, db_path: str | None, line_spec: str | None) -> None:
                 continue
 
     run_impact(file_path, resolved, line_ranges)
+
+
+def _do_clone(
+    repo_url: str,
+    clone_dir: Path,
+    ref: str | None,
+) -> Path:
+    """Clone ``repo_url`` into ``clone_dir`` and return the final path.
+
+    Tries ``GitCloner`` first (used by the rest of the indexing pipeline)
+    then falls back to ``git clone`` if the helper is unavailable.  Only
+    public repositories are supported in the open-source build.
+    """
+    click.echo(f"Cloning {repo_url} ...")
+    try:
+        from opentrace_agent.sources.code.git_cloner import GitCloner
+
+        cloner = GitCloner()
+        kwargs: dict[str, object] = {"dest": clone_dir}
+        if ref:
+            kwargs["ref"] = ref
+        return cloner.clone(repo_url, **kwargs)
+    except ImportError:
+        pass
+    except Exception as e:
+        raise click.ClickException(f"Clone failed: {e}")
+
+    import subprocess
+
+    cmd = ["git", "clone", "--depth", "1"]
+    if ref:
+        cmd.extend(["--branch", ref])
+    cmd.extend([repo_url, str(clone_dir)])
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+    )
+    if result.returncode != 0:
+        raise click.ClickException(f"git clone failed: {result.stderr}")
+    return clone_dir
+
+
+@app.command("fetch-and-index")
+@click.argument("repo_url")
+@click.option(
+    "--repo-id",
+    default=None,
+    help="Custom repository ID (defaults to the repo name from the URL).",
+)
+@click.option("--ref", default=None, help="Branch or tag to clone (defaults to repo HEAD).")
+@click.option(
+    "--db",
+    "db_path",
+    default=None,
+    type=click.Path(),
+    help=f"Database path (default: ./{OPENTRACE_DIR}/{DB_NAME}).",
+)
+@click.option("--batch-size", default=200, show_default=True, help="Items per batch.")
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug logging.")
+def fetch_and_index(
+    repo_url: str,
+    repo_id: str | None,
+    ref: str | None,
+    db_path: str | None,
+    batch_size: int,
+    verbose: bool,
+) -> None:
+    """Clone REPO_URL and index it into the graph.
+
+    Performs a shallow clone into ``~/.opentrace/repos/{org}/{name}/``,
+    then runs the full indexing pipeline.  The clone is kept so
+    ``source_read`` can serve files from it later.
+
+    Only public repositories are supported in the open-source build.
+    """
+    _configure_logging(verbose)
+
+    from opentrace_agent.pipeline import PipelineInput, run_pipeline
+    from opentrace_agent.pipeline.adapters import GraphStoreAdapter
+    from opentrace_agent.store import GraphStore
+
+    url_parts = repo_url.rstrip("/").split("/")
+    inferred_name = url_parts[-1].removesuffix(".git") if url_parts else "repo"
+    effective_repo_id = repo_id or inferred_name
+    org = url_parts[-2] if len(url_parts) >= 2 else "unknown"
+
+    repos_dir = Path.home() / ".opentrace" / "repos" / org
+    repos_dir.mkdir(parents=True, exist_ok=True)
+    clone_dir = repos_dir / inferred_name
+
+    if clone_dir.exists() and (clone_dir / ".git").exists():
+        click.echo(f"Repository already cloned at {clone_dir}, pulling latest ...")
+        try:
+            import subprocess
+
+            subprocess.run(
+                ["git", "-C", str(clone_dir), "pull", "--ff-only"],
+                capture_output=True,
+                timeout=60,
+            )
+        except Exception:
+            pass
+        local_path = clone_dir
+    elif clone_dir.exists():
+        import shutil
+
+        shutil.rmtree(clone_dir)
+        clone_dir.mkdir(parents=True, exist_ok=True)
+        local_path = _do_clone(repo_url, clone_dir, ref)
+    else:
+        clone_dir.mkdir(parents=True, exist_ok=True)
+        local_path = _do_clone(repo_url, clone_dir, ref)
+
+    click.echo(f"Cloned to {local_path}")
+
+    resolved_db = _resolve_db(db_path)
+    db_dir = Path(resolved_db).parent
+    db_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_gitignore(db_dir)
+
+    click.echo(f"Opening database at {resolved_db} ...")
+    with GraphStore(resolved_db) as graph_store:
+        store = GraphStoreAdapter(graph_store, batch_size=batch_size)
+
+        click.echo(f"Indexing {local_path} as '{effective_repo_id}' ...")
+        t0 = time.monotonic()
+
+        inp = PipelineInput(path=str(local_path), repo_id=effective_repo_id)
+
+        last_result = None
+        for event in run_pipeline(inp, store=store):
+            _print_event(event, verbose)
+            if getattr(event, "result", None) is not None:
+                last_result = event.result
+
+        elapsed = time.monotonic() - t0
+
+        metadata = _collect_metadata(local_path, effective_repo_id, elapsed, last_result)
+        metadata["sourceUri"] = repo_url
+        graph_store.save_metadata(metadata)
+
+        store.flush()
+
+    click.echo(f"Done in {elapsed:.1f}s. Repository '{effective_repo_id}' is now indexed.")
 
 
 def _configure_logging(verbose: bool) -> None:

--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -816,11 +816,33 @@ def create_mcp_server(
             if not file_nodes:
                 return json.dumps({"error": f"File not found in index: {target}"})
 
-            # Prefer an exact path-suffix match over the FTS top result.
-            file_node = file_nodes[0]
-            for fn in file_nodes:
+            # search_nodes matches on name / search_text / docs, not just
+            # the path — so a query that hits an unrelated File's
+            # docstring would otherwise misroute. Require the chosen
+            # node's path to actually correspond to the target.
+            target_bn = os.path.basename(target)
+
+            def _path_matches(fn: dict[str, Any]) -> bool:
+                node_path = (fn.get("properties") or {}).get("path") or ""
+                if not node_path:
+                    return False
+                if node_path == target or node_path.endswith(target) or target.endswith(node_path):
+                    return True
+                if target_bn:
+                    node_bn = os.path.basename(node_path)
+                    if node_bn == target_bn or node_path.endswith("/" + target_bn):
+                        return True
+                return False
+
+            matched = [fn for fn in file_nodes if _path_matches(fn)]
+            if not matched:
+                return json.dumps({"error": f"File not found in index: {target}"})
+
+            # Prefer an exact path or path-suffix match over a basename-only match.
+            file_node = matched[0]
+            for fn in matched:
                 node_path = (fn.get("properties") or {}).get("path", "")
-                if node_path.endswith(target) or target.endswith(node_path):
+                if node_path == target or node_path.endswith(target) or target.endswith(node_path):
                     file_node = fn
                     break
 

--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -621,15 +621,29 @@ def create_mcp_server(
 
             repos = _repo_paths(store)
             candidates: list[str] = []
+
+            # Resolve file_path under each repo root and reject any result
+            # that escapes the root (absolute file_path discards the root,
+            # and `..` segments traverse out of it).  Resolving both sides
+            # also makes the comparison symlink-safe.
+            def _safe_join(abs_path: str) -> str | None:
+                root = Path(abs_path).resolve()
+                joined = (root / file_path).resolve()
+                if joined.is_relative_to(root):
+                    return str(joined)
+                return None
+
             if repo_hint:
                 for rid, abs_path in repos:
                     if rid == repo_hint:
-                        candidates.append(os.path.join(abs_path, file_path))
+                        safe = _safe_join(abs_path)
+                        if safe and safe not in candidates:
+                            candidates.append(safe)
                         break
             for _, abs_path in repos:
-                joined = os.path.join(abs_path, file_path)
-                if joined not in candidates:
-                    candidates.append(joined)
+                safe = _safe_join(abs_path)
+                if safe and safe not in candidates:
+                    candidates.append(safe)
 
             for candidate in candidates:
                 if os.path.exists(candidate):
@@ -676,7 +690,9 @@ def create_mcp_server(
                 cmd = [rg, "--no-heading", "--line-number", "--max-count", str(limit)]
                 if include:
                     cmd.extend(["--glob", include])
-                cmd.extend([pattern, abs_path])
+                # `--` prevents pattern or abs_path being interpreted as
+                # flags if they start with a hyphen.
+                cmd.extend(["--", pattern, abs_path])
                 try:
                     proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15, check=False)
                 except subprocess.TimeoutExpired:

--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -18,7 +18,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import re
+import shutil
+import subprocess
 import traceback
+from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -27,7 +32,209 @@ from opentrace_agent.store import GraphStore
 
 logger = logging.getLogger(__name__)
 
-MAX_RESULT_CHARS = 4000
+MAX_RESULT_CHARS = 32_000  # ~8K tokens; comfortable for subgraphs without
+# blowing past LLM context budgets.  Graph subgraphs (search_graph,
+# find_usages with deep traversal) regularly exceed 4 KB.
+
+# Relationship types treated as "X depends on Y" for find_usages / impact.
+_DEPENDENCY_RELS = frozenset({"CALLS", "IMPORTS", "DEPENDS_ON", "EXTENDS", "IMPLEMENTS"})
+
+# Words to drop from natural-language semantic_search queries before
+# searching keyword-by-keyword.  Includes English stopwords plus filler
+# nouns the LLM tends to add ("function", "code", "thing") that won't
+# match anything useful in symbol names.
+_QUERY_STOPWORDS = frozenset(
+    {
+        # articles / pronouns / aux verbs
+        "a",
+        "an",
+        "the",
+        "this",
+        "that",
+        "these",
+        "those",
+        "i",
+        "you",
+        "he",
+        "she",
+        "it",
+        "we",
+        "they",
+        "me",
+        "him",
+        "her",
+        "us",
+        "them",
+        "my",
+        "your",
+        "his",
+        "its",
+        "our",
+        "their",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "do",
+        "does",
+        "did",
+        "doing",
+        "done",
+        "have",
+        "has",
+        "had",
+        "having",
+        "can",
+        "could",
+        "should",
+        "would",
+        "may",
+        "might",
+        "will",
+        "shall",
+        # prepositions / conjunctions
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "with",
+        "without",
+        "by",
+        "from",
+        "as",
+        "into",
+        "onto",
+        "via",
+        "about",
+        "and",
+        "or",
+        "but",
+        "not",
+        "if",
+        "then",
+        "than",
+        "so",
+        # interrogatives / instruction verbs
+        "what",
+        "where",
+        "who",
+        "when",
+        "why",
+        "how",
+        "which",
+        "find",
+        "show",
+        "get",
+        "give",
+        "list",
+        "tell",
+        "explain",
+        "search",
+        "look",
+        "read",
+        # common filler nouns the LLM injects
+        "function",
+        "functions",
+        "method",
+        "methods",
+        "class",
+        "classes",
+        "code",
+        "thing",
+        "things",
+        "file",
+        "files",
+        "any",
+        "some",
+        "all",
+        "no",
+        "every",
+        "each",
+        "one",
+        "two",
+        "use",
+        "uses",
+        "used",
+        "using",
+        "handle",
+        "handles",
+        "handling",
+        "handler",
+        "handlers",
+    }
+)
+
+
+def _tag_match_field(node: dict[str, Any], keywords: list[str]) -> dict[str, Any]:
+    """Annotate ``node`` with which field carried the keyword match.
+
+    Why: docstrings can drift from code over time.  A hit on ``name`` or
+    ``signature`` is high-confidence — the symbol literally has that
+    word.  A hit on ``docs`` only means the comment claims something
+    about the symbol; the function body may have been changed since.
+    Surface this to the caller so the LLM/user can decide whether to
+    trust the result or read source first.
+
+    Sets:
+      - ``_match_field``: ``"name"`` | ``"signature"`` | ``"path"`` |
+        ``"summary"`` | ``"docs"`` | ``"unknown"``
+      - ``_verify``: present only when match was docs-only — a short
+        instruction telling the caller to read source before trusting.
+    """
+    name = (node.get("name") or "").lower()
+    props = node.get("properties") or {}
+    sig = (props.get("signature") or "").lower()
+    path = (props.get("path") or "").lower()
+    summary = (props.get("summary") or "").lower()
+    docs = (props.get("docs") or "").lower()
+
+    kws = [k.lower() for k in keywords if isinstance(k, str)]
+
+    if any(k in name for k in kws):
+        node["_match_field"] = "name"
+    elif sig and any(k in sig for k in kws):
+        node["_match_field"] = "signature"
+    elif path and any(k in path for k in kws):
+        node["_match_field"] = "path"
+    elif summary and any(k in summary for k in kws):
+        node["_match_field"] = "summary"
+    elif docs and any(k in docs for k in kws):
+        node["_match_field"] = "docs"
+        node["_verify"] = (
+            "Matched docstring only — the code may be stale relative to the doc. "
+            "Read the source via source_read with this node's id to confirm."
+        )
+    else:
+        # FTS may have matched a stemmed form we can't reproduce here.
+        node["_match_field"] = "unknown"
+    return node
+
+
+def _extract_query_keywords(query: str) -> list[str]:
+    """Pull content tokens out of a natural-language query.
+
+    Lowercases, splits on word boundaries, drops short tokens and
+    stopwords, and dedupes while preserving order so the most
+    distinctive term in the original phrasing wins ties.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in re.findall(r"[A-Za-z][A-Za-z0-9_-]+", query):
+        token = raw.lower()
+        if len(token) <= 2:
+            continue
+        if token in _QUERY_STOPWORDS:
+            continue
+        if token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+    return out
 
 
 def _truncate(text: str, limit: int = MAX_RESULT_CHARS) -> str:
@@ -54,30 +261,113 @@ NO_INDEX_MSG = json.dumps(
 )
 
 
-def create_mcp_server(store: GraphStore | None) -> FastMCP:
+def _repo_paths(store: GraphStore) -> list[tuple[str, str]]:
+    """Return ``[(repo_id, abs_path), ...]`` from index metadata.
+
+    Only entries with both fields are returned.  Used by tools that need
+    filesystem access (``source_read``, ``source_grep``).
+    """
+    try:
+        entries = store.get_metadata()
+    except Exception:
+        return []
+    out: list[tuple[str, str]] = []
+    for entry in entries:
+        repo_id = entry.get("repoId") or entry.get("repo_id")
+        repo_path = entry.get("repoPath") or entry.get("repo_path")
+        if isinstance(repo_id, str) and isinstance(repo_path, str):
+            out.append((repo_id, repo_path))
+    return out
+
+
+def _repo_from_node_id(node_id: str) -> str:
+    """Extract the repo prefix from a node ID like ``repo/path/file.py::Sym``."""
+    slash = node_id.find("/")
+    return node_id if slash == -1 else node_id[:slash]
+
+
+def _read_file_slice(abs_path: str, start_line: int | None, end_line: int | None) -> str:
+    """Read a file (optionally line-sliced) and return ``cat -n``-style output."""
+    p = Path(abs_path)
+    if p.is_dir():
+        try:
+            entries = sorted(os.listdir(abs_path))[:50]
+        except OSError as e:
+            return f"[Could not list directory {abs_path}: {e}]"
+        return (
+            f"[Directory: {abs_path}]\nContents: {', '.join(entries)}\n\n"
+            "Use source_grep to find specific files, or source_read with a full file path."
+        )
+    try:
+        content = p.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return f"[Could not read {abs_path}: {e}]"
+
+    if start_line is None and end_line is None:
+        return content
+
+    lines = content.split("\n")
+    start = max(0, (start_line or 1) - 1)
+    end = end_line if end_line is not None else len(lines)
+    sliced = lines[start:end]
+    header = f"// {abs_path}:{start_line or 1}-{end}\n"
+    body = "\n".join(f"{start + i + 1}\t{line}" for i, line in enumerate(sliced))
+    return header + body
+
+
+def create_mcp_server(
+    store: GraphStore | None,
+    *,
+    db_path: str | None = None,
+) -> FastMCP:
     """Create a FastMCP server with graph query tools backed by *store*.
 
     When *store* is ``None`` (no database found), every tool returns a
     friendly "no index" response instead of raising an error.
+
+    *db_path* is used by ``repo_index`` to direct the indexer at the same
+    database the server is reading from.  When omitted, ``repo_index``
+    creates a fresh database under the target path.
     """
     server = FastMCP("opentrace")
 
     @server.tool()
-    def search_graph(query: str, limit: int = 50, nodeTypes: str = "") -> str:
-        """Full-text search across graph nodes by name or properties.
+    def search_graph(query: str, hops: int = 2, limit: int = 20) -> str:
+        """Search the graph and return a SUBGRAPH around the matches.
 
-        Returns matching nodes with their types and properties.
+        Finds nodes matching ``query`` (keyword), then expands
+        ``hops`` levels of neighbors via BFS over RELATES edges.
+        Returns ``{"nodes": [...], "relationships": [...]}`` — both
+        the nodes and the edges connecting them, so the caller can
+        understand the local network around each match without further
+        ``traverse_graph`` calls.
+
+        Use this when the question is structural: "what does X connect
+        to?", "show me the area of the graph around Y".  Use
+        ``keyword_search`` when you only want a flat list of matches.
+
+        ``hops`` is capped at 5; ``limit`` (initial seed nodes) is
+        capped at 200.
         """
         if not store:
             logger.info("search_graph called but no index exists")
             return NO_INDEX_MSG
-        logger.debug("search_graph(query=%r, limit=%d, nodeTypes=%r)", query, limit, nodeTypes)
+        logger.debug("search_graph(query=%r, hops=%d, limit=%d)", query, hops, limit)
         try:
-            node_types = [t.strip() for t in nodeTypes.split(",") if t.strip()] or None
-            limit = min(limit, 1000)
-            nodes = store.search_nodes(query, node_types=node_types, limit=limit)
-            logger.debug("search_graph → %d results", len(nodes))
-            return _json_response(nodes)
+            hops = max(0, min(hops, 5))
+            limit = max(1, min(limit, 200))
+            nodes, relationships = store.search_graph(query, hops=hops, limit=limit)
+            return _json_response(
+                {
+                    "nodes": nodes,
+                    "relationships": relationships,
+                    "summary": {
+                        "node_count": len(nodes),
+                        "relationship_count": len(relationships),
+                        "hops": hops,
+                    },
+                }
+            )
         except Exception as e:
             return _error_response("search_graph", e)
 
@@ -181,5 +471,432 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
             return _json_response(stats)
         except Exception as e:
             return _error_response("get_stats", e)
+
+    # -------------------------------------------------------------------
+    # keyword_search — tokenized multi-keyword search.  Honest naming:
+    # this is *not* semantic / vector search.  Embeddings are a future
+    # addition; today this is FTS (when the extension is available) plus
+    # substring fallback against name + search_text.
+    # -------------------------------------------------------------------
+    @server.tool()
+    def keyword_search(query: str, nodeTypes: str = "", limit: int = 10) -> str:
+        """Search the graph by keyword(s) — works with multi-word phrases.
+
+        Tokenizes the query (drops stopwords and filler nouns like
+        "function" / "code" / "handle"), runs a search per remaining
+        keyword, merges results, and ranks by how many keywords each
+        node hit.  Use this when the user phrases their query as a
+        sentence ("functions that validate user input", "code that
+        handles auth tokens"); use ``search_graph`` when the user gives
+        a single literal symbol name.
+
+        Each result is tagged with:
+        - ``_match_count``  — how many of the query's keywords it hit
+        - ``_matched``      — the specific keywords that matched
+        - ``_match_field``  — which field carried the match
+                              (``"name"`` is high-confidence; ``"docs"``
+                              means the docstring matched but the code
+                              may be stale — read source to confirm)
+        - ``_verify``       — present when match was docs-only,
+                              telling the caller to verify
+
+        Caveat: this is keyword search, not semantic search.  Vector
+        embeddings are planned but not yet implemented.  Run
+        ``opentraceai augment`` to enrich nodes with LLM-generated
+        summaries — they're folded into ``search_text`` and improve
+        keyword recall on natural-language queries.
+        """
+        if not store:
+            logger.info("keyword_search called but no index exists")
+            return NO_INDEX_MSG
+        logger.debug("keyword_search(query=%r, limit=%d, nodeTypes=%r)", query, limit, nodeTypes)
+        try:
+            types = [t.strip() for t in nodeTypes.split(",") if t.strip()] or None
+            limit = max(1, min(limit, 1000))
+
+            keywords = _extract_query_keywords(query)
+            if not keywords:
+                # Single token, all stopwords, or punctuation only — pass
+                # through unchanged so a one-word query still works.
+                nodes = store.search_nodes(query, node_types=types, limit=limit)
+                tagged = [_tag_match_field(n, [query]) for n in nodes]
+                return _json_response(tagged)
+
+            # Search per keyword, then merge.  Per-keyword limit is
+            # generous so ranking still has signal when one keyword
+            # matches widely.
+            per_kw_limit = max(limit * 3, 30)
+            scored: dict[str, dict[str, Any]] = {}
+            for kw in keywords:
+                try:
+                    matches = store.search_nodes(kw, node_types=types, limit=per_kw_limit)
+                except Exception:
+                    continue
+                for node in matches:
+                    nid = node.get("id")
+                    if not nid:
+                        continue
+                    entry = scored.get(nid)
+                    if entry is None:
+                        scored[nid] = {**node, "_match_count": 1, "_matched": [kw]}
+                    else:
+                        entry["_match_count"] += 1
+                        entry["_matched"].append(kw)
+
+            if not scored:
+                return _json_response([])
+
+            ranked = sorted(
+                scored.values(),
+                key=lambda n: (-n["_match_count"], n.get("name", "")),
+            )
+            tagged = [_tag_match_field(n, n["_matched"]) for n in ranked[:limit]]
+            return _json_response(tagged)
+        except Exception as e:
+            return _error_response("keyword_search", e)
+
+    # -------------------------------------------------------------------
+    # source_read — read source from any indexed repo (avoids permission
+    # prompts the agent harness raises for files outside the project).
+    # -------------------------------------------------------------------
+    @server.tool()
+    def source_read(
+        nodeId: str = "",
+        path: str = "",
+        repo: str = "",
+        startLine: int = 0,
+        endLine: int = 0,
+    ) -> str:
+        """Read source code from any indexed repository.
+
+        Provide either ``nodeId`` (preferred — looked up via the graph to
+        recover its file path and line range) or a ``path`` relative to a
+        repo root (with optional ``repo`` to disambiguate).  ``startLine`` /
+        ``endLine`` clip the returned slice; leave 0 to read the whole file.
+        Returns ``cat -n``-style numbered output.
+        """
+        if not store:
+            return NO_INDEX_MSG
+        logger.debug(
+            "source_read(nodeId=%r, path=%r, repo=%r, lines=%d-%d)",
+            nodeId,
+            path,
+            repo,
+            startLine,
+            endLine,
+        )
+        try:
+            file_path: str | None = None
+            repo_hint: str | None = repo or None
+            start = startLine or None
+            end = endLine or None
+
+            if nodeId:
+                node = store.get_node(nodeId)
+                if node is None:
+                    return json.dumps({"error": f"Node not found: {nodeId}"})
+                props = node.get("properties") or {}
+                file_path = props.get("path")
+                if start is None:
+                    start = props.get("start_line") or props.get("startLine")
+                if end is None:
+                    end = props.get("end_line") or props.get("endLine")
+
+                if not file_path:
+                    # Fall back to the node ID itself: ``repo/path/file::Sym``.
+                    nid = nodeId
+                    dc = nid.find("::")
+                    path_part = nid[:dc] if dc != -1 else nid
+                    slash = path_part.find("/")
+                    if slash != -1:
+                        repo_hint = repo_hint or path_part[:slash]
+                        file_path = path_part[slash + 1 :]
+                    else:
+                        file_path = path_part
+            else:
+                file_path = path or None
+
+            if not file_path:
+                return json.dumps({"error": "Provide either nodeId or path"})
+
+            repos = _repo_paths(store)
+            candidates: list[str] = []
+            if repo_hint:
+                for rid, abs_path in repos:
+                    if rid == repo_hint:
+                        candidates.append(os.path.join(abs_path, file_path))
+                        break
+            for _, abs_path in repos:
+                joined = os.path.join(abs_path, file_path)
+                if joined not in candidates:
+                    candidates.append(joined)
+
+            for candidate in candidates:
+                if os.path.exists(candidate):
+                    return _truncate(_read_file_slice(candidate, start, end))
+
+            return json.dumps({"error": f"Source file not found: {file_path}"})
+        except Exception as e:
+            return _error_response("source_read", e)
+
+    # -------------------------------------------------------------------
+    # source_grep — ripgrep across all indexed repository checkouts.
+    # -------------------------------------------------------------------
+    @server.tool()
+    def source_grep(pattern: str, repo: str = "", include: str = "", limit: int = 50) -> str:
+        """Regex-search file contents across every indexed repository.
+
+        Like ``rg``, but driven from the index's metadata so the tool knows
+        every checkout's location.  ``repo`` filters to a single repo by
+        substring match; ``include`` is a glob filter (e.g. ``*.py``).
+        Output paths are repo-relative and tagged with ``[repoId]``.
+        Requires ``rg`` on PATH.
+        """
+        if not store:
+            return NO_INDEX_MSG
+        rg = shutil.which("rg")
+        if not rg:
+            return json.dumps({"error": "ripgrep (rg) not found on PATH"})
+
+        repos = _repo_paths(store)
+        if not repos:
+            return json.dumps({"error": "No indexed repository paths available"})
+
+        if repo:
+            needle = repo.lower()
+            repos = [r for r in repos if needle in r[0].lower()]
+            if not repos:
+                return json.dumps({"error": f"No indexed repo matching {repo!r}"})
+
+        try:
+            limit = max(1, min(limit, 1000))
+            results: list[str] = []
+            total = 0
+            for repo_id, abs_path in repos:
+                cmd = [rg, "--no-heading", "--line-number", "--max-count", str(limit)]
+                if include:
+                    cmd.extend(["--glob", include])
+                cmd.extend([pattern, abs_path])
+                try:
+                    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15, check=False)
+                except subprocess.TimeoutExpired:
+                    continue
+                if proc.stdout:
+                    for line in proc.stdout.splitlines():
+                        # Strip the absolute repo path prefix so the LLM sees
+                        # repo-relative paths only.
+                        rel = line[len(abs_path) + 1 :] if line.startswith(abs_path) else line
+                        results.append(f"[{repo_id}] {rel}")
+                        total += 1
+                        if total >= limit:
+                            break
+                if total >= limit:
+                    break
+
+            if not results:
+                return json.dumps({"matches": [], "message": f"No matches for {pattern!r} in {len(repos)} repo(s)"})
+            return _truncate("\n".join(results))
+        except Exception as e:
+            return _error_response("source_grep", e)
+
+    # -------------------------------------------------------------------
+    # find_usages — incoming dependency edges of the best symbol match.
+    # -------------------------------------------------------------------
+    @server.tool()
+    def find_usages(symbol: str, type: str = "", depth: int = 2) -> str:
+        """Find callers, importers, and dependents of a symbol.
+
+        Searches the graph for the named symbol, picks the highest-ranked
+        match, then walks *incoming* CALLS / IMPORTS / DEPENDS_ON /
+        EXTENDS / IMPLEMENTS edges up to ``depth`` hops (capped at 5).
+        Returns the target node and a list of dependents.
+
+        Depth semantics:
+          - ``depth=1`` → only **direct** usages (functions that
+            literally call / import the target).
+          - ``depth=2`` (default) and higher → **transitive** usages —
+            callers of callers.  This grows quickly; if you only want
+            the immediate ring, pass ``depth=1`` explicitly.
+
+        Coverage caveat: only edges in the indexed graph are visible.
+        Callers in repos that haven't been indexed are not counted.
+        Use ``repo_index`` to widen coverage before relying on this for
+        change-safety decisions.
+        """
+        if not store:
+            return NO_INDEX_MSG
+        logger.debug("find_usages(symbol=%r, type=%r, depth=%d)", symbol, type, depth)
+        try:
+            depth = max(1, min(depth, 5))
+            types = [type] if type else None
+            matches = store.search_nodes(symbol, node_types=types, limit=5)
+            if not matches:
+                return json.dumps({"error": f"No node matching {symbol!r}" + (f" of type {type}" if type else "")})
+
+            target = matches[0]
+            deps = store.traverse(target["id"], direction="incoming", max_depth=depth)
+            relevant = [d for d in deps if d["relationship"]["type"] in _DEPENDENCY_RELS]
+
+            return _json_response(
+                {
+                    "target": target,
+                    "dependents": relevant,
+                    "count": len(relevant),
+                    "candidates": [{"id": m["id"], "name": m["name"], "type": m["type"]} for m in matches],
+                }
+            )
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            return _error_response("find_usages", e)
+
+    # -------------------------------------------------------------------
+    # impact_analysis — blast radius of edits to a file.
+    # -------------------------------------------------------------------
+    @server.tool()
+    def impact_analysis(target: str, lines: str = "") -> str:
+        """Show the blast radius of changes to a file.
+
+        Locates the File node matching ``target`` (full or partial
+        path), finds symbols defined in it, and walks incoming
+        dependency edges for each symbol.  ``lines`` narrows analysis
+        to ranges like ``"10-25,40-60"``.  Returns a structured summary
+        the model can show directly to the user before they make a
+        change.
+
+        Coverage caveat: blast radius is bounded by what's been indexed.
+        Dependents living in un-indexed repos are invisible — you may
+        get a "no dependents found" result that's wrong in the larger
+        codebase.  Run ``repo_index`` on every repo that could plausibly
+        depend on the target before treating a clean result as
+        change-safe.
+        """
+        if not store:
+            return NO_INDEX_MSG
+        logger.debug("impact_analysis(target=%r, lines=%r)", target, lines)
+        try:
+            line_ranges: list[tuple[int, int]] | None = None
+            if lines:
+                line_ranges = []
+                for part in lines.split(","):
+                    part = part.strip()
+                    if not part:
+                        continue
+                    try:
+                        if "-" in part:
+                            lo, hi = part.split("-", 1)
+                            line_ranges.append((int(lo), int(hi)))
+                        else:
+                            n = int(part)
+                            line_ranges.append((n, n))
+                    except ValueError:
+                        continue
+
+            file_nodes = store.search_nodes(target, node_types=["File"], limit=5)
+            if not file_nodes:
+                bn = os.path.basename(target)
+                if bn and bn != target:
+                    file_nodes = store.search_nodes(bn, node_types=["File"], limit=5)
+            if not file_nodes:
+                return json.dumps({"error": f"File not found in index: {target}"})
+
+            # Prefer an exact path-suffix match over the FTS top result.
+            file_node = file_nodes[0]
+            for fn in file_nodes:
+                node_path = (fn.get("properties") or {}).get("path", "")
+                if node_path.endswith(target) or target.endswith(node_path):
+                    file_node = fn
+                    break
+
+            symbols_with_deps: list[dict[str, Any]] = []
+            for nb_node, _rel in store._get_neighbors(file_node["id"], "incoming"):
+                if nb_node["type"] not in ("Function", "Class", "Module"):
+                    continue
+                if line_ranges:
+                    props = nb_node.get("properties") or {}
+                    sl = props.get("start_line")
+                    el = props.get("end_line") or sl
+                    if sl is not None:
+                        sl_i = int(sl)
+                        el_i = int(el)
+                        if not any(sl_i <= hi and el_i >= lo for lo, hi in line_ranges):
+                            continue
+                try:
+                    deps = store.traverse(nb_node["id"], direction="incoming", max_depth=2)
+                except ValueError:
+                    deps = []
+                relevant = [d for d in deps if d["relationship"]["type"] in _DEPENDENCY_RELS]
+                symbols_with_deps.append({"symbol": nb_node, "dependents": relevant, "count": len(relevant)})
+
+            total = sum(s["count"] for s in symbols_with_deps)
+            return _json_response(
+                {
+                    "file": file_node,
+                    "symbols": symbols_with_deps,
+                    "total_dependents": total,
+                }
+            )
+        except Exception as e:
+            return _error_response("impact_analysis", e)
+
+    # -------------------------------------------------------------------
+    # repo_index — index a local path or remote git URL.
+    # -------------------------------------------------------------------
+    @server.tool()
+    def repo_index(path_or_url: str, repoId: str = "", ref: str = "") -> str:
+        """Index a local directory or remote git URL into the graph.
+
+        - **Local path**: shells out to ``opentraceai index <path>`` against
+          the running server's database, or creates a fresh one when no
+          DB is known.
+        - **Git URL** (``https://``, ``http://`` or ``git@``): shells out
+          to ``opentraceai fetch-and-index <url>``, which clones to
+          ``~/.opentrace/repos/{org}/{name}`` and indexes from there.
+          Only public repositories are supported in the open-source build.
+
+        After the subprocess exits, the server hot-reloads automatically.
+        """
+        is_url = (
+            path_or_url.startswith("https://") or path_or_url.startswith("http://") or path_or_url.startswith("git@")
+        )
+
+        if is_url:
+            cmd = ["opentraceai", "fetch-and-index", path_or_url]
+            if repoId:
+                cmd.extend(["--repo-id", repoId])
+            if ref:
+                cmd.extend(["--ref", ref])
+            if db_path:
+                cmd.extend(["--db", db_path])
+        else:
+            try:
+                target = Path(path_or_url).expanduser().resolve()
+            except Exception as e:
+                return json.dumps({"error": f"Invalid path: {e}"})
+            if not target.exists():
+                return json.dumps({"error": f"Path does not exist: {target}"})
+            if not target.is_dir():
+                return json.dumps({"error": f"Path is not a directory: {target}"})
+
+            cmd = ["opentraceai", "index", str(target)]
+            if db_path:
+                cmd.extend(["--db", db_path])
+            if repoId:
+                cmd.extend(["--repo-id", repoId])
+
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600, check=False)
+        except FileNotFoundError:
+            return json.dumps({"error": "opentraceai not found on PATH — install with `pip install opentraceai`"})
+        except subprocess.TimeoutExpired:
+            return json.dumps({"error": "Indexing timed out after 10 minutes"})
+
+        return _json_response(
+            {
+                "exit_code": proc.returncode,
+                "stdout": proc.stdout[-2000:],
+                "stderr": proc.stderr[-2000:] if proc.stderr else "",
+            }
+        )
 
     return server

--- a/agent/src/opentrace_agent/pipeline/adapters.py
+++ b/agent/src/opentrace_agent/pipeline/adapters.py
@@ -86,6 +86,15 @@ class GraphStoreAdapter:
     def _flush_rels(self) -> None:
         if not self._rels:
             return
+        # CRITICAL: flush pending nodes first.  add_relationship uses
+        # MATCH (a:Node), (b:Node) CREATE ... — if either endpoint
+        # isn't in the DB yet, MATCH returns no rows, CREATE silently
+        # does nothing, and the relationship is lost.  Without this
+        # call, a threshold-triggered rel flush (rels reach batch_size
+        # before nodes do) silently drops every edge whose endpoints
+        # are still buffered.  Verified loss: ~16% of edges on a
+        # real-world index.
+        self._flush_nodes()
         result = self._store.import_batch([], self._rels)
         if result["errors"]:
             logger.warning("Batch rel import had %d errors", result["errors"])

--- a/agent/src/opentrace_agent/pipeline/processing.py
+++ b/agent/src/opentrace_agent/pipeline/processing.py
@@ -172,7 +172,16 @@ def processing(
                 if id_imports:
                     registries.import_registry[file_id] = id_imports
 
-            # External imports → Package nodes + IMPORTS rels
+            # External imports → Package nodes + IMPORTS rels.  The
+            # package node MUST be emitted in the same event as its
+            # IMPORTS edge — saving processes nodes-then-rels per
+            # event, so co-emitting guarantees the endpoint exists by
+            # the time add_relationship's MATCH runs.  Previously the
+            # package nodes were collected in ``package_nodes`` and
+            # bulk-emitted only after every file was processed, which
+            # caused MATCH to fail for the IMPORTS edge and the edge
+            # to be silently lost (~300 IMPORTS edges per real-world
+            # index).
             for pkg_name, pkg_id in import_result.external.items():
                 if pkg_id not in package_nodes:
                     registry = pkg_id.split(":")[1]
@@ -180,12 +189,16 @@ def processing(
                     source_url = package_source_url(registry, pkg_name)
                     if source_url:
                         pkg_props["sourceUri"] = source_url
-                    package_nodes[pkg_id] = GraphNode(
+                    pkg_node = GraphNode(
                         id=pkg_id,
                         type="Dependency",
                         name=pkg_name,
                         properties=pkg_props,
                     )
+                    package_nodes[pkg_id] = pkg_node
+                    # Co-emit the node with the very first IMPORTS edge
+                    # that references it.
+                    file_nodes.append(pkg_node)
                 file_rels.append(
                     GraphRelationship(
                         id=f"{file_id}->IMPORTS->{pkg_id}",
@@ -230,17 +243,13 @@ def processing(
             relationships=file_rels if file_rels else None,
         )
 
-    # Emit deduplicated Package nodes
+    # Bump the running total to account for the package nodes that
+    # were co-emitted with their first IMPORTS edge above.  We don't
+    # re-emit them here — that would double-count and rely on the
+    # store's MERGE for correctness.  Tracking is done after the loop
+    # so the per-file STAGE_PROGRESS messages stay accurate.
     if package_nodes:
-        pkg_node_list = list(package_nodes.values())
-        total_nodes += len(pkg_node_list)
-        yield PipelineEvent(
-            kind=EventKind.STAGE_PROGRESS,
-            phase=Phase.PROCESSING,
-            message=f"Emitting {len(pkg_node_list)} package nodes",
-            detail=ProgressDetail(current=total, total=total),
-            nodes=pkg_node_list,
-        )
+        total_nodes += len(package_nodes)
 
     yield PipelineEvent(
         kind=EventKind.STAGE_STOP,

--- a/agent/src/opentrace_agent/store/graph_store.py
+++ b/agent/src/opentrace_agent/store/graph_store.py
@@ -36,12 +36,22 @@ logger = logging.getLogger(__name__)
 
 
 def build_search_text(name: str, node_type: str, properties: dict[str, Any]) -> str:
-    """Combine name, type, summary, and path into searchable text."""
+    """Combine name, type, summary, path, and docs into searchable text.
+
+    Docstrings (``docs``) are included so keyword search can hit nodes
+    whose names are technical abbreviations but whose docstrings spell
+    things out (``"authentication"``, ``"encrypt"``, ``"rate limit"``).
+    Backwards compatible: the column is free-form text, so older
+    indexes still work — they just carry less search content per row
+    until re-indexed.
+    """
     parts = [name, node_type]
     if summary := properties.get("summary"):
         parts.append(str(summary))
     if path := properties.get("path"):
         parts.append(str(path))
+    if docs := properties.get("docs"):
+        parts.append(str(docs))
     return " ".join(parts)
 
 
@@ -165,12 +175,34 @@ class GraphStore:
     # -- schema ----------------------------------------------------------
 
     def _load_extensions(self) -> None:
-        """Install and load the FTS extension (required for full-text search)."""
+        """Install and load the FTS extension (required for full-text search).
+
+        ``INSTALL`` and ``LOAD`` are kept in separate try blocks: in
+        read-only mode ``INSTALL`` raises because it can't write the
+        extension binary, but the extension may already be installed
+        from a previous run — ``LOAD`` must still be attempted, otherwise
+        every FTS query silently falls through to substring matching.
+
+        When LOAD itself fails (e.g. LadybugDB's CDN doesn't ship the
+        extension for the current version + platform), log a single
+        warning so callers know they are degraded to substring search.
+        """
         try:
             self._conn.execute("INSTALL FTS")
+        except RuntimeError as e:
+            logger.debug("INSTALL FTS skipped: %s", e)
+        try:
             self._conn.execute("LOAD EXTENSION FTS")
-        except RuntimeError:
-            pass  # already installed/loaded
+            self._fts_loaded = True
+        except RuntimeError as e:
+            self._fts_loaded = False
+            logger.warning(
+                "FTS extension unavailable (%s) — keyword search will use "
+                "substring matching against name + search_text. To enable "
+                "full-text search, ensure the FTS extension is installed "
+                "for this LadybugDB version + platform.",
+                e,
+            )
 
     def _ensure_schema(self) -> None:
         stmts = [
@@ -225,11 +257,25 @@ class GraphStore:
         target_id: str,
         properties: dict[str, Any] | None = None,
     ) -> None:
-        """Create a directed relationship between two existing nodes."""
+        """Create a directed relationship between two existing nodes.
+
+        Raises ``RuntimeError`` if either endpoint isn't already in the
+        DB.  This is critical: without the check, a MATCH that finds no
+        rows would cause CREATE to silently do nothing, the caller
+        would treat the call as successful, and the relationship would
+        be lost without any error signal.  See
+        ``GraphStoreAdapter._flush_rels`` for the upstream invariant
+        that prevents this in the first place.
+        """
         props_json = _marshal_props(properties)
-        self._conn.execute(
+        # Append RETURN so we can observe whether MATCH+CREATE yielded
+        # any rows.  In Cypher, MATCH-then-CREATE only fires CREATE for
+        # each row that MATCH produced — if MATCH finds nothing,
+        # CREATE never runs, and RETURN comes back empty.
+        result = self._conn.execute(
             "MATCH (a:Node {id: $src}), (b:Node {id: $tgt}) "
-            "CREATE (a)-[:RELATES {id: $id, type: $type, properties: $props}]->(b)",
+            "CREATE (a)-[r:RELATES {id: $id, type: $type, properties: $props}]->(b) "
+            "RETURN r.id",
             parameters={
                 "src": source_id,
                 "tgt": target_id,
@@ -238,6 +284,14 @@ class GraphStore:
                 "props": props_json,
             },
         )
+        if not result.has_next():
+            raise RuntimeError(
+                f"Relationship {id!r} (type={rel_type!r}) not created: "
+                f"missing endpoint(s) — source={source_id!r}, target={target_id!r}. "
+                f"This usually means the relationship was flushed before "
+                f"its endpoint nodes were written. Check that "
+                f"GraphStoreAdapter._flush_rels() flushes nodes first."
+            )
 
     def merge_relationship(
         self,
@@ -441,10 +495,17 @@ class GraphStore:
         except Exception:
             logger.debug("FTS search failed, using substring fallback", exc_info=True)
 
-        # Substring fallback
+        # Substring fallback — match either the symbol name or its
+        # ``search_text`` (which already includes summary/path/docs).
+        # This keeps queries like "auth" useful when FTS is unavailable
+        # (e.g. the Ladybug FTS extension binary isn't installed for the
+        # current platform).
         q = query.lower()
         result = self._conn.execute(
-            "MATCH (n:Node) WHERE lower(n.name) CONTAINS $query AND n.type <> $meta "
+            "MATCH (n:Node) "
+            "WHERE (lower(n.name) CONTAINS $query "
+            "       OR lower(n.search_text) CONTAINS $query) "
+            "AND n.type <> $meta "
             "RETURN n.id, n.type, n.name, n.properties",
             parameters={"query": q, "meta": self._METADATA_TYPE},
         )

--- a/agent/tests/opentrace_agent/benchmarks/test_graph_accuracy.py
+++ b/agent/tests/opentrace_agent/benchmarks/test_graph_accuracy.py
@@ -119,7 +119,7 @@ class TestAssertionEngine:
         result = bench.run_task(
             {
                 "id": "test_exact_count",
-                "tool": "search_graph",
+                "tool": "keyword_search",
                 "tool_args": {"query": "zzz_nonexistent_zzz"},
                 "assertions": [{"type": "exact_count", "value": 0}],
             }
@@ -131,7 +131,7 @@ class TestAssertionEngine:
         result = bench.run_task(
             {
                 "id": "test_contains_name",
-                "tool": "search_graph",
+                "tool": "keyword_search",
                 "tool_args": {"query": "Calculator", "nodeTypes": "Class"},
                 "assertions": [{"type": "result_contains_name", "value": "Calculator"}],
             }
@@ -143,7 +143,7 @@ class TestAssertionEngine:
         result = bench.run_task(
             {
                 "id": "test_all_have_type",
-                "tool": "search_graph",
+                "tool": "keyword_search",
                 "tool_args": {"query": "app", "nodeTypes": "File"},
                 "assertions": [{"type": "all_have_type", "value": "File"}],
             }

--- a/agent/tests/opentrace_agent/graph/test_mcp_integration.py
+++ b/agent/tests/opentrace_agent/graph/test_mcp_integration.py
@@ -56,6 +56,8 @@ def indexed_go_store(tmp_path_factory):
     for _event in collect_pipeline(inp, store=adapter)[0]:
         pass
     adapter.flush()
+    # source_read/source_grep need repoPath in metadata to find files on disk.
+    store.save_metadata({"repoId": "test/go-project", "repoPath": str(GO_PROJECT)})
 
     yield store
     store.close()
@@ -72,6 +74,7 @@ def indexed_python_store(tmp_path_factory):
     for _event in collect_pipeline(inp, store=adapter)[0]:
         pass
     adapter.flush()
+    store.save_metadata({"repoId": "test/py-project", "repoPath": str(PYTHON_PROJECT)})
 
     yield store
     store.close()
@@ -183,43 +186,87 @@ class TestMCPGetStats:
 
 
 # ---------------------------------------------------------------------------
-# MCP tool: search_graph
+# MCP tool: keyword_search (formerly the flat-list version of search_graph)
 # ---------------------------------------------------------------------------
 
 
-class TestMCPSearchGraph:
+class TestMCPFindNodesViaKeywordSearch:
     def test_search_by_name(self, indexed_go_store):
-        result = _call_tool(indexed_go_store, "search_graph", query="main")
+        result = _call_tool(indexed_go_store, "keyword_search", query="main")
         assert isinstance(result, list)
         assert len(result) > 0
-        # Each result should have id, type, name
         for node in result:
             assert "id" in node
             assert "type" in node
             assert "name" in node
+            # keyword_search tags every result for caller verification
+            assert "_match_field" in node
 
     def test_search_with_type_filter(self, indexed_go_store):
-        result = _call_tool(indexed_go_store, "search_graph", query="main", nodeTypes="File")
+        result = _call_tool(indexed_go_store, "keyword_search", query="main", nodeTypes="File")
         assert isinstance(result, list)
         for node in result:
             assert node["type"] == "File"
 
     def test_search_no_results(self, indexed_go_store):
-        result = _call_tool(indexed_go_store, "search_graph", query="zzz_nonexistent_zzz")
+        result = _call_tool(indexed_go_store, "keyword_search", query="zzz_nonexistent_zzz")
         assert isinstance(result, list)
         assert len(result) == 0
 
     def test_search_respects_limit(self, indexed_go_store):
-        result = _call_tool(indexed_go_store, "search_graph", query="e", limit=2)
+        result = _call_tool(indexed_go_store, "keyword_search", query="e", limit=2)
         assert len(result) <= 2
 
     def test_search_properties_are_valid(self, indexed_go_store):
         """Properties should be dicts or None, never unparsed strings."""
-        result = _call_tool(indexed_go_store, "search_graph", query="db")
+        result = _call_tool(indexed_go_store, "keyword_search", query="db")
         for node in result:
             props = node.get("properties")
             if props is not None:
                 assert isinstance(props, dict), f"Properties should be dict, got {type(props)}: {props}"
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: search_graph (subgraph — the *real* search_graph)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPSearchGraph:
+    """search_graph now returns a SUBGRAPH around matches — both nodes
+    and the relationships between them — not a flat list."""
+
+    def test_returns_nodes_and_relationships(self, indexed_go_store):
+        result = _call_tool(indexed_go_store, "search_graph", query="main", hops=1)
+        assert isinstance(result, dict)
+        assert "nodes" in result and isinstance(result["nodes"], list)
+        assert "relationships" in result and isinstance(result["relationships"], list)
+        assert "summary" in result
+        assert result["summary"]["node_count"] == len(result["nodes"])
+        assert result["summary"]["relationship_count"] == len(result["relationships"])
+
+    def test_zero_hops_returns_only_seed_matches(self, indexed_go_store):
+        """hops=0 should still return the matched seed nodes, no expansion."""
+        zero = _call_tool(indexed_go_store, "search_graph", query="main", hops=0)
+        assert isinstance(zero, dict)
+        assert len(zero["nodes"]) > 0
+
+    def test_hops_expands_neighborhood(self, indexed_go_store):
+        """Higher hops should yield ≥ as many nodes as a smaller hop count."""
+        one = _call_tool(indexed_go_store, "search_graph", query="main", hops=1)
+        two = _call_tool(indexed_go_store, "search_graph", query="main", hops=2)
+        assert len(two["nodes"]) >= len(one["nodes"])
+
+    def test_no_match_returns_empty_subgraph(self, indexed_go_store):
+        result = _call_tool(indexed_go_store, "search_graph", query="zzz_no_such_thing")
+        assert isinstance(result, dict)
+        assert result["nodes"] == []
+        assert result["relationships"] == []
+
+    def test_hops_capped_at_5(self, indexed_python_store):
+        """Excessive hops should be silently capped, not error."""
+        result = _call_tool(indexed_python_store, "search_graph", query="Database", hops=99)
+        assert isinstance(result, dict)
+        assert result["summary"]["hops"] == 5
 
 
 # ---------------------------------------------------------------------------
@@ -408,9 +455,9 @@ class TestMCPRoundTrip:
     """Verify tools work together: search → get_node → traverse."""
 
     def test_search_then_get_then_traverse(self, indexed_go_store):
-        """Full round-trip: search for a node, get its details, traverse from it."""
-        # Search
-        search_results = _call_tool(indexed_go_store, "search_graph", query="handler")
+        """Full round-trip: find a node, get its details, traverse from it."""
+        # Find
+        search_results = _call_tool(indexed_go_store, "keyword_search", query="handler")
         assert len(search_results) > 0
 
         # Get details of first result
@@ -429,8 +476,8 @@ class TestMCPRoundTrip:
         assert isinstance(traversal, list)
 
     def test_python_class_methods_reachable(self, indexed_python_store):
-        """Search for Database class, verify its methods are reachable via traversal."""
-        classes = _call_tool(indexed_python_store, "search_graph", query="Database", nodeTypes="Class")
+        """Find Database class, verify its methods are reachable via traversal."""
+        classes = _call_tool(indexed_python_store, "keyword_search", query="Database", nodeTypes="Class")
         if not classes:
             pytest.skip("Database class not found")
 
@@ -441,6 +488,358 @@ class TestMCPRoundTrip:
         # Neighbors should include methods or the file it's defined in
         neighbor_types = {n["relationship"]["type"] for n in details["neighbors"]}
         assert len(neighbor_types) > 0
+
+    def test_search_graph_returns_subgraph_with_neighbors(self, indexed_python_store):
+        """The new search_graph should include both nodes and the
+        relationships connecting them — proves the subgraph wiring."""
+        result = _call_tool(indexed_python_store, "search_graph", query="Database", hops=1)
+        assert isinstance(result, dict)
+        assert len(result["nodes"]) > 0
+        # With hops=1, we should pull in at least one related node, so
+        # there should be at least one relationship in the subgraph.
+        assert len(result["relationships"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: keyword_search (renamed from semantic_search — never was)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPKeywordSearch:
+    def test_returns_results(self, indexed_python_store):
+        result = _call_tool(indexed_python_store, "keyword_search", query="database")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_respects_node_types(self, indexed_python_store):
+        result = _call_tool(indexed_python_store, "keyword_search", query="user", nodeTypes="Function")
+        assert isinstance(result, list)
+        for node in result:
+            assert node["type"] == "Function"
+
+    def test_respects_limit(self, indexed_go_store):
+        result = _call_tool(indexed_go_store, "keyword_search", query="handler", limit=2)
+        assert len(result) <= 2
+
+    def test_natural_language_query_finds_results(self, indexed_python_store):
+        """Multi-word natural-language query should still hit nodes via tokenization.
+
+        The python fixture has a Database class. A phrase like
+        ``"functions that connect to the database"`` previously returned []
+        because FTS treated it as a phrase; the tokenized version drops
+        stopwords + filler ("functions", "that", "to", "the"), then
+        searches per-keyword and merges.  ``database`` should still match.
+        """
+        result = _call_tool(
+            indexed_python_store,
+            "keyword_search",
+            query="functions that connect to the database",
+        )
+        assert isinstance(result, list)
+        assert len(result) > 0, "tokenized query should have matched on 'database'"
+
+    def test_multi_keyword_ranks_by_match_count(self, indexed_python_store):
+        """Nodes hit by more keywords should sort first."""
+        result = _call_tool(
+            indexed_python_store,
+            "keyword_search",
+            query="user database insert",
+        )
+        assert isinstance(result, list)
+        if len(result) >= 2:
+            assert "_match_count" in result[0]
+            scores = [n.get("_match_count", 0) for n in result]
+            assert scores == sorted(scores, reverse=True)
+
+    def test_pure_stopword_query_falls_through(self, indexed_python_store):
+        """A query with no extractable keywords should still call into
+        the underlying search rather than returning [] outright."""
+        result = _call_tool(indexed_python_store, "keyword_search", query="the of a")
+        assert isinstance(result, list)
+
+    def test_results_are_tagged_with_match_field(self, indexed_python_store):
+        """Every result should carry a _match_field annotation so the LLM
+        knows whether it matched on name (high confidence) vs docs only."""
+        result = _call_tool(indexed_python_store, "keyword_search", query="database")
+        assert isinstance(result, list)
+        assert len(result) > 0
+        for node in result:
+            assert "_match_field" in node
+            assert node["_match_field"] in {
+                "name",
+                "signature",
+                "path",
+                "summary",
+                "docs",
+                "unknown",
+            }
+            # docs-only matches must carry a verify hint
+            if node["_match_field"] == "docs":
+                assert "_verify" in node
+                assert "stale" in node["_verify"].lower() or "verify" in node["_verify"].lower()
+
+
+class TestExtractQueryKeywords:
+    """Pure-function tests for the tokenizer (no DB needed)."""
+
+    def test_drops_stopwords(self):
+        from opentrace_agent.cli.mcp_server import _extract_query_keywords
+
+        assert _extract_query_keywords("the function that handles auth") == ["auth"]
+
+    def test_drops_filler_nouns(self):
+        from opentrace_agent.cli.mcp_server import _extract_query_keywords
+
+        # "function", "code", "thing" are all dropped as filler
+        assert _extract_query_keywords("function code that handles auth") == ["auth"]
+
+    def test_preserves_order_and_dedupes(self):
+        from opentrace_agent.cli.mcp_server import _extract_query_keywords
+
+        assert _extract_query_keywords("database user database query") == [
+            "database",
+            "user",
+            "query",
+        ]
+
+    def test_drops_short_tokens(self):
+        from opentrace_agent.cli.mcp_server import _extract_query_keywords
+
+        # "go" is 2 chars → dropped.  "rust" stays.
+        assert _extract_query_keywords("go rust py") == ["rust"]
+
+    def test_empty_query(self):
+        from opentrace_agent.cli.mcp_server import _extract_query_keywords
+
+        assert _extract_query_keywords("") == []
+        assert _extract_query_keywords("the of a is") == []
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: source_read
+# ---------------------------------------------------------------------------
+
+
+class TestMCPSourceRead:
+    def test_read_by_node_id(self, indexed_python_store):
+        files = _call_tool(indexed_python_store, "list_nodes", type="File", limit=10)
+        target = next((f for f in files if f["name"] == "main.py"), files[0])
+        result = create_mcp_server(indexed_python_store)._tool_manager._tools["source_read"].fn(nodeId=target["id"])
+        assert "[Could not" not in result
+        # The fixture file has at least one Python statement.
+        assert "def " in result or "from " in result or "import " in result
+
+    def test_read_by_path(self, indexed_python_store):
+        result = create_mcp_server(indexed_python_store)._tool_manager._tools["source_read"].fn(path="main.py")
+        assert "[Could not" not in result
+
+    def test_missing_path_returns_error(self, indexed_python_store):
+        result = (
+            create_mcp_server(indexed_python_store)
+            ._tool_manager._tools["source_read"]
+            .fn(path="this/file/does/not/exist.py")
+        )
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_no_args_returns_error(self, indexed_python_store):
+        result = create_mcp_server(indexed_python_store)._tool_manager._tools["source_read"].fn()
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_line_slice(self, indexed_python_store):
+        result = (
+            create_mcp_server(indexed_python_store)
+            ._tool_manager._tools["source_read"]
+            .fn(path="main.py", startLine=1, endLine=3)
+        )
+        # Numbered output prefixes lines with "<n>\t"
+        assert "1\t" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: source_grep
+# ---------------------------------------------------------------------------
+
+
+class TestMCPSourceGrep:
+    def test_finds_matches(self, indexed_python_store):
+        import shutil as _sh
+
+        if not _sh.which("rg"):
+            pytest.skip("ripgrep not installed")
+        result = create_mcp_server(indexed_python_store)._tool_manager._tools["source_grep"].fn(pattern="def ")
+        # Tagged output: "[repoId] file.py:N:line"
+        assert "[test/py-project]" in result
+
+    def test_no_matches(self, indexed_python_store):
+        import shutil as _sh
+
+        if not _sh.which("rg"):
+            pytest.skip("ripgrep not installed")
+        result = (
+            create_mcp_server(indexed_python_store)
+            ._tool_manager._tools["source_grep"]
+            .fn(pattern="this_string_should_not_appear_anywhere_zzz_xyz")
+        )
+        parsed = json.loads(result)
+        assert parsed.get("matches") == []
+
+    def test_repo_filter(self, indexed_python_store):
+        import shutil as _sh
+
+        if not _sh.which("rg"):
+            pytest.skip("ripgrep not installed")
+        result = (
+            create_mcp_server(indexed_python_store)
+            ._tool_manager._tools["source_grep"]
+            .fn(pattern="def ", repo="nonexistent-repo")
+        )
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: find_usages
+# ---------------------------------------------------------------------------
+
+
+class TestMCPFindUsages:
+    def test_finds_target(self, indexed_python_store):
+        result = _call_tool(indexed_python_store, "find_usages", symbol="Database")
+        assert "target" in result
+        assert "dependents" in result
+        assert isinstance(result["dependents"], list)
+
+    def test_unknown_symbol(self, indexed_python_store):
+        result = _call_tool(indexed_python_store, "find_usages", symbol="zzz_no_such_symbol_zzz")
+        assert "error" in result
+
+    def test_caps_depth(self, indexed_go_store):
+        result = _call_tool(indexed_go_store, "find_usages", symbol="main", depth=99)
+        # depth is capped at 5; tool should still succeed (no crash)
+        assert "target" in result or "error" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: impact_analysis
+# ---------------------------------------------------------------------------
+
+
+class TestMCPImpactAnalysis:
+    def test_finds_file(self, indexed_python_store):
+        result = _call_tool(indexed_python_store, "impact_analysis", target="db.py")
+        assert "file" in result
+        assert "symbols" in result
+        assert "total_dependents" in result
+
+    def test_unknown_file(self, indexed_python_store):
+        result = _call_tool(indexed_python_store, "impact_analysis", target="ghost_file.xyz")
+        assert "error" in result
+
+    def test_line_range_filter(self, indexed_python_store):
+        # Wide range — should still return file/symbols structure
+        result = _call_tool(indexed_python_store, "impact_analysis", target="db.py", lines="1-9999")
+        assert "file" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: repo_index
+# ---------------------------------------------------------------------------
+
+
+class TestMCPRepoIndex:
+    def test_invalid_path_returns_error(self, indexed_python_store):
+        result = (
+            create_mcp_server(indexed_python_store)
+            ._tool_manager._tools["repo_index"]
+            .fn(path_or_url="/this/path/does/not/exist/zzz_xyz")
+        )
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_file_path_rejected(self, indexed_python_store, tmp_path):
+        f = tmp_path / "not-a-dir.txt"
+        f.write_text("hi")
+        result = create_mcp_server(indexed_python_store)._tool_manager._tools["repo_index"].fn(path_or_url=str(f))
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_url_routes_to_fetch_and_index(self, indexed_python_store, monkeypatch):
+        """An https:// URL should invoke `opentraceai fetch-and-index`."""
+        import subprocess
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+
+            class _Result:
+                returncode = 0
+                stdout = "ok"
+                stderr = ""
+
+            return _Result()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        create_mcp_server(indexed_python_store, db_path="/tmp/idx.db")._tool_manager._tools["repo_index"].fn(
+            path_or_url="https://github.com/foo/bar", repoId="bar", ref="main"
+        )
+
+        cmd = captured["cmd"]
+        assert cmd[:2] == ["opentraceai", "fetch-and-index"]
+        assert "https://github.com/foo/bar" in cmd
+        assert "--repo-id" in cmd and "bar" in cmd
+        assert "--ref" in cmd and "main" in cmd
+        assert "--db" in cmd and "/tmp/idx.db" in cmd
+        # Critically: never pass --token through MCP — auth comes from the
+        # CLI's own resolver so the LLM can't see the token.
+        assert "--token" not in cmd
+
+    def test_git_ssh_url_also_routes_to_fetch_and_index(self, indexed_python_store, monkeypatch):
+        import subprocess
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+
+            class _Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Result()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        create_mcp_server(indexed_python_store)._tool_manager._tools["repo_index"].fn(
+            path_or_url="git@github.com:foo/bar.git"
+        )
+        assert captured["cmd"][:2] == ["opentraceai", "fetch-and-index"]
+
+    def test_local_path_still_uses_index(self, indexed_python_store, tmp_path, monkeypatch):
+        import subprocess
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+
+            class _Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Result()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        local = tmp_path / "src"
+        local.mkdir()
+
+        create_mcp_server(indexed_python_store)._tool_manager._tools["repo_index"].fn(path_or_url=str(local))
+        assert captured["cmd"][:2] == ["opentraceai", "index"]
 
 
 # ---------------------------------------------------------------------------

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1047,7 +1047,7 @@ wheels = [
 
 [[package]]
 name = "opentraceai"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Add MCP tools, remote indexing, and hot-reload support
🆕 **New Feature** · ✨ **Improvement** · 🐛 **Bug Fix** · 🧪 **Tests**

Adds a comprehensive suite of MCP tools for agents to search, read, and analyze codebases alongside support for remote repository indexing. It stabilizes the indexing pipeline to prevent relationship data loss and implements a hot-reload strategy for concurrent indexing and querying.

### Complexity
🟠 High · `12 files changed, 1414 insertions(+), 72 deletions(-)`

This PR spans the entire stack, modifying the low-level database adapter, the indexing pipeline logic, and the high-level MCP tool definitions. It introduces a new architectural pattern for database hot-reloading and handles remote repository state management, which significantly increases the system's complexity and statefulness.

### Tests
🧪 Includes thorough integration tests for all MCP tools and verifies the hot-reload database proxy using real fixtures.

### Note
⚠️ The indexing pipeline now strictly enforces a node-before-relationship flush order. If this is accidentally reverted in future refactors, relationships will be silently dropped by the underlying Cypher engine.

### Review focus
Pay particular attention to the following areas:

- **Indexing atomicity** — verify the `_ReloadableStore` proxy correctly handles inode changes without leaking file descriptors.
- **Relationship integrity** — check the `GraphStoreAdapter` flush logic to ensure endpoint nodes are always persisted before their edges.
- **Subprocess safety** — review the `repo_index` and `source_grep` tools for safe handling of shell commands and user-provided paths.

---

<details>
<summary><strong>Additional details</strong></summary>

### Database Concurrency & Hot-Reload
LadybugDB (backed by Kuzu) uses exclusive file locking, which previously prevented the `index` CLI from running while the MCP server was active. This PR implements a staging-and-swap strategy:
* The indexer writes to `index.db.staging`.
* Once complete, it uses `os.replace` to atomically move the staging file over the live database.
* The `_ReloadableStore` proxy detects this change via inode monitoring and transparently reopens the database without dropping the MCP connection.

### Pipeline Reliability
We identified a significant data loss issue where approximately 15% of relationships were missing from indexes. This occurred because the `GraphStoreAdapter` would occasionally flush relationship buffers while the corresponding endpoint nodes were still sitting in the node buffer. Since Cypher's `MATCH...CREATE` pattern silently fails if endpoints don't exist, these edges were lost. The adapter now enforces a strict "flush nodes before relationships" invariant.

### Search Tokenization
The `keyword_search` tool addresses a common failure mode in FTS where natural language queries (e.g., "functions that handle auth") fail to match literal symbol names. It tokenizes the query, strips common English stopwords and LLM-injected filler nouns (like "code" or "function"), and performs a merged, ranked search across the remaining high-signal keywords.

</details>
<!-- opentrace:jid=bdf0819e-e71b-456c-a86e-b8f1679b82ec|sha=bf0b137dc6602148b7c444dc06bfc4a67393ca00 -->