### PR TITLE
feat(ui): add projectKey prop to ChatPanel for conversation scoping

### DIFF
--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -90,6 +90,8 @@ interface Props {
   /** Fired once per accepted question submission so the graph can re-frame. */
   onQuestionSubmit?: () => void;
   repoUrl?: string;
+  /** Identifier used to scope persisted conversations. Defaults to `repoUrl`. */
+  projectKey?: string;
   onWidthChange?: (width: number) => void;
   /** Optional content rendered at the bottom of the settings view (e.g. managed provider UI). */
   settingsFooter?: React.ReactNode;
@@ -102,6 +104,7 @@ export default function ChatPanel({
   onChatHighlight,
   onQuestionSubmit,
   repoUrl,
+  projectKey,
   onWidthChange,
   settingsFooter,
 }: Props) {
@@ -144,7 +147,7 @@ export default function ChatPanel({
     persistMessages,
     loadingConversation,
     foundNodeIds: restoredFoundNodeIds,
-  } = useConversation(repoUrl, historyEnabled);
+  } = useConversation(projectKey ?? repoUrl, historyEnabled);
 
   const [showSettings, setShowSettings] = useState(false);
   const [input, setInput] = useState('');


### PR DESCRIPTION
## Add projectKey prop for custom chat history scoping
🆕 **New Feature** · ✨ **Improvement**

Adds a `projectKey` prop to `ChatPanel` to allow custom scoping of persisted chat history.

Embedders can now use unique identifiers for conversations, while the standard desktop application continues to default to `repoUrl`.

### Complexity
🟢 Trivial · `1 file changed, 4 insertions(+), 1 deletion(-)`

This is a single-file change that adds an optional prop with a safe fallback to existing behavior, resulting in no functional impact for standard users.
<!-- opentrace:jid=j-4157b053-c674-48c9-8a9a-252377114328|sha=1859d66c10cd5e9ba66e729cc0443da0d40f5b1d -->