### PR TITLE
chore(ci): allow same-version npm bumps in release workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set version
         working-directory: ui
         run: |
-          npm version "${{ needs.version.outputs.version }}" --no-git-tag-version
+          npm version "${{ needs.version.outputs.version }}" --no-git-tag-version --allow-same-version
           echo "Publishing @opentrace/opentrace@${{ needs.version.outputs.version }} with tag ${{ needs.version.outputs.tag }}"
 
       - name: Install dependencies

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set version
         working-directory: plugins/opencode
         run: |
-          npm version "${{ needs.version.outputs.version }}" --no-git-tag-version
+          npm version "${{ needs.version.outputs.version }}" --no-git-tag-version --allow-same-version
           echo "Publishing @opentrace/opencode@${{ needs.version.outputs.version }} with tag ${{ needs.version.outputs.tag }}"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
           # Bump UI version
           cd ui
-          npm version "${VERSION}" --no-git-tag-version
+          npm version "${VERSION}" --no-git-tag-version --allow-same-version
           cd ..
 
           # Regenerate full changelog


### PR DESCRIPTION
## Allow idempotent npm version bumps in CI workflows
🔧 **Chore**

Adds `--allow-same-version` to `npm version` commands across release workflows. 

This makes the versioning step idempotent and prevents CI failures when a version has been manually pre-bumped in a PR.

### Complexity
🟢 Trivial · `3 files changed, 3 insertions(+), 3 deletions(-)`

Simple addition of a standard npm flag to GitHub Actions workflows with no impact on runtime code.
<!-- opentrace:jid=e7c9845f-4c1c-4b78-855e-f7ec5be1ca47|sha=b114f8edc727139adb51bc42258d4c59251c469a -->