### PR TITLE
fix(oss domain): text change in docs and code to app.opentrace.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,27 +24,30 @@ OpenTrace indexes source code and builds a queryable knowledge graph. Point it a
 ## Get Started
 
 ### Linux/MacOS
-~~~sh
+
+```sh
 uvx opentraceai index .   # Index a local project for use with MCP etc
-~~~
+```
 
 ### Claude Plugin
-~~~
+
+```
 /plugin marketplace add https://github.com/opentrace/opentrace
 /plugin install opentrace-oss@opentrace-oss
 /reload-plugins
-~~~
+```
 
 More info: https://opentrace.github.io/opentrace/getting-started/install-plugin/
 
 ### Gemini CLI
-~~~sh
+
+```sh
 gemini mcp add opentraceai uvx opentraceai mcp
-~~~
+```
 
 ### Run Completely in the Browser
 
-**No install:** **[oss.opentrace.ai](https://oss.opentrace.ai)**
+**No install:** **[app.opentrace.ai](https://app.opentrace.ai)**
 
 ### Run UI Locally
 
@@ -57,28 +60,26 @@ make install && make ui  # Runs on http://localhost:5173/
 
 **Full documentation:** **[opentrace.github.io/opentrace](https://opentrace.github.io/opentrace/)** — install guides, architecture, and reference.
 
-
 **Prerequisites:** plugin and CLI need [`uv`](https://docs.astral.sh/uv/). Source build also needs Node 22+ and Python 3.12+. See [Troubleshooting](https://opentrace.github.io/opentrace/getting-started/troubleshooting/) if anything fails.
-
 
 ## Claude Code Plugin
 
 The plugin gives Claude Code 5 agents, 4 slash commands, and MCP graph tools.
 
-| Agent                  | Description                                                                          |
-| ---------------------- | ------------------------------------------------------------------------------------ |
-| `@opentrace`           | Default catch-all — any codebase question routed to the knowledge graph              |
-| `@code-explorer`       | Explore indexed code structure — find classes, functions, files, and relationships   |
-| `@dependency-analyzer` | Analyze dependencies and blast radius for code changes                               |
-| `@find-usages`         | Find all callers, references, and usages of a component                              |
-| `@explain-service`     | Top-down walkthrough of how a service or module works                                |
+| Agent                  | Description                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `@opentrace`           | Default catch-all — any codebase question routed to the knowledge graph            |
+| `@code-explorer`       | Explore indexed code structure — find classes, functions, files, and relationships |
+| `@dependency-analyzer` | Analyze dependencies and blast radius for code changes                             |
+| `@find-usages`         | Find all callers, references, and usages of a component                            |
+| `@explain-service`     | Top-down walkthrough of how a service or module works                              |
 
-| Command             | Description                                                      |
-| ------------------- | ---------------------------------------------------------------- |
-| `/index`            | Index (or re-index) the current project into the knowledge graph |
-| `/graph-status`     | Show overview of indexed nodes by type                           |
-| `/explore <name>`   | Quick exploration of a named component in the graph              |
-| `/interrogate`      | Answer a question about the codebase without making changes     |
+| Command           | Description                                                      |
+| ----------------- | ---------------------------------------------------------------- |
+| `/index`          | Index (or re-index) the current project into the knowledge graph |
+| `/graph-status`   | Show overview of indexed nodes by type                           |
+| `/explore <name>` | Quick exploration of a named component in the graph              |
+| `/interrogate`    | Answer a question about the codebase without making changes      |
 
 Full details: [Claude Code Plugin reference](https://opentrace.github.io/opentrace/reference/claude-code-plugin/).
 
@@ -96,7 +97,7 @@ Full language matrix: [Supported Languages](https://opentrace.github.io/opentrac
 ┌───────────────────────────────────────────────────────────┐
 │                      UI (React/TS)                        │
 │            Browser-based indexer + graph explorer         │
-│               localhost:5173 / oss.opentrace.ai           │
+│               localhost:5173 / app.opentrace.ai           │
 │                                                           │
 │  ┌───────────────┐  ┌─────────────────┐  ┌──────────────┐ │
 │  │  Web Worker   │  │  LadybugDB WASM │  │  Chat Agent  │ │

--- a/agent/README.md
+++ b/agent/README.md
@@ -67,19 +67,19 @@ Add OpenTrace to Claude Code as a plugin, or configure it manually in your proje
 
 ## MCP Tools
 
-| Tool | Description |
-|------|-------------|
-| `search_graph` | Full-text search across nodes by name or properties |
-| `list_nodes` | List nodes by type (Class, Function, File, etc.) |
-| `get_node` | Get a node's full details and immediate neighbors |
+| Tool             | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| `search_graph`   | Full-text search across nodes by name or properties          |
+| `list_nodes`     | List nodes by type (Class, Function, File, etc.)             |
+| `get_node`       | Get a node's full details and immediate neighbors            |
 | `traverse_graph` | Walk relationships from a node (outgoing, incoming, or both) |
-| `get_stats` | Graph statistics — node/edge counts broken down by type |
+| `get_stats`      | Graph statistics — node/edge counts broken down by type      |
 
 ## Supported Languages
 
-| Full extraction (symbols + calls + imports) | Structural extraction (symbols only) |
-|---------------------------------------------|--------------------------------------|
-| Python, TypeScript/JavaScript, Go | Rust, Java, Kotlin, C#, C/C++, Ruby, Swift |
+| Full extraction (symbols + calls + imports) | Structural extraction (symbols only)       |
+| ------------------------------------------- | ------------------------------------------ |
+| Python, TypeScript/JavaScript, Go           | Rust, Java, Kotlin, C#, C/C++, Ruby, Swift |
 
 Config and data files (JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash) are indexed as file nodes.
 
@@ -89,53 +89,53 @@ Config and data files (JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash) are index
 
 Index a local codebase into a LadybugDB knowledge graph.
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `PATH` | `.` | Directory to index |
-| `--db` | `.opentrace/index.db` | Database path |
-| `--repo-id` | directory name | Repository identifier |
-| `--batch-size` | `200` | Items per write batch |
-| `-v, --verbose` | off | Debug logging |
+| Option          | Default               | Description           |
+| --------------- | --------------------- | --------------------- |
+| `PATH`          | `.`                   | Directory to index    |
+| `--db`          | `.opentrace/index.db` | Database path         |
+| `--repo-id`     | directory name        | Repository identifier |
+| `--batch-size`  | `200`                 | Items per write batch |
+| `-v, --verbose` | off                   | Debug logging         |
 
 ### `opentraceai mcp`
 
 Start a stdio MCP server exposing graph query tools.
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--db` | auto-discovered | Database path |
-| `-v, --verbose` | off | Debug logging |
+| Option          | Default         | Description   |
+| --------------- | --------------- | ------------- |
+| `--db`          | auto-discovered | Database path |
+| `-v, --verbose` | off             | Debug logging |
 
 ### `opentraceai stats`
 
 Display graph statistics (node/edge counts by type).
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--db` | auto-discovered | Database path |
-| `--output` | `text` | Output format (`text` or `json`) |
+| Option     | Default         | Description                      |
+| ---------- | --------------- | -------------------------------- |
+| `--db`     | auto-discovered | Database path                    |
+| `--output` | `text`          | Output format (`text` or `json`) |
 
 ### `opentraceai serve`
 
 Start an HTTP server exposing the graph database as a REST API.
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--db` | auto-discovered | Database path |
-| `--host` | `127.0.0.1` | Bind address |
-| `--port` | `8787` | Bind port |
-| `-v, --verbose` | off | Debug logging |
+| Option          | Default         | Description   |
+| --------------- | --------------- | ------------- |
+| `--db`          | auto-discovered | Database path |
+| `--host`        | `127.0.0.1`     | Bind address  |
+| `--port`        | `8787`          | Bind port     |
+| `-v, --verbose` | off             | Debug logging |
 
 ### `opentraceai query QUERY_STRING`
 
 Run a Cypher or full-text search query against the graph database.
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--db` | auto-discovered | Database path |
-| `-t, --type` | `cypher` | Query language (`cypher` or `fts`) |
-| `--limit` | `100` | Max rows (FTS only) |
-| `--output` | `table` | Output format (`table`, `json`, or `jsonl`) |
+| Option       | Default         | Description                                 |
+| ------------ | --------------- | ------------------------------------------- |
+| `--db`       | auto-discovered | Database path                               |
+| `-t, --type` | `cypher`        | Query language (`cypher` or `fts`)          |
+| `--limit`    | `100`           | Max rows (FTS only)                         |
+| `--output`   | `table`         | Output format (`table`, `json`, or `jsonl`) |
 
 ### `opentraceai export [OUTPUT]`
 
@@ -168,7 +168,7 @@ uv run ruff format src/ tests/  # Format
 
 ## Part of OpenTrace
 
-This package is the CLI/MCP component of [OpenTrace](https://github.com/opentrace/opentrace), an open-source platform for mapping system architecture into knowledge graphs. The full project also includes a browser-based graph explorer at [oss.opentrace.ai](https://oss.opentrace.ai).
+This package is the CLI/MCP component of [OpenTrace](https://github.com/opentrace/opentrace), an open-source platform for mapping system architecture into knowledge graphs. The full project also includes a browser-based graph explorer at [app.opentrace.ai](https://app.opentrace.ai).
 
 ## License
 

--- a/docs/getting-started/install-browser.md
+++ b/docs/getting-started/install-browser.md
@@ -2,11 +2,11 @@
 
 The fastest way to try OpenTrace. Everything runs in your browser — no account, no download, no server.
 
-**[oss.opentrace.ai](https://oss.opentrace.ai)**
+**[app.opentrace.ai](https://app.opentrace.ai)**
 
 ## How It Works
 
-1. Open [oss.opentrace.ai](https://oss.opentrace.ai).
+1. Open [app.opentrace.ai](https://app.opentrace.ai).
 2. Paste a GitHub or GitLab repo URL (public repos work with no auth; private repos need a token).
 3. Watch it index — tree-sitter parses every file directly in a Web Worker, and the knowledge graph is stored in an embedded LadybugDB WASM instance.
 4. Explore the graph, or chat with the built-in agent.
@@ -29,4 +29,4 @@ OpenTrace needs **Cross-Origin Isolation** (for `SharedArrayBuffer`), so you nee
 
 ---
 
-*Other install paths: [Browser](install-browser.md) · [CLI](install-cli.md) · [Plugin](install-plugin.md) · [Source](../development/setup.md)*
+_Other install paths: [Browser](install-browser.md) · [CLI](install-cli.md) · [Plugin](install-plugin.md) · [Source](../development/setup.md)_

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,12 +2,12 @@
 
 OpenTrace has four ways in. Pick the one that matches what you want to do.
 
-| You want to…                          | Use                              | Time       | Guide |
-|---------------------------------------|----------------------------------|------------|-------|
-| See what OpenTrace is                 | Browser                          | 30 seconds | [Browser](install-browser.md) |
-| Give Claude Code codebase awareness   | Claude Code plugin               | 2 minutes  | [Plugin](install-plugin.md) |
-| Index repos from a terminal           | CLI (`uvx` / `pip` / `pipx`)     | 2 minutes  | [CLI](install-cli.md) |
-| Hack on OpenTrace itself              | Source build                     | 5 minutes  | [Development Setup](../development/setup.md) |
+| You want to…                        | Use                          | Time       | Guide                                        |
+| ----------------------------------- | ---------------------------- | ---------- | -------------------------------------------- |
+| See what OpenTrace is               | Browser                      | 30 seconds | [Browser](install-browser.md)                |
+| Give Claude Code codebase awareness | Claude Code plugin           | 2 minutes  | [Plugin](install-plugin.md)                  |
+| Index repos from a terminal         | CLI (`uvx` / `pip` / `pipx`) | 2 minutes  | [CLI](install-cli.md)                        |
+| Hack on OpenTrace itself            | Source build                 | 5 minutes  | [Development Setup](../development/setup.md) |
 
 ## One-Liners
 
@@ -15,7 +15,7 @@ If you already know which path you want:
 
 === "Browser"
 
-    Open [**oss.opentrace.ai**](https://oss.opentrace.ai) and paste a repo URL. Done.
+    Open [**app.opentrace.ai**](https://app.opentrace.ai) and paste a repo URL. Done.
 
 === "Claude Code Plugin"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,16 +2,16 @@
 
 A knowledge graph that maps your codebase structure, service architecture, and system relationships — then exposes it all through MCP so AI tools can understand your systems.
 
-**[Try it now at oss.opentrace.ai](https://oss.opentrace.ai)** — no install required, runs entirely in your browser.
+**[Try it now at app.opentrace.ai](https://app.opentrace.ai)** — no install required, runs entirely in your browser.
 
 ## Where to Start
 
-| Goal                                  | Start here |
-|---------------------------------------|------------|
-| See what OpenTrace is                 | [Browser (no install)](getting-started/install-browser.md) |
-| Give Claude Code codebase awareness   | [Claude Code Plugin](getting-started/install-plugin.md) |
-| Index repos from a terminal           | [CLI](getting-started/install-cli.md) |
-| Hack on OpenTrace itself              | [Development Setup](development/setup.md) |
+| Goal                                | Start here                                                 |
+| ----------------------------------- | ---------------------------------------------------------- |
+| See what OpenTrace is               | [Browser (no install)](getting-started/install-browser.md) |
+| Give Claude Code codebase awareness | [Claude Code Plugin](getting-started/install-plugin.md)    |
+| Index repos from a terminal         | [CLI](getting-started/install-cli.md)                      |
+| Hack on OpenTrace itself            | [Development Setup](development/setup.md)                  |
 
 Not sure? → [Pick Your Path](getting-started/quickstart.md)
 

--- a/ui/src/pr/client.ts
+++ b/ui/src/pr/client.ts
@@ -50,7 +50,7 @@ import { parseBitbucketUrl } from '../runner/browser/loader/bitbucket';
 import { parseAzureDevOpsUrl } from '../runner/browser/loader/azuredevops';
 
 const ATTRIBUTION_FOOTER =
-  '\n\n---\n*Generated via [OpenTrace](https://oss.opentrace.ai)*';
+  '\n\n---\n*Generated via [OpenTrace](https://app.opentrace.ai)*';
 
 export class PRClient {
   readonly meta: RepoMeta;


### PR DESCRIPTION
## Update public domain to app.opentrace.ai
📝 **Docs** · 🔧 **Chore** · ♻️ **Refactor**

Migrates the primary public domain from `oss.opentrace.ai` to `app.opentrace.ai`. 

Includes general Markdown cleanup, such as standardizing code block fences and realigning tables for better readability.

### Complexity
🟢 Low · `6 files changed, 80 insertions(+), 79 deletions(-)`

Straightforward search-and-replace of domain strings in documentation and a single UI constant. No architectural or logic changes are introduced.

### Review focus
Pay particular attention to the following areas:

- **Functional fallbacks** — Repository loaders (GitHub, GitLab, etc.) still hardcode the old domain as a fallback for the archive proxy.
- **CI/CD Pipeline** — The deployment workflow still performs health checks and Playwright tests against the old URL.
- **Environment Templates** — `.env.example` still references the old domain for `VITE_ARCHIVE_URL`.
<!-- opentrace:jid=j-2c12ea94-f0db-4c7f-9505-9237d9c3a24f|sha=c15d3ac80584e43a574fb2b18451896ba3613ca8 -->