### PR TITLE
refactor(ui): lift graph state into context providers

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,17 +22,14 @@ import type { GraphViewerHandle } from './appComponents/GraphViewer';
 import ChatPanel from './appComponents/ChatPanel';
 import SettingsDrawer from './appComponents/SettingsDrawer';
 import HelpDrawer from './appComponents/HelpDrawer';
-import type { GraphNode, GraphLink } from '@opentrace/components/utils';
+import SidePanel, { type SidePanelTab } from './appComponents/SidePanel';
 import { loadAnimationSettings } from './config/animation';
 import { normalizeRepoUrl, detectProvider } from '@opentrace/components';
 import type { AnimationSettings } from '@opentrace/components';
 import { useStore } from './store';
+import { GraphDataProvider, useGraph } from './providers/GraphDataProvider';
+import { GraphInteractionProvider } from './providers/GraphInteractionProvider';
 import './App.css';
-
-const EMPTY_GRAPH: { nodes: GraphNode[]; links: GraphLink[] } = {
-  nodes: [],
-  links: [],
-};
 
 interface AppProps {
   version?: string;
@@ -42,13 +39,24 @@ interface AppProps {
   onConnectServer?: (serverUrl: string) => void;
 }
 
-function App({
+function App(props: AppProps = {}) {
+  return (
+    <GraphDataProvider>
+      <GraphInteractionProvider>
+        <AppInner {...props} />
+      </GraphInteractionProvider>
+    </GraphDataProvider>
+  );
+}
+
+function AppInner({
   version,
   buildTime,
   initialRepoUrl,
   onConnectServer,
-}: AppProps = {}) {
+}: AppProps) {
   const { store } = useStore();
+  const { loadGraph } = useGraph();
   const jobService = useJobService();
   const {
     state: jobState,
@@ -59,7 +67,6 @@ function App({
   } = useJobStream(jobService);
 
   const graphViewerRef = useRef<GraphViewerHandle>(null);
-  const [chatGraphData, setChatGraphData] = useState(EMPTY_GRAPH);
   const [chatHighlightNodes, setChatHighlightNodes] = useState<Set<string>>(
     () => new Set(),
   );
@@ -79,6 +86,9 @@ function App({
   const [showAddRepo, setShowAddRepo] = useState(false);
   const [activeRepoUrl, setActiveRepoUrl] = useState('');
   const [jobExpanded, setJobExpanded] = useState(false);
+  const [mobilePanelTab, setMobilePanelTab] = useState<SidePanelTab | null>(
+    null,
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({
     width: window.innerWidth,
@@ -131,7 +141,7 @@ function App({
 
       if (existing) {
         setActiveRepoUrl(repoUrl);
-        await graphViewerRef.current?.reload(existing.id, 2);
+        await loadGraph(existing.id, 2);
         setTimeout(() => graphViewerRef.current?.selectNode(existing.id), 100);
       } else {
         const provider = detectProvider(repoUrl);
@@ -145,7 +155,7 @@ function App({
         });
       }
     },
-    [store, handleJobSubmit],
+    [store, handleJobSubmit, loadGraph],
   );
 
   // Handle initial repository on load (from prop or ?repo= param)
@@ -287,13 +297,19 @@ function App({
           onToggleSettings={handleToggleSettings}
           showHelp={showHelp}
           onToggleHelp={handleToggleHelp}
-          onGraphDataChange={setChatGraphData}
           chatHighlightNodes={chatHighlightNodes}
           animationSettings={animationSettings}
           graphFullscreen={isMobile ? graphFullscreen : undefined}
           onToggleGraphFullscreen={
             isMobile ? handleToggleGraphFullscreen : undefined
           }
+          onMobilePanelTabChange={setMobilePanelTab}
+        />
+
+        <SidePanel
+          mobileActiveTab={mobilePanelTab}
+          onMobileTabChange={setMobilePanelTab}
+          onMobileClose={() => setMobilePanelTab(null)}
         />
 
         {showChat && (
@@ -303,7 +319,6 @@ function App({
             }
           >
             <ChatPanel
-              graphData={chatGraphData}
               onClose={() => setShowChat(false)}
               onNodeSelect={(nodeId) => {
                 graphViewerRef.current?.selectNode(nodeId);
@@ -319,7 +334,7 @@ function App({
               }}
               onGraphChange={async (focusNodeId) => {
                 // Reload scoped to the PR node — 2 hops shows PR → Files → their neighbors
-                await graphViewerRef.current?.reload(focusNodeId, 2);
+                await loadGraph(focusNodeId, 2);
                 if (focusNodeId) {
                   // Wait for React to commit the re-render with new graph data
                   setTimeout(() => {
@@ -357,9 +372,9 @@ function App({
           onClose={() => setShowSettings(false)}
           onGraphCleared={() => {
             setShowSettings(false);
-            graphViewerRef.current?.reload();
+            loadGraph();
           }}
-          onLimitsChanged={() => graphViewerRef.current?.reload()}
+          onLimitsChanged={() => loadGraph()}
           onAnimationSettingsChanged={setAnimationSettings}
         />
       )}

--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -15,7 +15,6 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { GraphNode, GraphLink } from '@opentrace/components/utils';
 import {
   PROVIDERS,
   PROVIDER_IDS,
@@ -54,6 +53,7 @@ import {
 import { HumanMessage, AIMessage } from '@langchain/core/messages';
 import type { AIMessageChunk } from '@langchain/core/messages';
 import { useStore } from '../store';
+import { useGraph } from '../providers/GraphDataProvider';
 import { PRClient, parseRepoUrl } from '../pr/client';
 import { useResizablePanel } from '../hooks/useResizablePanel';
 import { PanelResizeHandle } from '@opentrace/components';
@@ -82,7 +82,6 @@ function TokenUsageFooter({ usage }: { usage: TokenUsage }) {
 type TabId = 'chat' | 'prs';
 
 interface Props {
-  graphData: { nodes: GraphNode[]; links: GraphLink[] };
   onClose: () => void;
   onNodeSelect?: (nodeId: string) => void;
   onGraphChange?: (focusNodeId?: string) => Promise<void>;
@@ -97,7 +96,6 @@ interface Props {
 }
 
 export default function ChatPanel({
-  graphData,
   onClose,
   onNodeSelect,
   onGraphChange,
@@ -108,6 +106,7 @@ export default function ChatPanel({
   settingsFooter,
 }: Props) {
   const { store } = useStore();
+  const { graphData } = useGraph();
 
   const panelRef = useRef<HTMLDivElement>(null);
   const { width: panelWidth, handleMouseDown } = useResizablePanel({
@@ -324,10 +323,7 @@ export default function ChatPanel({
   const getAgentHandle = (): AgentHandle => {
     const key = `${providerId}:${modelId}:${apiKey}:${localUrl}:${repoUrl ?? ''}`;
     if (agentKeyRef.current !== key || !agentRef.current) {
-      const systemPrompt = buildGraphContext(
-        graphData.nodes as GraphNode[],
-        graphData.links as GraphLink[],
-      );
+      const systemPrompt = buildGraphContext(graphData.nodes, graphData.links);
       agentRef.current = createChatAgent(
         providerId,
         modelId,

--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -508,7 +508,6 @@ const GraphViewer = memo(
         setHiddenNodeTypes,
         hiddenLinkTypes,
         hiddenSubTypes,
-        setHiddenSubTypes,
         hiddenCommunities,
         setHiddenCommunities,
         colorMode,
@@ -528,8 +527,6 @@ const GraphViewer = memo(
       const [showResetConfirm, setShowResetConfirm] = useState(false);
       const [showExportModal, setShowExportModal] = useState(false);
       const [exporting, setExporting] = useState(false);
-      // Track whether we've applied the default Dependency hiding
-      const defaultsApplied = useRef(false);
 
       // Append chat-highlighted nodes to session history
       useEffect(() => {
@@ -728,21 +725,6 @@ const GraphViewer = memo(
         [repulsion],
       );
 
-      // On first data load, hide all Dependency sub-types by default
-      useEffect(() => {
-        if (defaultsApplied.current) return;
-        const depSubs = availableSubTypes.get('Dependency');
-        if (depSubs && depSubs.length > 0) {
-          defaultsApplied.current = true;
-          // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional one-time default init
-          setHiddenSubTypes((prev) => {
-            const next = new Set(prev);
-            depSubs.forEach((s) => next.add(`Dependency:${s.subType}`));
-            return next;
-          });
-        }
-      }, [availableSubTypes, setHiddenSubTypes]);
-
       const onNodeClick = useCallback(
         (node: GraphNode) => {
           setSelectedNode(node);
@@ -809,17 +791,27 @@ const GraphViewer = memo(
         (edge: SelectedEdge) => {
           setSelectedLink(edge);
           setSelectedNode(null);
-          // Highlight the two endpoints and the clicked link
-          const sourceId = edge.source;
-          const targetId = edge.target;
-          setEdgeHighlightNodes(new Set([sourceId, targetId]));
-          setEdgeHighlightLinks(new Set([`${sourceId}-${targetId}`]));
-          setEdgeLabelNodes(new Set([sourceId, targetId]));
-          // Zoom to fit the two endpoints
-          canvasRef.current?.zoomToNodes([sourceId, targetId], 600);
         },
         [setSelectedLink, setSelectedNode],
       );
+
+      // Sync canvas-side edge highlights + zoom to whichever edge is selected
+      // — works for both the canvas-click path (onLinkClick) and the
+      // SidePanel "select edge from node details" path (which writes to
+      // context's selectedLink directly via the provider's selectLink helper).
+      useEffect(() => {
+        if (!selectedLink) {
+          setEdgeHighlightNodes(EMPTY_SET);
+          setEdgeHighlightLinks(EMPTY_SET);
+          setEdgeLabelNodes(EMPTY_SET);
+          return;
+        }
+        const { source: sourceId, target: targetId } = selectedLink;
+        setEdgeHighlightNodes(new Set([sourceId, targetId]));
+        setEdgeHighlightLinks(new Set([`${sourceId}-${targetId}`]));
+        setEdgeLabelNodes(new Set([sourceId, targetId]));
+        canvasRef.current?.zoomToNodes([sourceId, targetId], 600);
+      }, [selectedLink]);
 
       // Zoom to highlighted neighborhood when a node is selected,
       // or zoom to fit all nodes when deselected.

--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -15,6 +15,26 @@
  */
 
 import {
+  AddRepoModal,
+  DEFAULT_LAYOUT_CONFIG,
+  GraphLegend,
+  GraphToolbar,
+  IndexingProgress,
+  PhysicsPanel,
+  PixiGraphCanvas,
+  detectProvider,
+  normalizeRepoUrl,
+  type GraphCanvasHandle,
+  type IndexingState,
+  type SearchSuggestion,
+} from '@opentrace/components';
+import type {
+  GraphLink,
+  GraphNode,
+  SelectedEdge,
+} from '@opentrace/components/utils';
+import { getLinkColor, getNodeColor } from '@opentrace/components/utils';
+import {
   forwardRef,
   memo,
   useCallback,
@@ -24,53 +44,20 @@ import {
   useRef,
   useState,
 } from 'react';
-import type {
-  GraphNode,
-  GraphLink,
-  SelectedNode,
-  SelectedEdge,
-  FilterState,
-} from '@opentrace/components/utils';
-import {
-  getNodeColor,
-  getLinkColor,
-  useCommunities,
-  useHighlights,
-} from '@opentrace/components/utils';
-import {
-  PixiGraphCanvas,
-  GraphLegend,
-  GraphToolbar,
-  PhysicsPanel,
-  type GraphCanvasHandle,
-  type FilterItem,
-  type FilterPanelProps,
-  type SearchSuggestion,
-  DEFAULT_LAYOUT_CONFIG,
-} from '@opentrace/components';
-import type { NodeSourceResponse } from '../store/types';
-import { useStore } from '../store';
-import { useGraphData } from '../hooks/useGraphData';
-import type { JobState } from '../job';
-import type { JobMessage } from '../job';
+import { useGraph } from '../providers/GraphDataProvider';
+import { useGraphInteraction } from '../providers/GraphInteractionProvider';
+import { getSubType } from '../providers/graphFilterUtils';
+import type { JobMessage, JobState } from '../job';
 import { JobPhase } from '../job';
-import {
-  AddRepoModal,
-  IndexingProgress,
-  detectProvider,
-  normalizeRepoUrl,
-  type IndexingState,
-} from '@opentrace/components';
-import { GitHubIcon, GitLabIcon } from './providerIcons';
-import JobMinimizedBar from './JobMinimizedBar';
-import SidePanel from './SidePanel';
-import type { SidePanelTab } from './SidePanel';
-import type { HistoryEntry } from './historyTypes';
-import type { NodeEdge } from './NodeDetailsPanel';
-import ThemeSelector from './ThemeSelector';
-import { OpenTraceLogo } from './OpenTraceLogo';
-import ResetConfirmModal from './ResetConfirmModal';
+import { useStore } from '../store';
 import ExportModal from './ExportModal';
+import type { HistoryEntry } from './historyTypes';
+import JobMinimizedBar from './JobMinimizedBar';
+import { OpenTraceLogo } from './OpenTraceLogo';
+import { GitHubIcon, GitLabIcon } from './providerIcons';
+import ResetConfirmModal from './ResetConfirmModal';
+import type { SidePanelTab } from './SidePanel';
+import ThemeSelector from './ThemeSelector';
 
 const INDEXING_STAGES = [
   { key: String(JobPhase.JOB_PHASE_INITIALIZING), label: 'Initializing' },
@@ -117,47 +104,9 @@ function toIndexingProps(job: JobState, repoUrl: string) {
   return { state, title, message, icon };
 }
 
-/** Node types whose source code can be fetched and displayed. */
-const SOURCE_TYPES = new Set(['File', 'Function', 'Class', 'PullRequest']);
 // WARNING: Module-level singleton — do NOT mutate (add/delete). Used as a
 // stable empty default for highlight props to avoid unnecessary re-renders.
 const EMPTY_SET: Set<string> = Object.freeze(new Set<string>()) as Set<string>;
-
-/**
- * Extract a sub-type value from a node based on its type.
- * Returns null if no meaningful sub-type can be derived.
- */
-function getSubType(node: GraphNode): string | null {
-  if (node.type === 'File') {
-    const name = node.name || node.id;
-    const lastDot = name.lastIndexOf('.');
-    if (lastDot > 0) return name.slice(lastDot); // e.g. ".ts", ".go"
-    return null;
-  }
-  if (node.type === 'Function' || node.type === 'Class') {
-    const lang = node.properties?.language as string | undefined;
-    return lang || null;
-  }
-  if (node.type === 'Dependency') {
-    const registry = node.properties?.registry as string | undefined;
-    return registry || null;
-  }
-  if (node.type === 'Variable') {
-    const kind = node.properties?.kind as string | undefined;
-    return kind || null;
-  }
-  return null;
-}
-
-/**
- * Extract the string ID from a link endpoint.
- * GraphLink endpoints are always strings in our data model,
- * but we keep this helper for safety.
- */
-function linkId(endpoint: string | number | GraphNode | undefined): string {
-  if (typeof endpoint === 'object' && endpoint !== null) return endpoint.id;
-  return String(endpoint);
-}
 
 // GraphLegend is now imported from @opentrace/components
 
@@ -355,9 +304,7 @@ function HelpMenuButton({
 }
 
 export interface GraphViewerHandle {
-  graphData: { nodes: GraphNode[]; links: GraphLink[] };
   selectNode: (nodeId: string, hops?: number) => void;
-  reload: (query?: string, hops?: number) => Promise<void>;
   triggerPing: (nodeIds: Iterable<string>) => void;
   resetCamera: () => void;
   zoomToFit: (duration?: number) => void;
@@ -387,11 +334,6 @@ export interface GraphViewerProps {
   onToggleSettings: () => void;
   showHelp: boolean;
   onToggleHelp: () => void;
-  /** Called when graphData changes so parent can pass it reactively to siblings */
-  onGraphDataChange?: (data: {
-    nodes: GraphNode[];
-    links: GraphLink[];
-  }) => void;
   /** Node IDs found by chat tool results — highlighted when no other selection is active */
   chatHighlightNodes?: Set<string>;
   /** Animation settings from SettingsDrawer */
@@ -403,6 +345,8 @@ export interface GraphViewerProps {
   graphFullscreen?: boolean;
   /** Mobile: toggle graph fullscreen */
   onToggleGraphFullscreen?: () => void;
+  /** Mobile: open SidePanel on a given tab (state lives in App). */
+  onMobilePanelTabChange?: (tab: SidePanelTab) => void;
 }
 
 const GraphViewer = memo(
@@ -429,12 +373,12 @@ const GraphViewer = memo(
         onToggleSettings,
         showHelp,
         onToggleHelp,
-        onGraphDataChange,
         chatHighlightNodes,
         animationSettings,
         toolbarActions,
         graphFullscreen,
         onToggleGraphFullscreen,
+        onMobilePanelTabChange,
       } = props;
 
       const { store } = useStore();
@@ -486,20 +430,11 @@ const GraphViewer = memo(
       //
       // Known limitation: if the `persisted` loadGraph is still in-flight
       // when `done` fires (tiny repos with near-instant embedding + slow
-      // fetchGraph), the wrong callback may consume the flag. The window
+      // fetchGraph), the wrong increment may consume the flag. The window
       // is small in practice — embedding typically dominates `fetchGraph`
       // by orders of magnitude — so we accept the race rather than thread
-      // per-promise suppression tokens through useGraphData.
+      // per-promise suppression tokens through useGraph.
       const suppressNextFitRef = useRef(false);
-      const onGraphLoaded = useCallback(() => {
-        if (suppressNextFitRef.current) {
-          suppressNextFitRef.current = false;
-          return;
-        }
-        // scheduleAutoFit is throttled and gated by the user's pan/zoom state,
-        // so this is a no-op if the user has already moved the camera.
-        canvasRef.current?.scheduleAutoFit?.(400);
-      }, []);
 
       const {
         graphData,
@@ -510,18 +445,40 @@ const GraphViewer = memo(
         graphVersion,
         loadGraph,
         setError,
-      } = useGraphData(onGraphLoaded);
+      } = useGraph();
 
-      // Keep a ref to latest graphData so imperative selectNode always reads fresh data
+      // Pointer to the same graphData object the provider holds — not a copy.
+      // useRef stores the reference (`ref.current === graphData`); the nodes
+      // and links arrays exist on the heap exactly once.
+      //
+      // Why we don't just read `graphData` from useGraph() at each call site:
+      // useImperativeHandle, the narrow-dep chat-highlight effect, and
+      // handleSelectEdgeFromNode all need *stable identity* but must see the
+      // *latest* data. Reading `graphData` directly inside those closures
+      // would force it into their dependency arrays, re-creating the
+      // handle/callback on every load and re-firing effects (which would
+      // duplicate history entries, churn the imperative handle, etc.).
+      // The ref lets stale closures dereference the current pointer without
+      // subscribing.
       const graphDataRef = useRef(graphData);
       useEffect(() => {
         graphDataRef.current = graphData;
       }, [graphData]);
 
-      // Notify parent when graphData changes (for reactive sibling props like ChatPanel)
+      // Auto-fit after each successful graph load (graphVersion bumps on success).
+      // The post-embedding reload (which only attaches vector properties without
+      // changing graph structure) sets `suppressNextFitRef` to skip the next
+      // auto-fit so the user's existing camera position isn't disturbed.
       useEffect(() => {
-        onGraphDataChange?.(graphData);
-      }, [graphData, onGraphDataChange]);
+        if (graphVersion === 0) return;
+        if (suppressNextFitRef.current) {
+          suppressNextFitRef.current = false;
+          return;
+        }
+        // scheduleAutoFit is throttled and gated by the user's pan/zoom state,
+        // so this is a no-op if the user has already moved the camera.
+        canvasRef.current?.scheduleAutoFit?.(400);
+      }, [graphVersion]);
 
       // Compute edges between chat-highlighted nodes
       const chatHighlightLinks = useMemo(() => {
@@ -539,35 +496,40 @@ const GraphViewer = memo(
         return links;
       }, [graphData.links, chatHighlightNodes]);
 
-      const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(
-        null,
-      );
-      const [selectedLink, setSelectedLink] = useState<SelectedEdge | null>(
-        null,
-      );
-      const [searchQuery, setSearchQuery] = useState('');
+      // Selection, filter state, history, search/hops, and derived data all
+      // live in GraphInteractionProvider so SidePanel can sit as a sibling.
+      const {
+        selectedNode,
+        setSelectedNode,
+        selectedLink,
+        setSelectedLink,
+        setNodeHistory,
+        hiddenNodeTypes,
+        setHiddenNodeTypes,
+        hiddenLinkTypes,
+        hiddenSubTypes,
+        setHiddenSubTypes,
+        hiddenCommunities,
+        setHiddenCommunities,
+        colorMode,
+        setColorMode,
+        searchQuery,
+        setSearchQuery,
+        hops,
+        setHops,
+        focusedCommunityNodes,
+        setFocusedCommunityNodes,
+        availableSubTypes,
+        communityData,
+        filteredGraphData,
+        highlights,
+      } = useGraphInteraction();
+
       const [showResetConfirm, setShowResetConfirm] = useState(false);
       const [showExportModal, setShowExportModal] = useState(false);
-      const [mobilePanelTab, setMobilePanelTab] = useState<SidePanelTab | null>(
-        null,
-      );
-      const [hops, setHops] = useState(2);
       const [exporting, setExporting] = useState(false);
-      const [hiddenNodeTypes, setHiddenNodeTypes] = useState(new Set<string>());
-      const [hiddenLinkTypes, setHiddenLinkTypes] = useState(new Set<string>());
-      const [hiddenSubTypes, setHiddenSubTypes] = useState(new Set<string>());
-      const [hiddenCommunities, setHiddenCommunities] = useState(
-        new Set<number>(),
-      );
       // Track whether we've applied the default Dependency hiding
       const defaultsApplied = useRef(false);
-      const [nodeSource, setNodeSource] = useState<NodeSourceResponse | null>(
-        null,
-      );
-      const [sourceLoading, setSourceLoading] = useState(false);
-      const [sourceError, setSourceError] = useState<string | null>(null);
-
-      const [nodeHistory, setNodeHistory] = useState<HistoryEntry[]>([]);
 
       // Append chat-highlighted nodes to session history
       useEffect(() => {
@@ -591,7 +553,7 @@ const GraphViewer = memo(
           if (newEntries.length === 0) return prev;
           return [...newEntries, ...prev].slice(0, 500);
         });
-      }, [chatHighlightNodes]);
+      }, [chatHighlightNodes, setNodeHistory]);
 
       const pendingMinimize = useRef(false);
       const minimizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -608,10 +570,6 @@ const GraphViewer = memo(
       const [edgeLabelNodes, setEdgeLabelNodes] = useState<Set<string>>(
         new Set(),
       );
-
-      // Community-focus highlight override state
-      const [focusedCommunityNodes, setFocusedCommunityNodes] =
-        useState<Set<string>>(EMPTY_SET);
 
       // Active search filter — stored as data so we can re-apply it
       const [activeFilter, setActiveFilter] = useState<{
@@ -770,58 +728,6 @@ const GraphViewer = memo(
         [repulsion],
       );
 
-      // Compute Louvain communities on the full graph (before filtering, so
-      // community assignments are available for the community filter).
-      const communityData = useCommunities(
-        graphData.nodes,
-        graphData.links,
-        layoutConfig,
-      );
-
-      // Derive available types from raw graph data (for filter panel)
-      const availableNodeTypes = useMemo(() => {
-        const counts: Record<string, number> = {};
-        graphData.nodes.forEach((n) => {
-          counts[n.type] = (counts[n.type] || 0) + 1;
-        });
-        return Object.entries(counts)
-          .map(([type, count]) => ({ type, count }))
-          .sort((a, b) => b.count - a.count);
-      }, [graphData.nodes]);
-
-      const availableLinkTypes = useMemo(() => {
-        const counts: Record<string, number> = {};
-        graphData.links.forEach((l) => {
-          const label = (l as unknown as GraphLink).label || 'unknown';
-          counts[label] = (counts[label] || 0) + 1;
-        });
-        return Object.entries(counts)
-          .map(([type, count]) => ({ type, count }))
-          .sort((a, b) => b.count - a.count);
-      }, [graphData.links]);
-
-      // Derive sub-type counts grouped by node type (for filter panel)
-      const availableSubTypes = useMemo(() => {
-        const map = new Map<string, Record<string, number>>();
-        graphData.nodes.forEach((n) => {
-          const sub = getSubType(n);
-          if (!sub) return;
-          if (!map.has(n.type)) map.set(n.type, {});
-          const counts = map.get(n.type)!;
-          counts[sub] = (counts[sub] || 0) + 1;
-        });
-        const result = new Map<string, { subType: string; count: number }[]>();
-        map.forEach((counts, type) => {
-          result.set(
-            type,
-            Object.entries(counts)
-              .map(([subType, count]) => ({ subType, count }))
-              .sort((a, b) => b.count - a.count),
-          );
-        });
-        return result;
-      }, [graphData.nodes]);
-
       // On first data load, hide all Dependency sub-types by default
       useEffect(() => {
         if (defaultsApplied.current) return;
@@ -835,99 +741,37 @@ const GraphViewer = memo(
             return next;
           });
         }
-      }, [availableSubTypes]);
+      }, [availableSubTypes, setHiddenSubTypes]);
 
-      // Apply type + sub-type + community filters to produce the rendered graph.
-      const filteredGraphData = useMemo(() => {
-        const nodes = graphData.nodes.filter((n) => {
-          // Community filter (when any communities are hidden)
-          if (hiddenCommunities.size > 0) {
-            const cid = communityData.assignments[n.id];
-            if (cid !== undefined && hiddenCommunities.has(cid)) return false;
-          }
-          const hasSubTypeFilters = availableSubTypes.has(n.type);
-          if (hasSubTypeFilters) {
-            const sub = getSubType(n);
-            if (sub) {
-              return !hiddenSubTypes.has(`${n.type}:${sub}`);
-            }
-            const subs = availableSubTypes.get(n.type)!;
-            const allHidden = subs.every((s) =>
-              hiddenSubTypes.has(`${n.type}:${s.subType}`),
-            );
-            return !allHidden;
-          }
-          return !hiddenNodeTypes.has(n.type);
-        });
-        const visibleNodeIds = new Set(nodes.map((n) => n.id));
-        const links = graphData.links.filter((l) => {
-          const sourceId = linkId(l.source);
-          const targetId = linkId(l.target);
-          const label = (l as unknown as GraphLink).label || 'unknown';
-          return (
-            visibleNodeIds.has(sourceId) &&
-            visibleNodeIds.has(targetId) &&
-            !hiddenLinkTypes.has(label)
-          );
-        });
-        return { nodes, links };
-      }, [
-        graphData,
-        hiddenNodeTypes,
-        hiddenLinkTypes,
-        hiddenSubTypes,
-        hiddenCommunities,
-        communityData.assignments,
-        availableSubTypes,
-      ]);
-
-      // Build filterState for the new hooks
-      const filterState: FilterState = useMemo(
-        () => ({
-          hiddenNodeTypes,
-          hiddenLinkTypes,
-          hiddenSubTypes,
-          hiddenCommunities,
-        }),
-        [hiddenNodeTypes, hiddenLinkTypes, hiddenSubTypes, hiddenCommunities],
-      );
-
-      const onNodeClick = useCallback((node: GraphNode) => {
-        setSelectedNode(node);
-        setSelectedLink(null);
-        // Clear edge-click and community-focus highlights (use stable empty sets)
-        setEdgeHighlightNodes(EMPTY_SET);
-        setEdgeHighlightLinks(EMPTY_SET);
-        setEdgeLabelNodes(EMPTY_SET);
-        setFocusedCommunityNodes(EMPTY_SET);
-        // Record in session history (skip consecutive duplicates)
-        setNodeHistory((prev) => {
-          if (prev.length > 0 && prev[0].id === node.id) return prev;
-          const entry: HistoryEntry = {
-            id: node.id,
-            name: node.name,
-            type: node.type,
-            timestamp: Date.now(),
-            source: 'user',
-          };
-          return [entry, ...prev].slice(0, 500);
-        });
-        // Zoom is handled by the effect below after highlights are computed
-      }, []);
-
-      const onCommunityFocus = useCallback(
-        (key: string) => {
-          const cid = Number(key);
-          const nodeIds = Object.entries(communityData.assignments)
-            .filter(([, id]) => id === cid)
-            .map(([nodeId]) => nodeId);
-          if (nodeIds.length > 0) {
-            setFocusedCommunityNodes(new Set(nodeIds));
-            setSelectedNode(null);
-            setSelectedLink(null);
-          }
+      const onNodeClick = useCallback(
+        (node: GraphNode) => {
+          setSelectedNode(node);
+          setSelectedLink(null);
+          // Clear edge-click and community-focus highlights (use stable empty sets)
+          setEdgeHighlightNodes(EMPTY_SET);
+          setEdgeHighlightLinks(EMPTY_SET);
+          setEdgeLabelNodes(EMPTY_SET);
+          setFocusedCommunityNodes(EMPTY_SET);
+          // Record in session history (skip consecutive duplicates)
+          setNodeHistory((prev) => {
+            if (prev.length > 0 && prev[0].id === node.id) return prev;
+            const entry: HistoryEntry = {
+              id: node.id,
+              name: node.name,
+              type: node.type,
+              timestamp: Date.now(),
+              source: 'user',
+            };
+            return [entry, ...prev].slice(0, 500);
+          });
+          // Zoom is handled by the effect below after highlights are computed
         },
-        [communityData.assignments],
+        [
+          setSelectedNode,
+          setSelectedLink,
+          setFocusedCommunityNodes,
+          setNodeHistory,
+        ],
       );
 
       // Zoom camera to focused community nodes when they change
@@ -941,7 +785,6 @@ const GraphViewer = memo(
       useImperativeHandle(
         ref,
         () => ({
-          graphData,
           selectNode: (nodeId: string, nodeHops?: number) => {
             if (nodeHops !== undefined) setHops(nodeHops);
             const node = graphDataRef.current.nodes.find(
@@ -949,7 +792,6 @@ const GraphViewer = memo(
             );
             if (node) onNodeClick(node);
           },
-          reload: (query?: string, hops?: number) => loadGraph(query, hops),
           triggerPing: (nodeIds: Iterable<string>) => {
             canvasRef.current?.triggerPing?.(nodeIds);
           },
@@ -960,135 +802,23 @@ const GraphViewer = memo(
             canvasRef.current?.zoomToFit(duration);
           },
         }),
-        [graphData, loadGraph, onNodeClick],
+        [onNodeClick, setHops],
       );
 
-      const onLinkClick = useCallback((edge: SelectedEdge) => {
-        setSelectedLink(edge);
-        setSelectedNode(null);
-        // Highlight the two endpoints and the clicked link
-        const sourceId = edge.source;
-        const targetId = edge.target;
-        setEdgeHighlightNodes(new Set([sourceId, targetId]));
-        setEdgeHighlightLinks(new Set([`${sourceId}-${targetId}`]));
-        setEdgeLabelNodes(new Set([sourceId, targetId]));
-        // Zoom to fit the two endpoints
-        canvasRef.current?.zoomToNodes([sourceId, targetId], 600);
-      }, []);
-
-      // Fetch source code when a source-bearing node is selected.
-      /* eslint-disable react-hooks/set-state-in-effect -- async fetch pattern with cleanup */
-      useEffect(() => {
-        if (!selectedNode || !SOURCE_TYPES.has(selectedNode.type)) {
-          setNodeSource(null);
-          setSourceError(null);
-          return;
-        }
-
-        let cancelled = false;
-        setSourceLoading(true);
-        setSourceError(null);
-        setNodeSource(null);
-
-        const startLine = selectedNode.properties?.startLine as
-          | number
-          | undefined;
-        const endLine = selectedNode.properties?.endLine as number | undefined;
-
-        store
-          .fetchSource(selectedNode.id, startLine, endLine)
-          .then((src) => {
-            if (!cancelled) {
-              if (src) setNodeSource(src);
-              else setSourceError('Source not available');
-            }
-          })
-          .catch((err) => {
-            if (cancelled) return;
-            // Swallow AbortError — clearGraph fired mid-fetch, expected.
-            if (err?.name === 'AbortError') return;
-            setSourceError(err.message);
-          })
-          .finally(() => {
-            if (!cancelled) setSourceLoading(false);
-          });
-
-        return () => {
-          cancelled = true;
-        };
-      }, [selectedNode?.id, store]); // eslint-disable-line react-hooks/exhaustive-deps
-      /* eslint-enable react-hooks/set-state-in-effect */
-
-      // Compute edges connected to the selected node for the details panel
-      const selectedNodeEdges = useMemo(() => {
-        if (!selectedNode) return [];
-        const nodeId = selectedNode.id;
-        const nodeMap = new Map(filteredGraphData.nodes.map((n) => [n.id, n]));
-        return filteredGraphData.links
-          .filter(
-            (l) => linkId(l.source) === nodeId || linkId(l.target) === nodeId,
-          )
-          .map((l) => {
-            const sourceId = linkId(l.source);
-            const targetId = linkId(l.target);
-            const isOutgoing = sourceId === nodeId;
-            const otherId = isOutgoing ? targetId : sourceId;
-            const otherNode = nodeMap.get(otherId);
-            return {
-              label: l.label,
-              direction: isOutgoing
-                ? ('outgoing' as const)
-                : ('incoming' as const),
-              otherNodeId: otherId,
-              otherNodeName: otherNode?.name ?? otherId,
-              otherNodeType: otherNode?.type,
-              properties: l.properties,
-            };
-          });
-      }, [selectedNode, filteredGraphData.nodes, filteredGraphData.links]);
-
-      // Convert a NodeEdge back to a SelectedEdge and trigger edge selection
-      const handleSelectEdgeFromNode = useCallback(
-        (edge: NodeEdge) => {
-          if (!selectedNode) return;
-          const nodeMap = new Map(
-            graphDataRef.current.nodes.map((n) => [n.id, n]),
-          );
-          const sourceId =
-            edge.direction === 'outgoing' ? selectedNode.id : edge.otherNodeId;
-          const targetId =
-            edge.direction === 'outgoing' ? edge.otherNodeId : selectedNode.id;
-          onLinkClick({
-            source: sourceId,
-            target: targetId,
-            label: edge.label,
-            properties: edge.properties,
-            sourceNode: nodeMap.get(sourceId),
-            targetNode: nodeMap.get(targetId),
-          });
+      const onLinkClick = useCallback(
+        (edge: SelectedEdge) => {
+          setSelectedLink(edge);
+          setSelectedNode(null);
+          // Highlight the two endpoints and the clicked link
+          const sourceId = edge.source;
+          const targetId = edge.target;
+          setEdgeHighlightNodes(new Set([sourceId, targetId]));
+          setEdgeHighlightLinks(new Set([`${sourceId}-${targetId}`]));
+          setEdgeLabelNodes(new Set([sourceId, targetId]));
+          // Zoom to fit the two endpoints
+          canvasRef.current?.zoomToNodes([sourceId, targetId], 600);
         },
-        [selectedNode, onLinkClick],
-      );
-
-      // Compute degree (connection count) per node for size scaling
-      const graphNodeIds = useMemo(
-        () => graphData.nodes.map((n) => n.id as string),
-        [graphData.nodes],
-      );
-
-      const [colorMode, setColorMode] = useState<'type' | 'community'>('type');
-
-      // ─── Highlights (computed from arrays) ────────────────────────────
-
-      const highlights = useHighlights(
-        null as never, // _graph — unused
-        false, // _layoutReady — unused
-        graphData.nodes,
-        graphData.links,
-        searchQuery,
-        selectedNode?.id ?? null,
-        hops,
-        filterState,
+        [setSelectedLink, setSelectedNode],
       );
 
       // Zoom to highlighted neighborhood when a node is selected,
@@ -1112,11 +842,6 @@ const GraphViewer = memo(
         focusedCommunityNodes.size,
       ]);
 
-      const hopMap = useMemo(() => {
-        if (selectedLink) return new Map<string, number>();
-        return highlights.hopMap;
-      }, [selectedLink, highlights.hopMap]);
-
       const legendNodeItems = useMemo(() => {
         const counts: Record<string, number> = {};
         filteredGraphData.nodes.forEach((n) => {
@@ -1130,25 +855,6 @@ const GraphViewer = memo(
           }))
           .sort((a, b) => b.count - a.count);
       }, [filteredGraphData.nodes]);
-
-      // Derive available communities from raw graph data (for filter panel)
-      const availableCommunities = useMemo(() => {
-        const counts = new Map<number, number>();
-        for (const n of graphData.nodes) {
-          const cid = communityData.assignments[n.id];
-          if (cid !== undefined) {
-            counts.set(cid, (counts.get(cid) || 0) + 1);
-          }
-        }
-        return [...counts.entries()]
-          .sort((a, b) => b[1] - a[1])
-          .map(([cid, count]) => ({
-            communityId: cid,
-            label: communityData.names.get(cid) ?? `Community ${cid}`,
-            count,
-            color: communityData.colorMap.get(cid) ?? '#64748b',
-          }));
-      }, [graphData.nodes, communityData]);
 
       const legendCommunityItems = useMemo(() => {
         if (colorMode !== 'community') return [];
@@ -1237,7 +943,7 @@ const GraphViewer = memo(
             }
           }
         },
-        [communityData.assignments],
+        [communityData.assignments, setFocusedCommunityNodes],
       );
 
       const handleSuggestionSelect = useCallback(
@@ -1276,7 +982,14 @@ const GraphViewer = memo(
             }
           }
         },
-        [applyFilter, hops, loadGraph, onNodeClick],
+        [
+          applyFilter,
+          hops,
+          loadGraph,
+          onNodeClick,
+          setSelectedLink,
+          setSelectedNode,
+        ],
       );
 
       const legendLinkItems = useMemo(() => {
@@ -1348,7 +1061,7 @@ const GraphViewer = memo(
         setEdgeLabelNodes(EMPTY_SET);
         // Re-apply the active search filter (e.g. community focus)
         applyFilter(activeFilterRef.current);
-      }, [applyFilter]);
+      }, [applyFilter, setSelectedLink, setSelectedNode]);
 
       // --- Early returns for loading/error/empty states ---
 
@@ -1489,187 +1202,8 @@ const GraphViewer = memo(
 
       // --- Main graph viewport ---
 
-      const selectedCommunityId = selectedNode
-        ? communityData.assignments[selectedNode.id]
-        : undefined;
-      const selectedCommunityName =
-        selectedCommunityId !== undefined
-          ? communityData.names.get(selectedCommunityId)
-          : undefined;
-      const selectedCommunityColor =
-        selectedCommunityId !== undefined
-          ? communityData.colorMap.get(selectedCommunityId)
-          : undefined;
-
-      // ─── Build filter sections for SidePanel ──────────────────────────
-
-      const nodeFilterItems: FilterItem[] = availableNodeTypes.map(
-        ({ type, count }) => {
-          const subs = availableSubTypes.get(type);
-          const children = subs?.map((s) => ({
-            key: `${type}:${s.subType}`,
-            label: s.subType,
-            count: s.count,
-            color: getNodeColor(type),
-            hidden: hiddenSubTypes.has(`${type}:${s.subType}`),
-          }));
-          return {
-            key: type,
-            label: type,
-            count,
-            color: getNodeColor(type),
-            hidden: hiddenNodeTypes.has(type),
-            children,
-          };
-        },
-      );
-
-      const toggleNodeFilter = (key: string) => {
-        if (key.includes(':')) {
-          // Sub-type key like "Class:Controller"
-          setHiddenSubTypes((prev) => {
-            const next = new Set(prev);
-            if (next.has(key)) next.delete(key);
-            else next.add(key);
-            return next;
-          });
-        } else {
-          // Parent type key — toggle all sub-types if any, else toggle type
-          const subs = availableSubTypes.get(key);
-          if (subs && subs.length > 0) {
-            setHiddenSubTypes((prev) => {
-              const keys = subs.map((s) => `${key}:${s.subType}`);
-              const allHidden = keys.every((k) => prev.has(k));
-              const next = new Set(prev);
-              if (allHidden) {
-                keys.forEach((k) => next.delete(k));
-              } else {
-                keys.forEach((k) => next.add(k));
-              }
-              return next;
-            });
-          } else {
-            setHiddenNodeTypes((prev) => {
-              const next = new Set(prev);
-              if (next.has(key)) next.delete(key);
-              else next.add(key);
-              return next;
-            });
-          }
-        }
-      };
-
-      const linkFilterItems: FilterItem[] = availableLinkTypes.map(
-        ({ type, count }) => ({
-          key: type,
-          label: type.toUpperCase(),
-          count,
-          color: getLinkColor(type),
-          hidden: hiddenLinkTypes.has(type),
-        }),
-      );
-
-      const communityFilterItems: FilterItem[] = availableCommunities.map(
-        ({ communityId, label, count, color }) => ({
-          key: String(communityId),
-          label,
-          count,
-          color,
-          hidden: hiddenCommunities.has(communityId),
-        }),
-      );
-
-      const filterSections: FilterPanelProps[] = [];
-
-      if (colorMode === 'community' && communityFilterItems.length > 0) {
-        filterSections.push({
-          title: 'Communities',
-          items: communityFilterItems,
-          onToggle: (key) => {
-            const cid = Number(key);
-            setHiddenCommunities((prev) => {
-              const next = new Set(prev);
-              if (next.has(cid)) next.delete(cid);
-              else next.add(cid);
-              return next;
-            });
-          },
-          onShowAll: () => setHiddenCommunities(new Set()),
-          onHideAll: () =>
-            setHiddenCommunities(
-              new Set(availableCommunities.map((c) => c.communityId)),
-            ),
-          onFocus: onCommunityFocus,
-        });
-      }
-
-      filterSections.push({
-        title: 'Node Types',
-        items: nodeFilterItems,
-        onToggle: toggleNodeFilter,
-        onShowAll: () => {
-          setHiddenNodeTypes(new Set());
-          setHiddenSubTypes(new Set());
-        },
-        onHideAll: () => {
-          setHiddenNodeTypes(new Set(availableNodeTypes.map((t) => t.type)));
-          const allSubKeys = new Set<string>();
-          availableSubTypes.forEach((subs, type) => {
-            subs.forEach((s) => allSubKeys.add(`${type}:${s.subType}`));
-          });
-          setHiddenSubTypes(allSubKeys);
-        },
-      });
-
-      filterSections.push({
-        title: 'Edges',
-        items: linkFilterItems,
-        indicator: 'line',
-        emptyMessage: 'No edges',
-        onToggle: (key) =>
-          setHiddenLinkTypes((prev) => {
-            const next = new Set(prev);
-            if (next.has(key)) next.delete(key);
-            else next.add(key);
-            return next;
-          }),
-        onShowAll: () => setHiddenLinkTypes(new Set()),
-        onHideAll: () =>
-          setHiddenLinkTypes(new Set(availableLinkTypes.map((t) => t.type))),
-      });
-
       return (
         <div className="graph-viewport">
-          <SidePanel
-            filterSections={filterSections}
-            selectedNode={selectedNode}
-            nodeSource={nodeSource}
-            sourceLoading={sourceLoading}
-            sourceError={sourceError}
-            communityName={selectedCommunityName}
-            communityColor={selectedCommunityColor}
-            selectedNodeEdges={selectedNodeEdges}
-            onSelectEdge={handleSelectEdgeFromNode}
-            selectedLink={selectedLink}
-            onSelectNode={(nodeId) => {
-              const node = graphDataRef.current.nodes.find(
-                (n) => n.id === nodeId,
-              );
-              if (node) onNodeClick(node);
-            }}
-            onCloseDetails={() => {
-              setSelectedNode(null);
-              setSelectedLink(null);
-            }}
-            graphVersion={graphVersion}
-            graphNodeIds={graphNodeIds}
-            hopMap={hopMap}
-            nodeHistory={nodeHistory}
-            onClearHistory={() => setNodeHistory([])}
-            mobileActiveTab={mobilePanelTab}
-            onMobileTabChange={setMobilePanelTab}
-            onMobileClose={() => setMobilePanelTab(null)}
-          />
           <GraphToolbar
             logo={
               <button
@@ -1757,7 +1291,9 @@ const GraphViewer = memo(
                 ),
               },
             ]}
-            onMobilePanelTab={(key) => setMobilePanelTab(key as SidePanelTab)}
+            onMobilePanelTab={(key) =>
+              onMobilePanelTabChange?.(key as SidePanelTab)
+            }
             persistentActions={
               <a
                 className="github-star-btn"
@@ -1999,6 +1535,7 @@ const GraphViewer = memo(
             }
             return null;
           })()}
+
           <PixiGraphCanvas
             ref={canvasRef}
             nodes={graphData.nodes}
@@ -2220,6 +1757,7 @@ const GraphViewer = memo(
                 <circle cx="12" cy="19" r="1" />
               </svg>
             </button>
+
             <div
               className={`graph-controls-items${showGraphMenu ? ' graph-controls-items--open' : ''}`}
             >
@@ -2252,6 +1790,7 @@ const GraphViewer = memo(
                   )}
                 </svg>
               </button>
+
               <button
                 className="graph-control-btn"
                 onClick={() => canvasRef.current?.zoomIn()}
@@ -2271,6 +1810,7 @@ const GraphViewer = memo(
                   <line x1="5" y1="12" x2="19" y2="12" />
                 </svg>
               </button>
+
               <button
                 className="graph-control-btn"
                 onClick={() => canvasRef.current?.zoomOut()}
@@ -2289,6 +1829,7 @@ const GraphViewer = memo(
                   <line x1="5" y1="12" x2="19" y2="12" />
                 </svg>
               </button>
+
               <button
                 className="graph-control-btn"
                 onClick={() => canvasRef.current?.resetCamera()}
@@ -2310,6 +1851,7 @@ const GraphViewer = memo(
                   <line x1="3" y1="21" x2="10" y2="14" />
                 </svg>
               </button>
+
               <button
                 className={`graph-control-btn${showPhysicsPanel ? ' graph-control-btn--active' : ''}`}
                 onClick={() => setShowPhysicsPanel((v) => !v)}
@@ -2336,6 +1878,7 @@ const GraphViewer = memo(
                   <line x1="17" y1="16" x2="23" y2="16" />
                 </svg>
               </button>
+
               <button
                 className={`graph-control-btn${layoutMode === 'compact' ? ' graph-control-btn--active' : ''}`}
                 onClick={() => {
@@ -2370,6 +1913,7 @@ const GraphViewer = memo(
                   )}
                 </svg>
               </button>
+
               <button
                 className={`graph-control-btn${mode3d ? ' graph-control-btn--active' : ''}`}
                 onClick={() => {

--- a/ui/src/appComponents/SidePanel.tsx
+++ b/ui/src/appComponents/SidePanel.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { SelectedNode, SelectedEdge } from '@opentrace/components/utils';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   FilterPanel,
   PanelResizeHandle,
+  getLinkColor,
+  getNodeColor,
+  type FilterItem,
   type FilterPanelProps,
 } from '@opentrace/components';
 import type { NodeSourceResponse } from '../store/types';
@@ -27,54 +29,23 @@ import {
   useResizablePanel,
   useResizablePanelHeight,
 } from '../hooks/useResizablePanel';
+import { useGraph } from '../providers/GraphDataProvider';
+import { useGraphInteraction } from '../providers/GraphInteractionProvider';
+import { linkId } from '../providers/graphFilterUtils';
 import DiscoverPanelContainer from './DiscoverPanelContainer';
 import { createStoreDataProvider } from './storeDataProvider';
 import NodeDetailsPanel, { type NodeEdge } from './NodeDetailsPanel';
 import EdgeDetailsPanel from './EdgeDetailsPanel';
 import HistoryPanel from './HistoryPanel';
 import IndexMetadataPanel from './IndexMetadataPanel';
-import type { HistoryEntry } from './historyTypes';
 import './SidePanel.css';
 
 export type SidePanelTab = 'filters' | 'discover' | 'history' | 'details';
 
+/** Node types whose source code can be fetched and displayed. */
+const SOURCE_TYPES = new Set(['File', 'Function', 'Class', 'PullRequest']);
+
 interface SidePanelProps {
-  /** Filter sections to render in the Filters tab. */
-  filterSections: FilterPanelProps[];
-
-  /* Node details props */
-  selectedNode: SelectedNode | null;
-  nodeSource: NodeSourceResponse | null;
-  sourceLoading: boolean;
-  sourceError: string | null;
-  onCloseDetails: () => void;
-  /** Community name for the selected node */
-  communityName?: string;
-  /** Community color for the selected node */
-  communityColor?: string;
-
-  /** Edges connected to the selected node */
-  selectedNodeEdges?: NodeEdge[];
-
-  /** Callback to select an edge from the node edges list */
-  onSelectEdge?: (edge: NodeEdge) => void;
-
-  /* Edge details props */
-  selectedLink: SelectedEdge | null;
-  onSelectNode?: (nodeId: string) => void;
-
-  /** Session history of selected nodes */
-  nodeHistory?: HistoryEntry[];
-  /** Callback to clear session history */
-  onClearHistory?: () => void;
-
-  /** Bumps when the graph store changes (new indexing, PR import, etc.) */
-  graphVersion?: number;
-  /** IDs of nodes currently in the graph view */
-  graphNodeIds?: string[];
-  /** Map of node ID → hop distance from selected node (0 = selected) */
-  hopMap?: Map<string, number>;
-
   /** Mobile: externally controlled active tab */
   mobileActiveTab?: SidePanelTab | null;
   /** Mobile: callback to switch tabs while the panel is open */
@@ -84,28 +55,118 @@ interface SidePanelProps {
 }
 
 export default function SidePanel({
-  filterSections,
-  selectedNode,
-  nodeSource,
-  communityName,
-  communityColor,
-  sourceLoading,
-  sourceError,
-  onCloseDetails,
-  selectedNodeEdges,
-  onSelectEdge,
-  selectedLink,
-  onSelectNode,
-  nodeHistory = [],
-  onClearHistory,
-  graphVersion,
-  graphNodeIds,
-  hopMap,
   mobileActiveTab,
   onMobileTabChange,
   onMobileClose,
 }: SidePanelProps) {
   const { store } = useStore();
+
+  // Selection, filters, history, color mode, and derived data come from the
+  // GraphInteractionProvider so SidePanel can live as a sibling of GraphViewer.
+  const {
+    selectedNode,
+    selectedLink,
+    selectNode,
+    selectLink,
+    clearSelection,
+    nodeHistory,
+    setNodeHistory,
+    hiddenNodeTypes,
+    setHiddenNodeTypes,
+    hiddenLinkTypes,
+    setHiddenLinkTypes,
+    hiddenSubTypes,
+    setHiddenSubTypes,
+    hiddenCommunities,
+    setHiddenCommunities,
+    colorMode,
+    availableNodeTypes,
+    availableLinkTypes,
+    availableSubTypes,
+    availableCommunities,
+    communityData,
+    filteredGraphData,
+    focusCommunity,
+    hopMap,
+    graphNodeIds,
+  } = useGraphInteraction();
+  const { graphVersion, graphData } = useGraph();
+
+  // ─── Source code fetch for the selected node ─────────────────────────
+  const [nodeSource, setNodeSource] = useState<NodeSourceResponse | null>(null);
+  const [sourceLoading, setSourceLoading] = useState(false);
+  const [sourceError, setSourceError] = useState<string | null>(null);
+
+  /* eslint-disable react-hooks/set-state-in-effect -- async fetch pattern with cleanup */
+  useEffect(() => {
+    if (!selectedNode || !SOURCE_TYPES.has(selectedNode.type)) {
+      setNodeSource(null);
+      setSourceError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setSourceLoading(true);
+    setSourceError(null);
+    setNodeSource(null);
+
+    const startLine = selectedNode.properties?.startLine as number | undefined;
+    const endLine = selectedNode.properties?.endLine as number | undefined;
+
+    store
+      .fetchSource(selectedNode.id, startLine, endLine)
+      .then((src) => {
+        if (cancelled) return;
+        if (src) setNodeSource(src);
+        else setSourceError('Source not available');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err?.name === 'AbortError') return;
+        setSourceError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setSourceLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedNode?.id, store]); // eslint-disable-line react-hooks/exhaustive-deps
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  // ─── Selection callbacks (from context, plus light wrappers) ─────────
+  const onCommunityFocus = useCallback(
+    (key: string) => focusCommunity(Number(key)),
+    [focusCommunity],
+  );
+  const handleSelectNodeId = useCallback(
+    (nodeId: string) => {
+      const node = graphData.nodes.find((n) => n.id === nodeId);
+      if (node) selectNode(node);
+    },
+    [graphData.nodes, selectNode],
+  );
+  const handleSelectEdgeFromNode = useCallback(
+    (edge: NodeEdge) => {
+      if (!selectedNode) return;
+      const sourceId =
+        edge.direction === 'outgoing' ? selectedNode.id : edge.otherNodeId;
+      const targetId =
+        edge.direction === 'outgoing' ? edge.otherNodeId : selectedNode.id;
+      const nodeMap = new Map(filteredGraphData.nodes.map((n) => [n.id, n]));
+      selectLink({
+        source: sourceId,
+        target: targetId,
+        label: edge.label,
+        properties: edge.properties,
+        sourceNode: nodeMap.get(sourceId),
+        targetNode: nodeMap.get(targetId),
+      });
+    },
+    [selectedNode, filteredGraphData.nodes, selectLink],
+  );
+
   const discoverDataProvider = useMemo(
     () => createStoreDataProvider(store),
     [store],
@@ -161,10 +222,204 @@ export default function SidePanel({
     }
   }, [selectedNode, selectedLink]);
 
+  // ─── Derived: community label for selected node ───────────────────────
+  const selectedCommunityId =
+    selectedNode !== null
+      ? communityData.assignments[selectedNode.id]
+      : undefined;
+  const communityName =
+    selectedCommunityId !== undefined
+      ? communityData.names.get(selectedCommunityId)
+      : undefined;
+  const communityColor =
+    selectedCommunityId !== undefined
+      ? communityData.colorMap.get(selectedCommunityId)
+      : undefined;
+
+  // ─── Derived: edges connected to the selected node ────────────────────
+  const selectedNodeEdges = useMemo<NodeEdge[]>(() => {
+    if (!selectedNode) return [];
+    const nodeId = selectedNode.id;
+    const nodeMap = new Map(filteredGraphData.nodes.map((n) => [n.id, n]));
+    return filteredGraphData.links
+      .filter((l) => linkId(l.source) === nodeId || linkId(l.target) === nodeId)
+      .map((l) => {
+        const sourceId = linkId(l.source);
+        const targetId = linkId(l.target);
+        const isOutgoing = sourceId === nodeId;
+        const otherId = isOutgoing ? targetId : sourceId;
+        const otherNode = nodeMap.get(otherId);
+        return {
+          direction: isOutgoing ? ('outgoing' as const) : ('incoming' as const),
+          label: l.label || 'unknown',
+          properties: l.properties,
+          otherNodeId: otherId,
+          otherNodeName: otherNode?.name ?? otherId,
+          otherNodeType: otherNode?.type,
+        };
+      });
+  }, [selectedNode, filteredGraphData.nodes, filteredGraphData.links]);
+
+  // ─── Derived: filter sections for the FilterPanel UI ──────────────────
+  const filterSections = useMemo<FilterPanelProps[]>(() => {
+    const nodeFilterItems: FilterItem[] = availableNodeTypes.map(
+      ({ type, count }) => {
+        const subs = availableSubTypes.get(type);
+        const children = subs?.map((s) => ({
+          key: `${type}:${s.subType}`,
+          label: s.subType,
+          count: s.count,
+          color: getNodeColor(type),
+          hidden: hiddenSubTypes.has(`${type}:${s.subType}`),
+        }));
+        return {
+          key: type,
+          label: type,
+          count,
+          color: getNodeColor(type),
+          hidden: hiddenNodeTypes.has(type),
+          children,
+        };
+      },
+    );
+
+    const toggleNodeFilter = (key: string) => {
+      if (key.includes(':')) {
+        // Sub-type key like "Class:Controller"
+        setHiddenSubTypes((prev) => {
+          const next = new Set(prev);
+          if (next.has(key)) next.delete(key);
+          else next.add(key);
+          return next;
+        });
+      } else {
+        const subs = availableSubTypes.get(key);
+        if (subs && subs.length > 0) {
+          setHiddenSubTypes((prev) => {
+            const keys = subs.map((s) => `${key}:${s.subType}`);
+            const allHidden = keys.every((k) => prev.has(k));
+            const next = new Set(prev);
+            if (allHidden) {
+              keys.forEach((k) => next.delete(k));
+            } else {
+              keys.forEach((k) => next.add(k));
+            }
+            return next;
+          });
+        } else {
+          setHiddenNodeTypes((prev) => {
+            const next = new Set(prev);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            return next;
+          });
+        }
+      }
+    };
+
+    const linkFilterItems: FilterItem[] = availableLinkTypes.map(
+      ({ type, count }) => ({
+        key: type,
+        label: type.toUpperCase(),
+        count,
+        color: getLinkColor(type),
+        hidden: hiddenLinkTypes.has(type),
+      }),
+    );
+
+    const communityFilterItems: FilterItem[] = availableCommunities.map(
+      ({ communityId, label, count, color }) => ({
+        key: String(communityId),
+        label,
+        count,
+        color,
+        hidden: hiddenCommunities.has(communityId),
+      }),
+    );
+
+    const sections: FilterPanelProps[] = [];
+
+    if (colorMode === 'community' && communityFilterItems.length > 0) {
+      sections.push({
+        title: 'Communities',
+        items: communityFilterItems,
+        onToggle: (key) => {
+          const cid = Number(key);
+          setHiddenCommunities((prev) => {
+            const next = new Set(prev);
+            if (next.has(cid)) next.delete(cid);
+            else next.add(cid);
+            return next;
+          });
+        },
+        onShowAll: () => setHiddenCommunities(new Set()),
+        onHideAll: () =>
+          setHiddenCommunities(
+            new Set(availableCommunities.map((c) => c.communityId)),
+          ),
+        onFocus: onCommunityFocus,
+      });
+    }
+
+    sections.push({
+      title: 'Node Types',
+      items: nodeFilterItems,
+      onToggle: toggleNodeFilter,
+      onShowAll: () => {
+        setHiddenNodeTypes(new Set());
+        setHiddenSubTypes(new Set());
+      },
+      onHideAll: () => {
+        setHiddenNodeTypes(new Set(availableNodeTypes.map((t) => t.type)));
+        const allSubKeys = new Set<string>();
+        availableSubTypes.forEach((subs, type) => {
+          subs.forEach((s) => allSubKeys.add(`${type}:${s.subType}`));
+        });
+        setHiddenSubTypes(allSubKeys);
+      },
+    });
+
+    sections.push({
+      title: 'Edges',
+      items: linkFilterItems,
+      indicator: 'line',
+      emptyMessage: 'No edges',
+      onToggle: (key) =>
+        setHiddenLinkTypes((prev) => {
+          const next = new Set(prev);
+          if (next.has(key)) next.delete(key);
+          else next.add(key);
+          return next;
+        }),
+      onShowAll: () => setHiddenLinkTypes(new Set()),
+      onHideAll: () =>
+        setHiddenLinkTypes(new Set(availableLinkTypes.map((t) => t.type))),
+    });
+
+    return sections;
+  }, [
+    availableNodeTypes,
+    availableLinkTypes,
+    availableSubTypes,
+    availableCommunities,
+    hiddenNodeTypes,
+    hiddenLinkTypes,
+    hiddenSubTypes,
+    hiddenCommunities,
+    colorMode,
+    onCommunityFocus,
+    setHiddenNodeTypes,
+    setHiddenLinkTypes,
+    setHiddenSubTypes,
+    setHiddenCommunities,
+  ]);
+
   const handleCloseDetails = () => {
-    onCloseDetails();
+    clearSelection();
     setActiveTab(previousTab.current);
   };
+
+  const handleClearHistory = () => setNodeHistory([]);
 
   const isMobileOpen = !!mobileActiveTab;
 
@@ -244,7 +499,7 @@ export default function SidePanel({
         style={{ display: effectiveTab === 'discover' ? undefined : 'none' }}
       >
         <DiscoverPanelContainer
-          onSelectNode={onSelectNode ?? (() => {})}
+          onSelectNode={handleSelectNodeId}
           dataProvider={discoverDataProvider}
           graphVersion={graphVersion}
           selectedNodeId={selectedNode?.id as string | undefined}
@@ -259,8 +514,8 @@ export default function SidePanel({
       >
         <HistoryPanel
           entries={nodeHistory}
-          onSelectNode={onSelectNode ?? (() => {})}
-          onClear={onClearHistory ?? (() => {})}
+          onSelectNode={handleSelectNodeId}
+          onClear={handleClearHistory}
         />
       </div>
       {effectiveTab === 'details' && (
@@ -274,11 +529,14 @@ export default function SidePanel({
               communityColor={communityColor}
               sourceError={sourceError}
               edges={selectedNodeEdges}
-              onSelectNode={onSelectNode}
-              onSelectEdge={onSelectEdge}
+              onSelectNode={handleSelectNodeId}
+              onSelectEdge={handleSelectEdgeFromNode}
             />
           ) : selectedLink ? (
-            <EdgeDetailsPanel link={selectedLink} onSelectNode={onSelectNode} />
+            <EdgeDetailsPanel
+              link={selectedLink}
+              onSelectNode={handleSelectNodeId}
+            />
           ) : null}
         </div>
       )}

--- a/ui/src/appComponents/SidePanel.tsx
+++ b/ui/src/appComponents/SidePanel.tsx
@@ -154,7 +154,10 @@ export default function SidePanel({
         edge.direction === 'outgoing' ? selectedNode.id : edge.otherNodeId;
       const targetId =
         edge.direction === 'outgoing' ? edge.otherNodeId : selectedNode.id;
-      const nodeMap = new Map(filteredGraphData.nodes.map((n) => [n.id, n]));
+      // Use the unfiltered graph so endpoint metadata is still available
+      // when one side of the edge has been hidden by the active filters —
+      // EdgeDetailsPanel needs the full node objects to render names/types.
+      const nodeMap = new Map(graphData.nodes.map((n) => [n.id, n]));
       selectLink({
         source: sourceId,
         target: targetId,
@@ -164,7 +167,7 @@ export default function SidePanel({
         targetNode: nodeMap.get(targetId),
       });
     },
-    [selectedNode, filteredGraphData.nodes, selectLink],
+    [selectedNode, graphData.nodes, selectLink],
   );
 
   const discoverDataProvider = useMemo(

--- a/ui/src/appComponents/index.ts
+++ b/ui/src/appComponents/index.ts
@@ -23,3 +23,18 @@ export { default as SettingsDrawer } from './SettingsDrawer';
 export { default as SidePanel } from './SidePanel';
 export type { SidePanelTab } from './SidePanel';
 export { useGraphData } from '../hooks/useGraphData';
+export type { GraphDataState } from '../hooks/useGraphData';
+export { GraphDataProvider, useGraph } from '../providers/GraphDataProvider';
+export {
+  GraphInteractionProvider,
+  useGraphInteraction,
+} from '../providers/GraphInteractionProvider';
+export type {
+  AvailableType,
+  AvailableSubType,
+  AvailableCommunity,
+  CommunityData,
+  GraphInteractionState,
+  HighlightsResult,
+} from '../providers/GraphInteractionProvider';
+export { getSubType, linkId } from '../providers/graphFilterUtils';

--- a/ui/src/hooks/useGraphData.ts
+++ b/ui/src/hooks/useGraphData.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   GraphNode,
   GraphLink,
@@ -117,14 +117,30 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
     }
   }, [loadGraph, store]);
 
-  return {
-    graphData,
-    loading,
-    error,
-    stats,
-    lastSearchQuery,
-    graphVersion,
-    loadGraph,
-    setError,
-  };
+  // Memoize the returned state so context consumers (and downstream
+  // memoized components) don't re-render every commit just because the
+  // wrapping object changed identity. `loadGraph`/`setError` are already
+  // stable (useCallback / useState dispatcher); the rest is primitive
+  // state, so identity tracks the values.
+  return useMemo(
+    () => ({
+      graphData,
+      loading,
+      error,
+      stats,
+      lastSearchQuery,
+      graphVersion,
+      loadGraph,
+      setError,
+    }),
+    [
+      graphData,
+      loading,
+      error,
+      stats,
+      lastSearchQuery,
+      graphVersion,
+      loadGraph,
+    ],
+  );
 }

--- a/ui/src/providers/GraphDataProvider.tsx
+++ b/ui/src/providers/GraphDataProvider.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { useGraphData, type GraphDataState } from '../hooks/useGraphData';
+
+const GraphDataContext = createContext<GraphDataState | null>(null);
+
+interface GraphDataProviderProps {
+  children: ReactNode;
+  /**
+   * When provided, the provider exposes this value directly instead of
+   * calling `useGraphData()` to fetch from the configured store. Use for
+   * apps that own their own data flow (e.g. a Neo4j-backed viewer) and
+   * want downstream consumers (SidePanel, ChatPanel) to read it via the
+   * standard context.
+   *
+   * The presence/absence of `value` must be stable for a given mounted
+   * provider — don't toggle between modes after mount.
+   */
+  value?: GraphDataState;
+}
+
+export function GraphDataProvider({ children, value }: GraphDataProviderProps) {
+  if (value !== undefined) {
+    return (
+      <GraphDataContext.Provider value={value}>
+        {children}
+      </GraphDataContext.Provider>
+    );
+  }
+  return <InternalGraphDataProvider>{children}</InternalGraphDataProvider>;
+}
+
+function InternalGraphDataProvider({ children }: { children: ReactNode }) {
+  const value = useGraphData();
+  return (
+    <GraphDataContext.Provider value={value}>
+      {children}
+    </GraphDataContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- co-located hook + provider
+export function useGraph(): GraphDataState {
+  const ctx = useContext(GraphDataContext);
+  if (!ctx) {
+    throw new Error('useGraph must be used within a GraphDataProvider');
+  }
+  return ctx;
+}

--- a/ui/src/providers/GraphInteractionProvider.tsx
+++ b/ui/src/providers/GraphInteractionProvider.tsx
@@ -18,7 +18,9 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type Dispatch,
   type ReactNode,
@@ -168,7 +170,7 @@ function InternalGraphInteractionProvider({
 }: {
   children: ReactNode;
 }) {
-  const { graphData } = useGraph();
+  const { graphData, graphVersion } = useGraph();
 
   // Selection
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
@@ -236,6 +238,26 @@ function InternalGraphInteractionProvider({
     });
     return result;
   }, [graphData.nodes]);
+
+  // ─── First-load defaults: hide Dependency sub-types ──────────────────
+  // Runs once per successful graph load (graphVersion bump). Tracks the
+  // last applied version so re-loads (e.g. switching repositories or
+  // re-indexing) re-apply the defaults — the original ref-only flag was
+  // session-scoped, which broke for the second repo a user opened.
+  const lastDefaultsVersion = useRef(0);
+  useEffect(() => {
+    if (graphVersion === 0) return;
+    if (lastDefaultsVersion.current === graphVersion) return;
+    const depSubs = availableSubTypes.get('Dependency');
+    if (!depSubs || depSubs.length === 0) return;
+    lastDefaultsVersion.current = graphVersion;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time-per-load default init
+    setHiddenSubTypes((prev) => {
+      const next = new Set(prev);
+      depSubs.forEach((s) => next.add(`Dependency:${s.subType}`));
+      return next;
+    });
+  }, [graphVersion, availableSubTypes]);
 
   // ─── Derived: communities (Louvain) ──────────────────────────────────
   const communityData = useCommunities(

--- a/ui/src/providers/GraphInteractionProvider.tsx
+++ b/ui/src/providers/GraphInteractionProvider.tsx
@@ -1,0 +1,472 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from 'react';
+import type {
+  FilterState,
+  GraphLink,
+  GraphNode,
+  SelectedEdge,
+  SelectedNode,
+} from '@opentrace/components/utils';
+import {
+  DEFAULT_LAYOUT_CONFIG,
+  getNodeColor,
+  useCommunities,
+  useHighlights,
+} from '@opentrace/components';
+import type { HistoryEntry } from '../appComponents/historyTypes';
+import { useGraph } from './GraphDataProvider';
+import { getSubType, linkId } from './graphFilterUtils';
+
+type ColorMode = 'type' | 'community';
+
+const EMPTY_NODE_SET: Set<string> = Object.freeze(
+  new Set<string>(),
+) as Set<string>;
+
+export interface AvailableType {
+  type: string;
+  count: number;
+}
+
+export interface AvailableSubType {
+  subType: string;
+  count: number;
+}
+
+export interface AvailableCommunity {
+  communityId: number;
+  label: string;
+  count: number;
+  color: string;
+}
+
+export type CommunityData = ReturnType<typeof useCommunities>;
+export type HighlightsResult = ReturnType<typeof useHighlights>;
+
+export interface GraphInteractionState {
+  // Selection
+  selectedNode: SelectedNode | null;
+  selectedLink: SelectedEdge | null;
+  setSelectedNode: Dispatch<SetStateAction<SelectedNode | null>>;
+  setSelectedLink: Dispatch<SetStateAction<SelectedEdge | null>>;
+  /** Select a node and record it in history. Pass `null` to deselect. */
+  selectNode: (node: SelectedNode | null) => void;
+  /** Select a link (edge). Pass `null` to deselect. */
+  selectLink: (edge: SelectedEdge | null) => void;
+  /** Clear both selections. */
+  clearSelection: () => void;
+
+  // History
+  nodeHistory: HistoryEntry[];
+  setNodeHistory: Dispatch<SetStateAction<HistoryEntry[]>>;
+
+  // Filter state
+  hiddenNodeTypes: Set<string>;
+  hiddenLinkTypes: Set<string>;
+  hiddenSubTypes: Set<string>;
+  hiddenCommunities: Set<number>;
+  setHiddenNodeTypes: Dispatch<SetStateAction<Set<string>>>;
+  setHiddenLinkTypes: Dispatch<SetStateAction<Set<string>>>;
+  setHiddenSubTypes: Dispatch<SetStateAction<Set<string>>>;
+  setHiddenCommunities: Dispatch<SetStateAction<Set<number>>>;
+  filterState: FilterState;
+
+  // Color mode
+  colorMode: ColorMode;
+  setColorMode: Dispatch<SetStateAction<ColorMode>>;
+
+  // Search / hops (toolbar-driven, but read by highlights and SidePanel)
+  searchQuery: string;
+  setSearchQuery: Dispatch<SetStateAction<string>>;
+  hops: number;
+  setHops: Dispatch<SetStateAction<number>>;
+
+  // Community-focus highlight (set by toolbar suggestions / filter panel)
+  focusedCommunityNodes: Set<string>;
+  setFocusedCommunityNodes: Dispatch<SetStateAction<Set<string>>>;
+  /** Focus all nodes in a community (also clears selection). */
+  focusCommunity: (communityId: number) => void;
+
+  // Derived (memoized) — computed once here, read by both GraphViewer and SidePanel
+  availableNodeTypes: AvailableType[];
+  availableLinkTypes: AvailableType[];
+  availableSubTypes: Map<string, AvailableSubType[]>;
+  availableCommunities: AvailableCommunity[];
+  communityData: CommunityData;
+  filteredGraphData: { nodes: GraphNode[]; links: GraphLink[] };
+  highlights: HighlightsResult;
+  /** Map of node ID → hop distance from selected node. Empty when an edge is selected. */
+  hopMap: Map<string, number>;
+  /** All node IDs currently in the loaded graph (unfiltered). */
+  graphNodeIds: string[];
+}
+
+const GraphInteractionContext = createContext<GraphInteractionState | null>(
+  null,
+);
+
+interface GraphInteractionProviderProps {
+  children: ReactNode;
+  /**
+   * When provided, the provider exposes this value directly instead of
+   * deriving everything from `useGraph()`. Use for apps that own their
+   * own selection / filter / community / highlight machinery (e.g. a
+   * Neo4j-backed viewer with granularity-aware data) and just want
+   * downstream consumers like `SidePanel` to read it via the standard
+   * context.
+   *
+   * The presence/absence of `value` must be stable for a given mounted
+   * provider — don't toggle between modes after mount.
+   */
+  value?: GraphInteractionState;
+}
+
+export function GraphInteractionProvider({
+  children,
+  value,
+}: GraphInteractionProviderProps) {
+  if (value !== undefined) {
+    return (
+      <GraphInteractionContext.Provider value={value}>
+        {children}
+      </GraphInteractionContext.Provider>
+    );
+  }
+  return (
+    <InternalGraphInteractionProvider>
+      {children}
+    </InternalGraphInteractionProvider>
+  );
+}
+
+function InternalGraphInteractionProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { graphData } = useGraph();
+
+  // Selection
+  const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
+  const [selectedLink, setSelectedLink] = useState<SelectedEdge | null>(null);
+
+  // History
+  const [nodeHistory, setNodeHistory] = useState<HistoryEntry[]>([]);
+
+  // Filter state
+  const [hiddenNodeTypes, setHiddenNodeTypes] = useState(new Set<string>());
+  const [hiddenLinkTypes, setHiddenLinkTypes] = useState(new Set<string>());
+  const [hiddenSubTypes, setHiddenSubTypes] = useState(new Set<string>());
+  const [hiddenCommunities, setHiddenCommunities] = useState(new Set<number>());
+
+  // Color mode
+  const [colorMode, setColorMode] = useState<ColorMode>('type');
+
+  // Search / hops
+  const [searchQuery, setSearchQuery] = useState('');
+  const [hops, setHops] = useState(2);
+
+  // Community focus
+  const [focusedCommunityNodes, setFocusedCommunityNodes] =
+    useState<Set<string>>(EMPTY_NODE_SET);
+
+  // ─── Derived: available types ────────────────────────────────────────
+  const availableNodeTypes = useMemo<AvailableType[]>(() => {
+    const counts: Record<string, number> = {};
+    graphData.nodes.forEach((n) => {
+      counts[n.type] = (counts[n.type] || 0) + 1;
+    });
+    return Object.entries(counts)
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [graphData.nodes]);
+
+  const availableLinkTypes = useMemo<AvailableType[]>(() => {
+    const counts: Record<string, number> = {};
+    graphData.links.forEach((l) => {
+      const label = (l as unknown as GraphLink).label || 'unknown';
+      counts[label] = (counts[label] || 0) + 1;
+    });
+    return Object.entries(counts)
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [graphData.links]);
+
+  const availableSubTypes = useMemo<Map<string, AvailableSubType[]>>(() => {
+    const map = new Map<string, Record<string, number>>();
+    graphData.nodes.forEach((n) => {
+      const sub = getSubType(n);
+      if (!sub) return;
+      if (!map.has(n.type)) map.set(n.type, {});
+      const counts = map.get(n.type)!;
+      counts[sub] = (counts[sub] || 0) + 1;
+    });
+    const result = new Map<string, AvailableSubType[]>();
+    map.forEach((counts, type) => {
+      result.set(
+        type,
+        Object.entries(counts)
+          .map(([subType, count]) => ({ subType, count }))
+          .sort((a, b) => b.count - a.count),
+      );
+    });
+    return result;
+  }, [graphData.nodes]);
+
+  // ─── Derived: communities (Louvain) ──────────────────────────────────
+  const communityData = useCommunities(
+    graphData.nodes,
+    graphData.links,
+    DEFAULT_LAYOUT_CONFIG,
+  );
+
+  const availableCommunities = useMemo<AvailableCommunity[]>(() => {
+    const counts: Record<number, number> = {};
+    for (const n of graphData.nodes) {
+      const cid = communityData.assignments[n.id];
+      if (cid !== undefined) counts[cid] = (counts[cid] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([cidStr, count]) => {
+        const cid = Number(cidStr);
+        return {
+          communityId: cid,
+          label: communityData.names.get(cid) ?? `Community ${cid}`,
+          count,
+          color: communityData.colorMap.get(cid) ?? getNodeColor('Unknown'),
+        };
+      })
+      .sort((a, b) => b.count - a.count);
+  }, [graphData.nodes, communityData]);
+
+  // ─── Derived: filtered graph (canvas-rendered) ───────────────────────
+  const filteredGraphData = useMemo(() => {
+    const nodes = graphData.nodes.filter((n) => {
+      if (hiddenCommunities.size > 0) {
+        const cid = communityData.assignments[n.id];
+        if (cid !== undefined && hiddenCommunities.has(cid)) return false;
+      }
+      const hasSubTypeFilters = availableSubTypes.has(n.type);
+      if (hasSubTypeFilters) {
+        const sub = getSubType(n);
+        if (sub) {
+          return !hiddenSubTypes.has(`${n.type}:${sub}`);
+        }
+        const subs = availableSubTypes.get(n.type)!;
+        const allHidden = subs.every((s) =>
+          hiddenSubTypes.has(`${n.type}:${s.subType}`),
+        );
+        return !allHidden;
+      }
+      return !hiddenNodeTypes.has(n.type);
+    });
+    const visibleNodeIds = new Set(nodes.map((n) => n.id));
+    const links = graphData.links.filter((l) => {
+      const sourceId = linkId(l.source);
+      const targetId = linkId(l.target);
+      const label = (l as unknown as GraphLink).label || 'unknown';
+      return (
+        visibleNodeIds.has(sourceId) &&
+        visibleNodeIds.has(targetId) &&
+        !hiddenLinkTypes.has(label)
+      );
+    });
+    return { nodes, links };
+  }, [
+    graphData,
+    hiddenNodeTypes,
+    hiddenLinkTypes,
+    hiddenSubTypes,
+    hiddenCommunities,
+    communityData.assignments,
+    availableSubTypes,
+  ]);
+
+  const filterState = useMemo<FilterState>(
+    () => ({
+      hiddenNodeTypes,
+      hiddenLinkTypes,
+      hiddenSubTypes,
+      hiddenCommunities,
+    }),
+    [hiddenNodeTypes, hiddenLinkTypes, hiddenSubTypes, hiddenCommunities],
+  );
+
+  const graphNodeIds = useMemo(
+    () => graphData.nodes.map((n) => n.id as string),
+    [graphData.nodes],
+  );
+
+  // ─── Highlights (used by canvas + Discover panel hop colouring) ───────
+  const highlights = useHighlights(
+    null as never, // _graph — unused
+    false, // _layoutReady — unused
+    graphData.nodes,
+    graphData.links,
+    searchQuery,
+    selectedNode?.id ?? null,
+    hops,
+    filterState,
+  );
+
+  const hopMap = useMemo(() => {
+    if (selectedLink) return new Map<string, number>();
+    return highlights.hopMap;
+  }, [selectedLink, highlights.hopMap]);
+
+  // ─── Selection helpers ───────────────────────────────────────────────
+  // selectNode / selectLink also clear any community focus — selection
+  // takes precedence over a focused community group.
+  const selectNode = useCallback((node: SelectedNode | null) => {
+    setSelectedNode(node);
+    setSelectedLink(null);
+    setFocusedCommunityNodes(EMPTY_NODE_SET);
+    if (!node) return;
+    // Record in session history (skip consecutive duplicates)
+    setNodeHistory((prev) => {
+      if (prev.length > 0 && prev[0].id === node.id) return prev;
+      const entry: HistoryEntry = {
+        id: node.id,
+        name: node.name,
+        type: node.type,
+        timestamp: Date.now(),
+        source: 'user',
+      };
+      return [entry, ...prev].slice(0, 500);
+    });
+  }, []);
+
+  const selectLink = useCallback((edge: SelectedEdge | null) => {
+    setSelectedLink(edge);
+    setSelectedNode(null);
+    setFocusedCommunityNodes(EMPTY_NODE_SET);
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedNode(null);
+    setSelectedLink(null);
+  }, []);
+
+  const focusCommunity = useCallback(
+    (cid: number) => {
+      const nodeIds = Object.entries(communityData.assignments)
+        .filter(([, id]) => id === cid)
+        .map(([nodeId]) => nodeId);
+      if (nodeIds.length > 0) {
+        setFocusedCommunityNodes(new Set(nodeIds));
+        setSelectedNode(null);
+        setSelectedLink(null);
+      }
+    },
+    [communityData.assignments],
+  );
+
+  const value = useMemo<GraphInteractionState>(
+    () => ({
+      selectedNode,
+      selectedLink,
+      setSelectedNode,
+      setSelectedLink,
+      selectNode,
+      selectLink,
+      clearSelection,
+      nodeHistory,
+      setNodeHistory,
+      hiddenNodeTypes,
+      hiddenLinkTypes,
+      hiddenSubTypes,
+      hiddenCommunities,
+      setHiddenNodeTypes,
+      setHiddenLinkTypes,
+      setHiddenSubTypes,
+      setHiddenCommunities,
+      filterState,
+      colorMode,
+      setColorMode,
+      searchQuery,
+      setSearchQuery,
+      hops,
+      setHops,
+      focusedCommunityNodes,
+      setFocusedCommunityNodes,
+      focusCommunity,
+      availableNodeTypes,
+      availableLinkTypes,
+      availableSubTypes,
+      availableCommunities,
+      communityData,
+      filteredGraphData,
+      highlights,
+      hopMap,
+      graphNodeIds,
+    }),
+    [
+      selectedNode,
+      selectedLink,
+      selectNode,
+      selectLink,
+      clearSelection,
+      nodeHistory,
+      hiddenNodeTypes,
+      hiddenLinkTypes,
+      hiddenSubTypes,
+      hiddenCommunities,
+      filterState,
+      colorMode,
+      searchQuery,
+      hops,
+      focusedCommunityNodes,
+      focusCommunity,
+      availableNodeTypes,
+      availableLinkTypes,
+      availableSubTypes,
+      availableCommunities,
+      communityData,
+      filteredGraphData,
+      highlights,
+      hopMap,
+      graphNodeIds,
+    ],
+  );
+
+  return (
+    <GraphInteractionContext.Provider value={value}>
+      {children}
+    </GraphInteractionContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- co-located hook + provider
+export function useGraphInteraction(): GraphInteractionState {
+  const ctx = useContext(GraphInteractionContext);
+  if (!ctx) {
+    throw new Error(
+      'useGraphInteraction must be used within a GraphInteractionProvider',
+    );
+  }
+  return ctx;
+}

--- a/ui/src/providers/graphFilterUtils.ts
+++ b/ui/src/providers/graphFilterUtils.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GraphNode } from '@opentrace/components/utils';
+
+/**
+ * Extract a sub-type value from a node based on its type.
+ * Returns null if no meaningful sub-type can be derived.
+ */
+export function getSubType(node: GraphNode): string | null {
+  if (node.type === 'File') {
+    const name = node.name || node.id;
+    const lastDot = name.lastIndexOf('.');
+    if (lastDot > 0) return name.slice(lastDot);
+    return null;
+  }
+  if (node.type === 'Function' || node.type === 'Class') {
+    const lang = node.properties?.language as string | undefined;
+    return lang || null;
+  }
+  if (node.type === 'Dependency') {
+    const registry = node.properties?.registry as string | undefined;
+    return registry || null;
+  }
+  if (node.type === 'Variable') {
+    const kind = node.properties?.kind as string | undefined;
+    return kind || null;
+  }
+  return null;
+}
+
+/**
+ * Extract the string ID from a link endpoint.
+ * GraphLink endpoints are always strings in our data model,
+ * but we keep this helper for safety.
+ */
+export function linkId(
+  endpoint: string | number | GraphNode | undefined,
+): string {
+  if (typeof endpoint === 'object' && endpoint !== null) return endpoint.id;
+  return String(endpoint);
+}


### PR DESCRIPTION
## Refactor graph state into centralized context providers
♻️ **Refactor** · ✨ **Improvement**

Moves graph data, selection, and filtering logic out of `GraphViewer` into centralized context providers. This decouples the canvas from side panels and allows downstream components to consume state without prop-drilling.

### Complexity
🟡 Moderate · `8 files changed, 1106 insertions(+), 677 deletions(-)`

This PR performs a large-scale refactor of the application's core state, moving the primary graph data and interaction logic out of a monolithic component and into a provider layer. While it uses standard React patterns (Context + useMemo), the scope is broad and touches nearly every major UI component, meaning a bug here could break the entire navigation and filtering loop.

### Tests
🧪 Existing tests for `useGraphData` and `useHighlights` still apply, but the component-level interaction logic is currently untested.

### Review focus
Pay particular attention to the following areas:

- **Selection Helpers** — verify that the `selectNode` and `selectLink` helpers in the provider correctly clear conflicting states (like community focus).
- **History Duplication** — check that node selection history is recorded exactly once now that logic exists in both the provider and the viewer's click handler.
- **Memoization Stability** — ensure `filteredGraphData` and `highlights` only re-calculate when necessary to avoid performance lag on large graphs.
- **Layout Calculations** — confirm that moving `SidePanel` to a sibling of `GraphViewer` in `App.tsx` preserves correct canvas resizing logic.
<!-- opentrace:jid=c52592c1-241e-4d29-abe6-47cd213230bd|sha=122eec763bdb4e07f8235fa46395d6f69dab9759 -->