### PR TITLE
fix(ui): prompt for PR review token inline and persist reviews

### DIFF
--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -186,10 +186,8 @@ export default function ChatPanel({
     if (!repoUrl) return null;
     const meta = parseRepoUrl(repoUrl);
     if (!meta) return null;
-    // Use the same localStorage keys as AddRepoModal
-    const tokenKey =
-      meta.provider === 'gitlab' ? 'ot_gitlab_pat' : 'ot_github_pat';
-    const token = localStorage.getItem(tokenKey) ?? undefined;
+    // Same localStorage keys as AddRepoModal: ot_<provider>_pat
+    const token = localStorage.getItem(`ot_${meta.provider}_pat`) ?? undefined;
     return new PRClient(meta, token);
   }, [repoUrl]);
 

--- a/ui/src/appComponents/PRDetailPanel.tsx
+++ b/ui/src/appComponents/PRDetailPanel.tsx
@@ -29,6 +29,11 @@ import type { PRClient } from '../pr/client';
 import type { GraphStore } from '../store/types';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { runPRReview } from '../pr/reviewRunner';
+import {
+  loadReview,
+  saveReview,
+  clearReview as clearSavedReview,
+} from '../pr/reviewStorage';
 import './PRDetailPanel.css';
 
 interface Props {
@@ -97,9 +102,26 @@ export default function PRDetailPanel({
   const [reviewSteps, setReviewSteps] = useState<string[]>([]);
   const [reviewResult, setReviewResult] = useState<string | null>(null);
   const [reviewError, setReviewError] = useState<string | null>(null);
+  const [reviewSubmitted, setReviewSubmitted] = useState(false);
+  const [hasToken, setHasToken] = useState(() => prClient?.hasToken() ?? false);
   const abortRef = useRef<AbortController | null>(null);
 
   const canReview = !!(llm && store);
+
+  // Restore any previously cached review for this PR
+  useEffect(() => {
+    setReviewSteps([]);
+    setReviewError(null);
+    if (!prClient) {
+      setReviewResult(null);
+      setReviewSubmitted(false);
+      return;
+    }
+    const saved = loadReview(prClient.meta, pr.number);
+    setReviewResult(saved?.result ?? null);
+    setReviewSubmitted(!!saved?.submittedAt);
+    setHasToken(prClient.hasToken());
+  }, [prClient, pr.number]);
 
   // Check if this PR is already indexed in the graph
   useEffect(() => {
@@ -152,6 +174,8 @@ export default function PRDetailPanel({
     setReviewSteps([]);
     setReviewResult(null);
     setReviewError(null);
+    setReviewSubmitted(false);
+    if (prClient) clearSavedReview(prClient.meta, pr.number);
 
     const meta = prClient
       ? { owner: prClient.meta.owner, repo: prClient.meta.repo }
@@ -164,6 +188,9 @@ export default function PRDetailPanel({
       });
       if (!controller.signal.aborted) {
         setReviewResult(result);
+        if (prClient) {
+          saveReview(prClient.meta, pr.number, { result });
+        }
       }
     } catch (err) {
       if (!controller.signal.aborted) {
@@ -188,11 +215,33 @@ export default function PRDetailPanel({
       data.comments.filter((c) => c.path),
       pr.files, // pass diffs so line numbers can be validated against patches
     );
+    // Persist submitted state so refresh / re-open doesn't re-show the form.
+    setReviewSubmitted(true);
+    if (reviewResult) {
+      saveReview(prClient.meta, pr.number, {
+        result: reviewResult,
+        submittedAt: Date.now(),
+      });
+    }
   };
 
   const handlePostAsComment = async (body: string) => {
     if (!prClient) throw new Error('No PR client configured');
     await prClient.postComment(pr.number, body);
+    setReviewSubmitted(true);
+    if (reviewResult) {
+      saveReview(prClient.meta, pr.number, {
+        result: reviewResult,
+        submittedAt: Date.now(),
+      });
+    }
+  };
+
+  const handleProvideToken = (token: string) => {
+    if (!prClient) return;
+    localStorage.setItem(`ot_${prClient.meta.provider}_pat`, token);
+    prClient.setToken(token);
+    setHasToken(true);
   };
 
   const totalAdditions = pr.files.reduce((s, f) => s + f.additions, 0);
@@ -373,6 +422,10 @@ export default function PRDetailPanel({
               review={parsedReview}
               onSubmit={prClient ? handleSubmitReview : undefined}
               onPostAsComment={prClient ? handlePostAsComment : undefined}
+              provider={prClient?.meta.provider}
+              onProvideToken={prClient ? handleProvideToken : undefined}
+              tokenMissing={!!prClient && !hasToken}
+              submitted={reviewSubmitted}
             />
           ) : (
             <ReviewResult
@@ -383,6 +436,10 @@ export default function PRDetailPanel({
               }}
               onSubmit={prClient ? handleSubmitReview : undefined}
               onPostAsComment={prClient ? handlePostAsComment : undefined}
+              provider={prClient?.meta.provider}
+              onProvideToken={prClient ? handleProvideToken : undefined}
+              tokenMissing={!!prClient && !hasToken}
+              submitted={reviewSubmitted}
             />
           )}
           {onChatWithPR && (

--- a/ui/src/appComponents/PRDetailPanel.tsx
+++ b/ui/src/appComponents/PRDetailPanel.tsx
@@ -103,10 +103,21 @@ export default function PRDetailPanel({
   const [reviewResult, setReviewResult] = useState<string | null>(null);
   const [reviewError, setReviewError] = useState<string | null>(null);
   const [reviewSubmitted, setReviewSubmitted] = useState(false);
-  const [hasToken, setHasToken] = useState(() => prClient?.hasToken() ?? false);
+  // `hasToken` is set by the restore effect on mount / PR change; starting at
+  // `false` here would cause a one-render flash of the token form, so we
+  // derive it lazily from `prClient` at first read and keep it in sync below.
+  const [hasToken, setHasToken] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  // Mirror of `reviewResult` so async handlers always see the latest value
+  // even if a re-render happens between the click and the save.
+  const reviewResultRef = useRef<string | null>(null);
 
   const canReview = !!(llm && store);
+
+  // Keep the ref mirror of reviewResult in sync each render.
+  useEffect(() => {
+    reviewResultRef.current = reviewResult;
+  }, [reviewResult]);
 
   // Restore any previously cached review for this PR
   useEffect(() => {
@@ -115,6 +126,7 @@ export default function PRDetailPanel({
     if (!prClient) {
       setReviewResult(null);
       setReviewSubmitted(false);
+      setHasToken(false);
       return;
     }
     const saved = loadReview(prClient.meta, pr.number);
@@ -217,9 +229,10 @@ export default function PRDetailPanel({
     );
     // Persist submitted state so refresh / re-open doesn't re-show the form.
     setReviewSubmitted(true);
-    if (reviewResult) {
+    const latest = reviewResultRef.current;
+    if (latest) {
       saveReview(prClient.meta, pr.number, {
-        result: reviewResult,
+        result: latest,
         submittedAt: Date.now(),
       });
     }
@@ -229,9 +242,10 @@ export default function PRDetailPanel({
     if (!prClient) throw new Error('No PR client configured');
     await prClient.postComment(pr.number, body);
     setReviewSubmitted(true);
-    if (reviewResult) {
+    const latest = reviewResultRef.current;
+    if (latest) {
       saveReview(prClient.meta, pr.number, {
-        result: reviewResult,
+        result: latest,
         submittedAt: Date.now(),
       });
     }

--- a/ui/src/appComponents/PRDetailPanel.tsx
+++ b/ui/src/appComponents/PRDetailPanel.tsx
@@ -22,6 +22,7 @@ import {
   ReviewResult,
   parseReviewResult,
   stripReviewBlock,
+  TOKEN_PROVIDER_LABEL,
   type ReviewData,
 } from '@opentrace/components/chat';
 import type { PRDetail, PRFileDiff } from '../pr/types';
@@ -351,7 +352,8 @@ export default function PRDetailPanel({
           target="_blank"
           rel="noopener noreferrer"
         >
-          Open in {pr.url.includes('gitlab') ? 'GitLab' : 'GitHub'}
+          Open in{' '}
+          {prClient ? TOKEN_PROVIDER_LABEL[prClient.meta.provider] : 'GitHub'}
           <svg
             width="12"
             height="12"

--- a/ui/src/appComponents/SettingsDrawer.tsx
+++ b/ui/src/appComponents/SettingsDrawer.tsx
@@ -44,6 +44,55 @@ function loadLimit(key: string, fallback: number): number {
   return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
+type PatProvider = 'github' | 'gitlab' | 'bitbucket' | 'azuredevops';
+
+const PAT_PROVIDERS: ReadonlyArray<{
+  id: PatProvider;
+  label: string;
+  helpUrl: string;
+  noun: string;
+}> = [
+  {
+    id: 'github',
+    label: 'GitHub',
+    helpUrl: 'https://github.com/settings/tokens',
+    noun: 'Personal Access Token',
+  },
+  {
+    id: 'gitlab',
+    label: 'GitLab',
+    helpUrl: 'https://gitlab.com/-/user_settings/personal_access_tokens',
+    noun: 'Personal Access Token',
+  },
+  {
+    id: 'bitbucket',
+    label: 'Bitbucket',
+    helpUrl: 'https://bitbucket.org/account/settings/app-passwords/',
+    noun: 'App Password',
+  },
+  {
+    id: 'azuredevops',
+    label: 'Azure DevOps',
+    helpUrl:
+      'https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate',
+    noun: 'Personal Access Token',
+  },
+];
+
+function patStorageKey(p: PatProvider): string {
+  return `ot_${p}_pat`;
+}
+
+function loadAllPats(): Record<PatProvider, string> {
+  return PAT_PROVIDERS.reduce(
+    (acc, p) => {
+      acc[p.id] = localStorage.getItem(patStorageKey(p.id)) ?? '';
+      return acc;
+    },
+    {} as Record<PatProvider, string>,
+  );
+}
+
 interface SettingsDrawerProps {
   onClose: () => void;
   onGraphCleared: () => void;
@@ -82,6 +131,23 @@ export default function SettingsDrawer({
     loadLimit(LS_KEY_EDGES, DEFAULT_MAX_EDGES),
   );
   const [animSettings, setAnimSettings] = useState(loadAnimationSettings);
+  const [pats, setPats] = useState<Record<PatProvider, string>>(loadAllPats);
+  const [patSaved, setPatSaved] = useState<PatProvider | null>(null);
+
+  const handlePatChange = (provider: PatProvider, value: string) => {
+    setPats((prev) => ({ ...prev, [provider]: value }));
+    if (patSaved === provider) setPatSaved(null);
+  };
+
+  const handlePatSave = (provider: PatProvider) => {
+    const value = pats[provider].trim();
+    if (value) {
+      localStorage.setItem(patStorageKey(provider), value);
+    } else {
+      localStorage.removeItem(patStorageKey(provider));
+    }
+    setPatSaved(provider);
+  };
 
   const handleAnimToggle = (key: keyof AnimationSettings) => {
     const next = { ...animSettings, [key]: !animSettings[key] };
@@ -399,6 +465,61 @@ export default function SettingsDrawer({
                   style={{ width: '100%', marginTop: 2 }}
                 >
                   {hint}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="settings-section">
+          <h4>PR Tokens</h4>
+          <div className="setting-card">
+            <div className="setting-info">
+              <strong>Git host access tokens</strong>
+              <p>
+                Used to fetch private repos and to submit PR reviews / comments
+                from OpenTrace. Stored locally in your browser — never sent to
+                OpenTrace servers.
+              </p>
+            </div>
+            {PAT_PROVIDERS.map((p) => (
+              <div
+                key={p.id}
+                className="limit-row"
+                style={{ flexWrap: 'wrap' }}
+              >
+                <label
+                  className="limit-label"
+                  htmlFor={`pat-${p.id}`}
+                  style={{ flex: 1 }}
+                >
+                  {p.label}
+                </label>
+                <input
+                  id={`pat-${p.id}`}
+                  type="password"
+                  className="settings-select"
+                  placeholder={`${p.noun}`}
+                  value={pats[p.id]}
+                  onChange={(e) => handlePatChange(p.id, e.target.value)}
+                  style={{ flex: '1 1 200px' }}
+                  autoComplete="off"
+                />
+                <button
+                  type="button"
+                  className="settings-back-btn"
+                  onClick={() => handlePatSave(p.id)}
+                  style={{ flex: 'none' }}
+                >
+                  {patSaved === p.id ? 'Saved ✓' : 'Save'}
+                </button>
+                <p
+                  className="setting-hint"
+                  style={{ width: '100%', marginTop: 2 }}
+                >
+                  <a href={p.helpUrl} target="_blank" rel="noopener noreferrer">
+                    Create a {p.label} {p.noun} &rarr;
+                  </a>
                 </p>
               </div>
             ))}

--- a/ui/src/components/chat/index.ts
+++ b/ui/src/components/chat/index.ts
@@ -51,7 +51,9 @@ export {
   default as ReviewResult,
   parseReviewResult,
   stripReviewBlock,
+  TOKEN_PROVIDER_LABEL,
   type ReviewData,
+  type TokenProvider,
 } from './results/ReviewResult';
 export {
   default as SuggestCommentResult,

--- a/ui/src/components/chat/results/ReviewResult.css
+++ b/ui/src/components/chat/results/ReviewResult.css
@@ -215,6 +215,57 @@
   cursor: not-allowed;
 }
 
+/* ── Inline token prompt (shown when submit fails with "Token required") ── */
+
+.review-token-prompt-header {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.review-token-prompt-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+  width: 100%;
+}
+
+.review-token-input {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  border-radius: calc(var(--radius) - 2px);
+  border: 1px solid color-mix(in oklch, var(--border) 50%, transparent);
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+}
+
+.review-token-input:focus {
+  outline: none;
+  border-color: var(--primary, #3b82f6);
+}
+
+.review-token-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.review-token-prompt-hint {
+  font-size: 0.7rem;
+  color: var(--muted-foreground);
+  font-style: italic;
+}
+
+.review-token-prompt-hint a {
+  color: var(--primary, #3b82f6);
+  text-decoration: none;
+}
+
+.review-token-prompt-hint a:hover {
+  text-decoration: underline;
+}
+
 .review-submitted-badge {
   display: flex;
   align-items: center;

--- a/ui/src/components/chat/results/ReviewResult.tsx
+++ b/ui/src/components/chat/results/ReviewResult.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import type { PRReviewComment } from '../types';
 import { markdownComponents } from '../markdownComponents';
@@ -171,6 +171,13 @@ export default function ReviewResult({
   const [tokenInput, setTokenInput] = useState('');
   const [savingToken, setSavingToken] = useState(false);
 
+  // Sync `done` if the parent later flips `submitted` to true (e.g. after
+  // restoring a previously-submitted review from cache while this component
+  // stays mounted across PR switches).
+  useEffect(() => {
+    if (submitted) setDone(true);
+  }, [submitted]);
+
   const handleSubmit = async () => {
     if (!onSubmit) return;
     setSubmitting(true);
@@ -190,15 +197,22 @@ export default function ReviewResult({
 
   const handleSaveTokenAndRetry = async () => {
     if (!onProvideToken || !tokenInput.trim()) return;
+    if (submitting || savingToken) return; // guard against double-submits
     setSavingToken(true);
     try {
       await onProvideToken(tokenInput.trim());
-      setTokenInput('');
-      // Clear the error so the prompt collapses; then retry submit.
+      // Clear error so the prompt collapses; then retry submit.
       setError(null);
       setErrorRaw(null);
       await handleSubmit();
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : String(err);
+      setErrorRaw(raw);
+      setError(friendlyError(raw));
     } finally {
+      // Always clear the token from state — even on failure — so it doesn't
+      // linger in the React tree.
+      setTokenInput('');
       setSavingToken(false);
     }
   };
@@ -327,6 +341,7 @@ export default function ReviewResult({
               <div className="review-token-prompt-row">
                 <input
                   type="password"
+                  autoComplete="new-password"
                   className="review-token-input"
                   placeholder={`Paste ${providerLabel} ${tokenNoun}`}
                   value={tokenInput}

--- a/ui/src/components/chat/results/ReviewResult.tsx
+++ b/ui/src/components/chat/results/ReviewResult.tsx
@@ -117,9 +117,11 @@ function isTokenError(raw: string): boolean {
   );
 }
 
-type TokenProvider = 'github' | 'gitlab' | 'bitbucket' | 'azuredevops';
+// eslint-disable-next-line react-refresh/only-export-components
+export type TokenProvider = 'github' | 'gitlab' | 'bitbucket' | 'azuredevops';
 
-const TOKEN_PROVIDER_LABEL: Record<TokenProvider, string> = {
+// eslint-disable-next-line react-refresh/only-export-components
+export const TOKEN_PROVIDER_LABEL: Record<TokenProvider, string> = {
   github: 'GitHub',
   gitlab: 'GitLab',
   bitbucket: 'Bitbucket',

--- a/ui/src/components/chat/results/ReviewResult.tsx
+++ b/ui/src/components/chat/results/ReviewResult.tsx
@@ -107,11 +107,51 @@ function isOwnPRError(raw: string): boolean {
   return /approve your own/i.test(raw) || /Can not approve/i.test(raw);
 }
 
+/** Check if the error is a missing/invalid token error */
+function isTokenError(raw: string): boolean {
+  return (
+    /token required/i.test(raw) ||
+    /bad credentials/i.test(raw) ||
+    /401\b/.test(raw) ||
+    /requires authentication/i.test(raw)
+  );
+}
+
+type TokenProvider = 'github' | 'gitlab' | 'bitbucket' | 'azuredevops';
+
+const TOKEN_PROVIDER_LABEL: Record<TokenProvider, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  bitbucket: 'Bitbucket',
+  azuredevops: 'Azure DevOps',
+};
+
+const TOKEN_PROVIDER_HELP: Record<TokenProvider, string> = {
+  github: 'https://github.com/settings/tokens',
+  gitlab: 'https://gitlab.com/-/user_settings/personal_access_tokens',
+  bitbucket: 'https://bitbucket.org/account/settings/app-passwords/',
+  azuredevops:
+    'https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate',
+};
+
 interface Props {
   review: ReviewData;
   onSubmit?: (data: ReviewData) => Promise<void>;
   onPostAsComment?: (body: string) => Promise<void>;
   submitted?: boolean;
+  /** Provider for the repo this review targets — controls the "Get a token" help link. */
+  provider?: TokenProvider;
+  /**
+   * Called when the user enters a token via the inline prompt that appears after a
+   * "Token required" submit failure. Implementer should persist the token and update
+   * any in-memory client so the next submit retry succeeds.
+   */
+  onProvideToken?: (token: string) => Promise<void> | void;
+  /**
+   * If true, no auth token is configured for the target host — show the token entry
+   * form proactively (instead of waiting for the user to click Submit and fail).
+   */
+  tokenMissing?: boolean;
 }
 
 export default function ReviewResult({
@@ -119,12 +159,17 @@ export default function ReviewResult({
   onSubmit,
   onPostAsComment,
   submitted,
+  provider,
+  onProvideToken,
+  tokenMissing,
 }: Props) {
   const [verdict, setVerdict] = useState(review.verdict);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorRaw, setErrorRaw] = useState<string | null>(null);
   const [done, setDone] = useState(submitted ?? false);
+  const [tokenInput, setTokenInput] = useState('');
+  const [savingToken, setSavingToken] = useState(false);
 
   const handleSubmit = async () => {
     if (!onSubmit) return;
@@ -140,6 +185,21 @@ export default function ReviewResult({
       setError(friendlyError(raw));
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleSaveTokenAndRetry = async () => {
+    if (!onProvideToken || !tokenInput.trim()) return;
+    setSavingToken(true);
+    try {
+      await onProvideToken(tokenInput.trim());
+      setTokenInput('');
+      // Clear the error so the prompt collapses; then retry submit.
+      setError(null);
+      setErrorRaw(null);
+      await handleSubmit();
+    } finally {
+      setSavingToken(false);
     }
   };
 
@@ -178,6 +238,23 @@ export default function ReviewResult({
     (isOwnPRError(errorRaw) || errorRaw.includes('422')) &&
     onPostAsComment
   );
+
+  const errorIsTokenIssue = !!(
+    error &&
+    errorRaw &&
+    isTokenError(errorRaw) &&
+    onProvideToken
+  );
+
+  // Show the token form when (a) no token is configured for this host yet, or
+  // (b) the last submit failed because of an auth/token problem.
+  const showTokenForm =
+    !!onProvideToken && (errorIsTokenIssue || !!tokenMissing);
+
+  const providerLabel = provider ? TOKEN_PROVIDER_LABEL[provider] : 'Git host';
+  const providerHelpUrl = provider ? TOKEN_PROVIDER_HELP[provider] : null;
+  const tokenNoun =
+    provider === 'bitbucket' ? 'App Password' : 'Personal Access Token';
 
   return (
     <div className="review-result">
@@ -232,33 +309,88 @@ export default function ReviewResult({
               onChange={(e) =>
                 setVerdict(e.target.value as ReviewData['verdict'])
               }
-              disabled={submitting}
+              disabled={submitting || savingToken}
             >
               <option value="COMMENT">Comment</option>
               <option value="APPROVE">Approve</option>
               <option value="REQUEST_CHANGES">Request Changes</option>
             </select>
           </div>
-          <button
-            className="review-submit-btn"
-            onClick={handleSubmit}
-            disabled={submitting}
-          >
-            {submitting ? 'Submitting...' : 'Submit Review'}
-          </button>
-          {error && (
+
+          {showTokenForm ? (
             <div className="review-submit-error">
-              {error}
-              {showCommentFallback && (
+              <div className="review-token-prompt-header">
+                {errorIsTokenIssue
+                  ? `That ${providerLabel} ${tokenNoun} didn't work — try another.`
+                  : `Add a ${providerLabel} ${tokenNoun} to submit reviews.`}
+              </div>
+              <div className="review-token-prompt-row">
+                <input
+                  type="password"
+                  className="review-token-input"
+                  placeholder={`Paste ${providerLabel} ${tokenNoun}`}
+                  value={tokenInput}
+                  onChange={(e) => setTokenInput(e.target.value)}
+                  disabled={savingToken || submitting}
+                  autoFocus={errorIsTokenIssue}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' &&
+                      tokenInput.trim() &&
+                      !savingToken
+                    ) {
+                      void handleSaveTokenAndRetry();
+                    }
+                  }}
+                />
                 <button
-                  className="review-fallback-btn"
-                  onClick={handlePostAsComment}
-                  disabled={submitting}
+                  type="button"
+                  className="review-submit-btn"
+                  onClick={() => void handleSaveTokenAndRetry()}
+                  disabled={!tokenInput.trim() || savingToken || submitting}
                 >
-                  Post as Comment Instead
+                  {savingToken || submitting
+                    ? 'Submitting...'
+                    : 'Save & Submit'}
                 </button>
+              </div>
+              {providerHelpUrl && (
+                <div className="review-token-prompt-hint">
+                  Token is stored locally in your browser.{' '}
+                  <a
+                    href={providerHelpUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Create one &rarr;
+                  </a>
+                </div>
               )}
             </div>
+          ) : (
+            <>
+              <button
+                className="review-submit-btn"
+                onClick={handleSubmit}
+                disabled={submitting}
+              >
+                {submitting ? 'Submitting...' : 'Submit Review'}
+              </button>
+              {error && (
+                <div className="review-submit-error">
+                  {error}
+                  {showCommentFallback && (
+                    <button
+                      className="review-fallback-btn"
+                      onClick={handlePostAsComment}
+                      disabled={submitting}
+                    >
+                      Post as Comment Instead
+                    </button>
+                  )}
+                </div>
+              )}
+            </>
           )}
         </div>
       )}

--- a/ui/src/pr/client.ts
+++ b/ui/src/pr/client.ts
@@ -66,6 +66,15 @@ export class PRClient {
     }
   }
 
+  /** Update the auth token in place (e.g. after the user enters one in a prompt). */
+  setToken(token: string | undefined): void {
+    this.token = token || undefined;
+  }
+
+  hasToken(): boolean {
+    return !!this.token;
+  }
+
   async listPRs(): Promise<PRSummary[]> {
     switch (this.meta.provider) {
       case 'gitlab':

--- a/ui/src/pr/reviewStorage.ts
+++ b/ui/src/pr/reviewStorage.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RepoMeta } from './types';
+
+const KEY_PREFIX = 'ot_pr_review:';
+
+export interface SavedReview {
+  /** Raw review output (markdown + ```json:review block). */
+  result: string;
+  /** Epoch ms when the review was submitted to the PR host. Absent if never submitted. */
+  submittedAt?: number;
+}
+
+function key(meta: Pick<RepoMeta, 'provider' | 'owner' | 'repo'>, n: number) {
+  return `${KEY_PREFIX}${meta.provider}:${meta.owner}:${meta.repo}:${n}`;
+}
+
+export function loadReview(
+  meta: Pick<RepoMeta, 'provider' | 'owner' | 'repo'>,
+  number: number,
+): SavedReview | null {
+  const raw = localStorage.getItem(key(meta, number));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as SavedReview;
+    if (typeof parsed?.result !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveReview(
+  meta: Pick<RepoMeta, 'provider' | 'owner' | 'repo'>,
+  number: number,
+  review: SavedReview,
+): void {
+  try {
+    localStorage.setItem(key(meta, number), JSON.stringify(review));
+  } catch {
+    /* quota — drop silently */
+  }
+}
+
+export function clearReview(
+  meta: Pick<RepoMeta, 'provider' | 'owner' | 'repo'>,
+  number: number,
+): void {
+  localStorage.removeItem(key(meta, number));
+}

--- a/ui/src/pr/reviewStorage.ts
+++ b/ui/src/pr/reviewStorage.ts
@@ -26,7 +26,12 @@ export interface SavedReview {
 }
 
 function key(meta: Pick<RepoMeta, 'provider' | 'owner' | 'repo'>, n: number) {
-  return `${KEY_PREFIX}${meta.provider}:${meta.owner}:${meta.repo}:${n}`;
+  // encodeURIComponent each component so values containing the `:` separator
+  // (e.g. Azure DevOps `org/project` style owners, or any future host) can't
+  // collide with a different repo's key.
+  return `${KEY_PREFIX}${encodeURIComponent(meta.provider)}:${encodeURIComponent(
+    meta.owner,
+  )}:${encodeURIComponent(meta.repo)}:${n}`;
 }
 
 export function loadReview(


### PR DESCRIPTION
## Enhance PR review tokens, persistence, and multi-provider support
🆕 **New Feature** · ✨ **Improvement** · 🐛 **Bug Fix**

This PR improves the PR review workflow by addressing "Token required" errors with a new inline authentication prompt and centralized token management. It also adds persistence for generated reviews so that progress is not lost on page refreshes or when navigating between PRs.

- **Inline Token Prompt**: Shows a password field directly in the review result if a token is missing or invalid, with a "Save & Submit" retry flow.
- **Token Management**: Adds a "PR Tokens" section to Settings for proactive management of GitHub, GitLab, Bitbucket, and Azure DevOps credentials.
- **Review Persistence**: Automatically caches generated reviews and their submission status in `localStorage`, keyed by repository and PR number.
- **Multi-provider Fixes**: Ensures Bitbucket and Azure DevOps use their own specific token keys instead of defaulting to GitHub.

### Complexity
🟡 Moderate · `7 files changed, 451 insertions(+), 19 deletions(-)`

The PR spans multiple functional areas including the settings drawer, chat panels, and PR detail views. It introduces a new persistence layer for reviews and modifies the internal state management of the `PRClient` to allow dynamic token updates without component reconstruction.

### Tests
🧪 Adds new UI logic and local storage persistence to a codebase with established tests, but does not include new unit tests for these specific components.

### Review focus
Pay particular attention to the following areas:

- **Auth Error Detection** — Review the `isTokenError` regex in `ReviewResult.tsx` to ensure it accurately catches 401s and "token required" messages across all four providers.
- **Persistence Collisions** — Verify the key format in `reviewStorage.ts` is sufficiently unique to prevent collisions between different providers or organizations with similar repo names.
- **Client State Sync** — Check that `prClient.setToken` correctly updates the existing client instance so that the immediate retry after entering a token uses the fresh credentials.
<!-- opentrace:jid=j-852f4a27-cf50-4bb9-bc8b-5aadae0421ac|sha=5e73ca6eb3ed73a9d22de45fa76780d8296f72c5 -->