### PR TITLE
fix(plugins/opencode): declare @opencode-ai/plugin as runtime dep

### DIFF
--- a/plugins/opencode/bun.lock
+++ b/plugins/opencode/bun.lock
@@ -5,19 +5,13 @@
     "": {
       "name": "@opentrace/opencode",
       "dependencies": {
+        "@opencode-ai/plugin": "^1.4.3",
         "zod": "^3.23.0",
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "^1.4.3",
         "@types/bun": "latest",
         "typescript": "^5.5.0",
       },
-      "peerDependencies": {
-        "@opencode-ai/plugin": "^1",
-      },
-      "optionalPeers": [
-        "@opencode-ai/plugin",
-      ],
     },
   },
   "packages": {

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -28,20 +28,12 @@
     "directory": "plugins/opencode"
   },
   "dependencies": {
+    "@opencode-ai/plugin": "^1.4.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "@opencode-ai/plugin": "^1.4.3",
     "@types/bun": "latest",
     "typescript": "^5.5.0"
-  },
-  "peerDependencies": {
-    "@opencode-ai/plugin": "^1"
-  },
-  "peerDependenciesMeta": {
-    "@opencode-ai/plugin": {
-      "optional": true
-    }
   },
   "engines": {
     "bun": ">=1.0.0"


### PR DESCRIPTION
Was peerDependency with optional=true, which makes bun install skip it. The bundled plugin runtime-imports @opencode-ai/plugin for the `tool` helper, so the import failed at load time with "Cannot find module".

## Summary

<!-- Brief description of what changed and why -->

## Changes

<!-- Bulleted list of specific changes -->

-

## Test plan

<!-- How the changes were verified -->

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or noted above)
