### PR TITLE
fix(ui): remove Linux from suggested repos in AddRepoModal

### DIFF
--- a/ui/src/components/indexing/AddRepoModal.tsx
+++ b/ui/src/components/indexing/AddRepoModal.tsx
@@ -297,12 +297,6 @@ const EXAMPLE_REPOS: {
     description: 'Open-source observability and monitoring platform',
     size: 'L',
   },
-  {
-    name: 'Linux',
-    url: 'https://github.com/torvalds/linux',
-    description: 'Linux kernel source tree',
-    size: 'L',
-  },
 ];
 
 // --- Main Component ---


### PR DESCRIPTION
## Remove Linux kernel from suggested example repositories
🐛 **Bug Fix** · ✨ **Improvement**

Removes the `torvalds/linux` repository from the suggested examples list in the `AddRepoModal`.

The Linux kernel source tree is too large for the browser-based playground to index reliably and consistently fails to load. This change prevents users from selecting a promoted example that leads to a failure.

### Complexity
🟢 Trivial · `1 file changed, 6 deletions(-)`

Simple removal of a static configuration entry from an array in a single file with no impact on component logic.
<!-- opentrace:jid=j-58f79c15-3e1d-4e6e-b3aa-8f86b34615dc|sha=a426395b4be2796729bd891495d49f56c0a0a1be -->