### PR TITLE
fix(plugins/opencode): surface install guidance when cached CLI vanishes

### DIFF
--- a/plugins/opencode/src/graph-client.ts
+++ b/plugins/opencode/src/graph-client.ts
@@ -441,6 +441,10 @@ export class GraphClient {
       return stdout.trim() || null
     } catch (e) {
       debug("graph", "run: spawn error", subArgs[0], e)
+      if (isMissingBinaryError(e)) {
+        this.exe = null
+        if (opts?.surfaceErrors) return getCliMissingMessage()
+      }
       return null
     }
   }
@@ -856,6 +860,10 @@ export class GraphClient {
       return { ok: true, output: stdout.trim(), exitCode }
     } catch (e: any) {
       debug("graph", "runWithTimeout: spawn error", subArgs[0], e)
+      if (isMissingBinaryError(e)) {
+        this.exe = null
+        return { ok: false, output: getCliMissingMessage() }
+      }
       return { ok: false, output: `Error: ${e.message ?? e}` }
     }
   }
@@ -884,6 +892,14 @@ function tryParseJson(s: string): Record<string, any> | undefined {
   } catch {
     return undefined
   }
+}
+
+// Spawn-level errors that mean the cached binary path is no longer usable
+// — typically a uv-tool / pipx shim whose target was removed mid-session.
+function isMissingBinaryError(e: unknown): boolean {
+  const code = (e as { code?: unknown })?.code
+  if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES") return true
+  return /ENOENT|ENOTDIR|EACCES/.test(String((e as { message?: unknown })?.message ?? e))
 }
 
 // Flags whose following argument is a secret and must not appear in debug logs.

--- a/plugins/opencode/test/_helpers/fake-cli.ts
+++ b/plugins/opencode/test/_helpers/fake-cli.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync, existsSync } from "node:fs"
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -58,6 +58,17 @@ export class FakeCli {
         process.env[`FAKE_STDOUT_BY_${sub.replace(/-/g, "_").toUpperCase()}`] = val
       }
     }
+  }
+
+  /** Delete the binary at its cached path — simulates a mid-session uninstall. */
+  removeBinary(): void {
+    rmSync(this.bin, { force: true })
+  }
+
+  /** Re-create the binary at the same path — simulates a reinstall mid-session. */
+  restoreBinary(): void {
+    writeFileSync(this.bin, FAKE_SCRIPT.replace("__ARGV_LOG__", this.argvLog))
+    chmodSync(this.bin, 0o755)
   }
 
   /** Read every recorded argv as a list of arrays. */

--- a/plugins/opencode/test/graph-client.test.ts
+++ b/plugins/opencode/test/graph-client.test.ts
@@ -786,3 +786,51 @@ describe("ftsSearch — nodeTypes without an explicit limit", () => {
     expect(argv).not.toContain("--limit")
   })
 })
+
+describe("binary vanishes after a successful create() probe", () => {
+  test("indexRepo surfaces install guidance instead of a raw posix_spawn ENOENT", async () => {
+    const client = await makeClient("/w")
+    expect(client.isCliAvailable()).toBe(true)
+
+    fake.removeBinary()
+    const result = await client.indexRepo("/local/repo")
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain("uv tool install opentraceai")
+    expect(result.message).toContain("pipx install opentraceai")
+    expect(result.message).not.toMatch(/ENOENT|posix_spawn/)
+  })
+
+  test("the cache is cleared so a reinstall is picked up without restart", async () => {
+    const client = await makeClient("/w")
+    fake.removeBinary()
+
+    const failed = await client.indexRepo("/local/repo")
+    expect(failed.ok).toBe(false)
+    expect(client.isCliAvailable()).toBe(false)
+
+    fake.restoreBinary()
+    fake.configure({ exitCode: 0, stdout: "Indexed" })
+    const recovered = await client.indexRepo("/local/repo")
+    expect(recovered).toEqual({ ok: true, message: "Indexed" })
+    expect(client.isCliAvailable()).toBe(true)
+  })
+
+  test("sourceSearchText (surfaceErrors path) returns install guidance", async () => {
+    const client = await makeClient("/w")
+    fake.removeBinary()
+
+    const out = await client.sourceSearchText("foo")
+    expect(out).toContain("uv tool install opentraceai")
+    expect(out).not.toMatch(/ENOENT|posix_spawn/)
+  })
+
+  test("stats() (non-surfacing path) returns null but still clears the cache", async () => {
+    const client = await makeClient("/w")
+    fake.removeBinary()
+
+    const stats = await client.stats()
+    expect(stats).toBeNull()
+    expect(client.isCliAvailable()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Fix persistent failures after CLI binary removal
🐛 **Bug Fix** · ✨ **Improvement** · 🧪 **Tests**

Fixes an issue where the `GraphClient` would permanently fail if the `opentraceai` binary was uninstalled or moved after the initial probe.

The runner now detects spawn-level errors (like `ENOENT`), clears the stale cached path, and returns helpful installation guidance to the user. This allows the plugin to pick up a reinstall immediately without requiring a restart.

### Complexity
🟢 Low · `3 files changed, 76 insertions(+), 1 deletion(-)`

Targeted fix to the CLI execution wrapper. The change is isolated to error-handling logic and includes thorough tests for the new behavior.

### Tests
🧪 Adds integration tests simulating mid-session uninstalls and reinstalls to verify recovery logic.

### Review focus
Pay particular attention to the following areas:

- **Error matching** — verify `isMissingBinaryError` correctly identifies environment issues without catching unrelated spawn failures.
<!-- opentrace:jid=j-32f99d9f-a604-4af5-ae35-37739e83f0e2|sha=f48e8c29f69028e2375ed6899c70759f0598a717 -->