### PR TITLE
fix(plugins/opencode): support Node runtime for OpenCode Desktop

### DIFF
--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -17,9 +17,10 @@
     "provenance": true
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outfile ./dist/index.js --target bun --format esm --external @opencode-ai/plugin",
+    "build": "bun build ./src/index.ts --outfile ./dist/index.js --target node --format esm --external @opencode-ai/plugin && ./scripts/check-dist-portable.sh",
     "lint": "tsc --noEmit",
     "test": "bun test",
+    "check:dist-portable": "./scripts/check-dist-portable.sh",
     "clean": "rm -rf node_modules dist"
   },
   "repository": {

--- a/plugins/opencode/scripts/check-dist-portable.sh
+++ b/plugins/opencode/scripts/check-dist-portable.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Copyright 2026 OpenTrace Contributors
+# Licensed under the Apache License, Version 2.0 — see LICENSE
+#
+# Regression guard: fail if the built bundle contains anything that only
+# works under Bun. Catches Bun.spawn / Bun.which / `bun:` protocol
+# imports / the `// @bun` header — any of these will silently break the
+# plugin in OpenCode Desktop, which loads plugins via a Node-based
+# Electron utility process. See plugins/opencode/src/util/process.ts
+# for the cross-runtime helpers that replace the Bun-only APIs.
+set -eu
+
+dist="${1:-dist/index.js}"
+
+if [ ! -f "$dist" ]; then
+  echo "check-dist-portable: $dist not found — run 'bun run build' first." >&2
+  exit 2
+fi
+
+fail=0
+
+# `// @bun` header — bun bundler stamps this when --target bun is used.
+if head -1 "$dist" | grep -q '^// @bun'; then
+  echo "check-dist-portable: FAIL — dist starts with '// @bun'. Use --target node." >&2
+  fail=1
+fi
+
+# `bun:` protocol imports (bun:test, bun:sqlite, etc.) — Node ESM loader
+# rejects these outright on the desktop sidecar.
+if grep -nE '"bun:[a-z]+' "$dist" >&2; then
+  echo "check-dist-portable: FAIL — dist contains bun: protocol imports (see above)." >&2
+  fail=1
+fi
+
+# Direct Bun.* runtime calls — these throw ReferenceError under Node.
+# Scoped to the known-problem APIs so we don't false-positive on the
+# string "Bun" in comments / docstrings.
+if grep -nE '\bBun\.(spawn|spawnSync|which|file|\$|env|argv|build|serve)\b' "$dist" >&2; then
+  echo "check-dist-portable: FAIL — dist references Bun runtime APIs (see above)." >&2
+  fail=1
+fi
+
+if [ $fail -ne 0 ]; then
+  echo "check-dist-portable: bundle is not portable to Node. Fix the offending source and rebuild." >&2
+  exit 1
+fi
+
+echo "check-dist-portable: ok — bundle is portable to both Bun and Node."

--- a/plugins/opencode/src/graph-client.ts
+++ b/plugins/opencode/src/graph-client.ts
@@ -17,6 +17,7 @@
 import { getCliMissingMessage } from "./util/cli-install.js"
 import { findExecutable, pathWithLocalBin } from "./util/db-discovery.js"
 import { debug } from "./util/debug.js"
+import { runCommand } from "./util/process.js"
 import {
   DB_MISSING_MESSAGE,
   EXIT_DB_MISSING,
@@ -404,22 +405,13 @@ export class GraphClient {
     // `--workspace` is a top-level flag, so it precedes the subcommand.
     const args = [...this.exe.args, "--workspace", this.directory, ...subArgs]
     try {
-      const proc = Bun.spawn([this.exe.cmd, ...args], {
-        stdout: "pipe",
-        stderr: "pipe",
+      // runCommand drains stdout/stderr via `data` events, so the pipes
+      // never deadlock on a chatty subprocess. Cross-runtime: same call
+      // works under Bun and the desktop's Node sidecar.
+      const { exitCode, stdout, stderr, timedOut } = await runCommand(this.exe.cmd, args, {
         env: spawnEnvWithLocalBin(),
+        timeoutMs: remaining,
       })
-
-      // Read stdout and stderr BEFORE awaiting exit to avoid pipe buffer deadlock
-      const stdoutPromise = new Response(proc.stdout).text()
-      const stderrPromise = new Response(proc.stderr).text()
-      let timedOut = false
-      const timeout = setTimeout(() => {
-        timedOut = true
-        proc.kill()
-      }, remaining)
-      const [exitCode, stdout, stderr] = await Promise.all([proc.exited, stdoutPromise, stderrPromise])
-      clearTimeout(timeout)
 
       const semanticMessage = this._recordExit(exitCode)
 
@@ -822,23 +814,15 @@ export class GraphClient {
         redactArgs(subArgs).join(" "),
         remaining !== null ? `(timeout ${remaining}ms)` : "(no timeout)",
       )
-      const proc = Bun.spawn([this.exe.cmd, ...args], {
-        stdout: "pipe",
-        stderr: "pipe",
+      // runCommand drains stdout/stderr via `data` events so the pipes
+      // never deadlock on chatty subprocesses (large index outputs are
+      // routine here). `timeoutMs: 0` / undefined disables the kill timer,
+      // matching the "wait indefinitely" semantics requested by callers
+      // that pass `indexTimeout: 0`.
+      const { exitCode, stdout, stderr, timedOut } = await runCommand(this.exe.cmd, args, {
         env: spawnEnvWithLocalBin(),
+        timeoutMs: remaining ?? 0,
       })
-      // Read stdout/stderr BEFORE awaiting exit to avoid pipe buffer deadlock
-      const stdoutPromise = new Response(proc.stdout).text()
-      const stderrPromise = new Response(proc.stderr).text()
-      let timedOut = false
-      const killTimer = remaining !== null
-        ? setTimeout(() => {
-            timedOut = true
-            proc.kill()
-          }, remaining)
-        : null
-      const [exitCode, stdout, stderr] = await Promise.all([proc.exited, stdoutPromise, stderrPromise])
-      if (killTimer) clearTimeout(killTimer)
 
       const semanticMessage = this._recordExit(exitCode)
 

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -106,6 +106,20 @@ const server: Plugin = async (
   }
   const opts = parseResult.data
   configureDebug({ debug: opts.debug, debugFile: opts.debugFile })
+  // Stamp the runtime up front so the next "plugin loaded but nothing
+  // works" report is a one-glance diagnosis: Bun (CLI / TUI) vs Node
+  // (OpenCode desktop's Electron utility process). Earlier versions
+  // assumed Bun and threw a synchronous ReferenceError on Node, killing
+  // every hook before they could register.
+  debug(
+    "plugin",
+    "runtime",
+    typeof (globalThis as any).Bun !== "undefined" ? "bun" : "node",
+    "process.version",
+    process.version,
+    "directory",
+    input.directory,
+  )
 
   // Initialize the graph client
   const client = await GraphClient.create(input.directory, {

--- a/plugins/opencode/src/util/db-discovery.ts
+++ b/plugins/opencode/src/util/db-discovery.ts
@@ -17,6 +17,7 @@
 import { homedir } from "node:os"
 import { join, delimiter } from "node:path"
 import { debug } from "./debug.js"
+import { runCommand, whichSync } from "./process.js"
 
 // Hard cap on how long `<cmd> --version` is allowed to run. The probe is
 // awaited synchronously by `GraphClient.run` / `runWithTimeout` before the
@@ -76,23 +77,15 @@ async function probeVersion(
   searchPath: string,
 ): Promise<boolean> {
   try {
-    const proc = Bun.spawn([cand.cmd, ...cand.args, "--version"], {
-      stdout: "pipe",
-      stderr: "pipe",
+    const result = await runCommand(cand.cmd, [...cand.args, "--version"], {
       env: { ...process.env, PATH: searchPath },
+      timeoutMs: PROBE_TIMEOUT_MS,
     })
-    let timedOut = false
-    const timer = setTimeout(() => {
-      timedOut = true
-      proc.kill()
-    }, PROBE_TIMEOUT_MS)
-    const exitCode = await proc.exited
-    clearTimeout(timer)
-    if (timedOut) {
+    if (result.timedOut) {
       debug("db", "probeVersion: timed out", cand.cmd, cand.args.join(" "))
       return false
     }
-    return exitCode === 0
+    return result.exitCode === 0
   } catch {
     return false
   }
@@ -135,20 +128,21 @@ export async function findExecutable(): Promise<{ cmd: string; args: string[] } 
   }
 
   // 2. Direct binary on PATH (including ~/.local/bin where `uv tool install`
-  //    and `pipx install` drop their shims). `Bun.which` does the lookup in
-  //    the runtime — no shelling out to `which` (which doesn't exist on
-  //    Windows by default), and on Windows it honors PATHEXT so an
-  //    `opentraceai.exe` shim resolves the same way.
-  const found = Bun.which("opentraceai", { PATH: searchPath })
+  //    and `pipx install` drop their shims). `whichSync` is a thin
+  //    cross-runtime port of `Bun.which`: no shelling out to `which`
+  //    (which doesn't exist on Windows by default), and on Windows it
+  //    honors PATHEXT so an `opentraceai.exe` shim resolves the same way.
+  //    Works under both Bun (CLI) and Node (desktop sidecar).
+  const found = whichSync("opentraceai", { PATH: searchPath })
   if (found) {
     const cand = { cmd: found, args: [] }
-    // Bun.which confirms the path resolves; --version confirms it's actually
+    // whichSync confirms the path resolves; --version confirms it's actually
     // a working opentraceai (and not a stale shim or unrelated binary).
     if (await probeVersion(cand, searchPath)) {
       debug("db", "findExecutable: found on PATH at", found)
       return cand
     }
-    debug("db", "findExecutable: Bun.which returned a path but --version failed", found)
+    debug("db", "findExecutable: whichSync returned a path but --version failed", found)
   }
 
   debug("db", "findExecutable: no opentraceai binary found")

--- a/plugins/opencode/src/util/process.ts
+++ b/plugins/opencode/src/util/process.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Cross-runtime process + PATH helpers.
+ *
+ * Both APIs route through `node:child_process` and `node:fs`, which Bun
+ * fully reimplements. That means the same bundle works under Bun (CLI /
+ * TUI) and Node (the OpenCode desktop's Electron utility process). The
+ * earlier `Bun.spawn` / `Bun.which` path threw a synchronous
+ * ReferenceError in the desktop sidecar, causing the plugin's `server()`
+ * factory to reject after `configureDebug()` and silently abandon every
+ * hook registration. See git blame for the diagnosis trail.
+ */
+
+import { spawn } from "node:child_process"
+import { statSync } from "node:fs"
+import { delimiter, join } from "node:path"
+
+export interface RunResult {
+  /** Process exit code. -1 when killed before exit (e.g. timeout, signal). */
+  exitCode: number
+  stdout: string
+  stderr: string
+  /** True when the kill timer fired before the process exited on its own. */
+  timedOut: boolean
+}
+
+/**
+ * Spawn a process, accumulate stdout/stderr, and resolve on exit. Mirrors
+ * the shape we previously got from `Bun.spawn` + `proc.exited` + a manual
+ * `new Response(proc.stdout).text()`, in a single call.
+ *
+ * Stdout/stderr are drained via `data` events so the pipes never deadlock
+ * on a chatty subprocess — the prior Bun-based code intentionally read
+ * the streams before awaiting exit for the same reason.
+ */
+export async function runCommand(
+  cmd: string,
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
+): Promise<RunResult> {
+  return new Promise<RunResult>((resolve, reject) => {
+    let child
+    try {
+      child = spawn(cmd, args, {
+        env: opts.env ?? process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+    } catch (e) {
+      // Synchronous spawn errors are rare (Node usually reports via the
+      // async "error" event), but reject so callers can match on
+      // `isMissingBinaryError` consistently with the async path.
+      reject(e)
+      return
+    }
+
+    let timedOut = false
+    let killTimer: ReturnType<typeof setTimeout> | undefined
+    if (opts.timeoutMs && opts.timeoutMs > 0) {
+      killTimer = setTimeout(() => {
+        timedOut = true
+        child.kill()
+      }, opts.timeoutMs)
+    }
+
+    const stdoutChunks: Buffer[] = []
+    const stderrChunks: Buffer[] = []
+    child.stdout?.on("data", (c: Buffer) => stdoutChunks.push(c))
+    child.stderr?.on("data", (c: Buffer) => stderrChunks.push(c))
+
+    // Resolve on `exit` rather than `close`. `close` waits for every stdio
+    // pipe to release, which lags arbitrarily when the spawned process
+    // forks a grandchild that inherits the pipes (e.g. a shell `sleep`
+    // outlives its parent shell). Bun's `proc.exited` resolved on process
+    // exit only — matching that here keeps the kill-and-move-on contract
+    // the rest of the codebase assumes.
+    child.once("error", (e) => {
+      if (killTimer) clearTimeout(killTimer)
+      reject(e)
+    })
+    child.once("exit", (code, signal) => {
+      if (killTimer) clearTimeout(killTimer)
+      // Detach our reader from any pipe still held by a grandchild so the
+      // event loop can drain. The chunks already collected stay in our
+      // local arrays.
+      child.stdout?.destroy()
+      child.stderr?.destroy()
+      resolve({
+        // Killed-by-signal exits report a null code; surface -1 so callers
+        // can distinguish from a normal "exit 0".
+        exitCode: code ?? (signal ? -1 : -1),
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: Buffer.concat(stderrChunks).toString("utf8"),
+        timedOut,
+      })
+    })
+  })
+}
+
+/**
+ * PATH-scan replacement for `Bun.which`. Returns the absolute path of the
+ * first executable named *name* found on *PATH*, or null. On Windows,
+ * tries the standard PATHEXT suffixes so `opentraceai.exe`/`.cmd`/`.bat`
+ * shims resolve.
+ *
+ * Symlinks are dereferenced by `statSync`, matching `Bun.which`'s
+ * behavior for typical `uv tool install` / `pipx install` shim layouts.
+ */
+export function whichSync(name: string, opts: { PATH: string }): string | null {
+  const exts =
+    process.platform === "win32"
+      ? splitPathExt(process.env.PATHEXT) ?? [".exe", ".cmd", ".bat", ".com", ""]
+      : [""]
+  for (const dir of opts.PATH.split(delimiter)) {
+    if (!dir) continue
+    for (const ext of exts) {
+      const candidate = join(dir, name + ext)
+      try {
+        const st = statSync(candidate)
+        if (st.isFile()) return candidate
+      } catch {
+        // ENOENT / ENOTDIR / EACCES — keep scanning.
+      }
+    }
+  }
+  return null
+}
+
+function splitPathExt(pathext: string | undefined): string[] | null {
+  if (!pathext) return null
+  const parts = pathext
+    .split(";")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => s.toLowerCase())
+  // Always try the bare name too so a no-extension script still resolves.
+  return [...parts, ""]
+}

--- a/plugins/opencode/test/util/process.test.ts
+++ b/plugins/opencode/test/util/process.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+import { runCommand, whichSync } from "../../src/util/process.js"
+
+describe("runCommand", () => {
+  test("captures stdout and stderr separately on a zero-exit subprocess", async () => {
+    const result = await runCommand("/bin/sh", ["-c", "printf out; printf err >&2; exit 0"])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe("out")
+    expect(result.stderr).toBe("err")
+    expect(result.timedOut).toBe(false)
+  })
+
+  test("propagates non-zero exit codes verbatim", async () => {
+    const result = await runCommand("/bin/sh", ["-c", "exit 7"])
+    expect(result.exitCode).toBe(7)
+    expect(result.timedOut).toBe(false)
+  })
+
+  test("rejects when the binary cannot be spawned (ENOENT)", async () => {
+    await expect(
+      runCommand("/definitely/not/a/real/binary/path", []),
+    ).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  test("kills and reports timedOut=true when the deadline elapses", async () => {
+    const start = Date.now()
+    const result = await runCommand("/bin/sh", ["-c", "sleep 5"], { timeoutMs: 150 })
+    const elapsed = Date.now() - start
+    // 150ms timeout; allow generous slack for CI but stay well under sleep 5
+    expect(elapsed).toBeLessThan(2_000)
+    expect(result.timedOut).toBe(true)
+    // Killed by signal — exit code is -1 in our normalized shape.
+    expect(result.exitCode).toBe(-1)
+  })
+
+  test("treats timeoutMs <= 0 as no-timeout (long-running subprocess completes)", async () => {
+    const result = await runCommand("/bin/sh", ["-c", "sleep 0.2; echo done"], { timeoutMs: 0 })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBe("done")
+    expect(result.timedOut).toBe(false)
+  })
+
+  test("forwards a custom env to the child without polluting process.env", async () => {
+    const before = process.env.OPENTRACE_TEST_VAR
+    const result = await runCommand("/bin/sh", ["-c", "printf %s \"$OPENTRACE_TEST_VAR\""], {
+      env: { ...process.env, OPENTRACE_TEST_VAR: "hello" },
+    })
+    expect(result.stdout).toBe("hello")
+    // Local env in our process must be untouched — Node passes env by value.
+    expect(process.env.OPENTRACE_TEST_VAR).toBe(before)
+  })
+
+  test("drains long stdout without pipe deadlock", async () => {
+    // 64 KB output — past the typical pipe buffer cap. With a naive
+    // "await exit before reading stdout" the child would block on a full
+    // pipe; runCommand drains via data events so this just works.
+    const result = await runCommand("/bin/sh", ["-c", "head -c 65536 /dev/zero | tr '\\0' 'x'"])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.length).toBe(65536)
+  })
+})
+
+describe("whichSync", () => {
+  let tmp: string
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "opentrace-which-"))
+  })
+  afterEach(() => {
+    try {
+      rmSync(tmp, { recursive: true, force: true })
+    } catch {}
+  })
+
+  test("returns the absolute path of the first match on PATH", () => {
+    const bin = join(tmp, "mytool")
+    writeFileSync(bin, "#!/bin/sh\necho hi\n")
+    chmodSync(bin, 0o755)
+    const found = whichSync("mytool", { PATH: tmp })
+    expect(found).toBe(bin)
+  })
+
+  test("returns null when no match exists on PATH", () => {
+    expect(whichSync("does-not-exist-anywhere", { PATH: tmp })).toBeNull()
+  })
+
+  test("walks every PATH segment until a match is found", () => {
+    const tmp2 = mkdtempSync(join(tmpdir(), "opentrace-which2-"))
+    try {
+      const bin = join(tmp2, "needle")
+      writeFileSync(bin, "#!/bin/sh\n")
+      chmodSync(bin, 0o755)
+      const found = whichSync("needle", { PATH: `${tmp}${delimiter}${tmp2}` })
+      expect(found).toBe(bin)
+    } finally {
+      rmSync(tmp2, { recursive: true, force: true })
+    }
+  })
+
+  test("skips empty PATH segments and unreadable directories", () => {
+    const bin = join(tmp, "tool")
+    writeFileSync(bin, "#!/bin/sh\n")
+    chmodSync(bin, 0o755)
+    // Leading and trailing empty segments + a nonexistent dir between.
+    const path = `${delimiter}${delimiter}/no/such/dir${delimiter}${tmp}${delimiter}`
+    expect(whichSync("tool", { PATH: path })).toBe(bin)
+  })
+
+  test("does not match directories that happen to share the name", () => {
+    // A directory called "mytool" must not be returned as the executable.
+    require("node:fs").mkdirSync(join(tmp, "mytool"))
+    expect(whichSync("mytool", { PATH: tmp })).toBeNull()
+  })
+})


### PR DESCRIPTION
## Support Node.js runtime for OpenCode plugin
✨ **Improvement** · 🐛 **Bug Fix** · ♻️ **Refactor** · 🧪 **Tests** · 🔧 **Chore**

This PR migrates the OpenCode plugin to use cross-runtime helpers instead of Bun-specific APIs. 

This fixes a failure where the plugin would crash when loaded by the Node-based Electron sidecar in OpenCode Desktop. It ensures the same bundle works across both Bun (CLI/TUI) and Node.js (Desktop).

### Complexity
🟡 Moderate · `7 files changed, 374 insertions(+), 49 deletions(-)`

The PR replaces foundational runtime APIs with custom implementations for process management and file discovery. While the scope is limited to a single plugin, the change involves manual handling of streams, process lifecycle events, and cross-platform path resolution, which carry subtle concurrency and portability risks.

### Tests
🧪 Includes 12 new unit tests for the cross-runtime process and PATH helpers, covering pipe overflows, timeouts, and edge-case discovery.

### Review focus
Pay particular attention to the following areas:

- **Pipe drainage** — verify that `runCommand` correctly drains stdout/stderr via events to prevent deadlocks on chatty subprocesses.
- **Process exit semantics** — confirm that resolving on the `exit` event (rather than `close`) is the correct choice for avoiding hangs when grandchildren inherit pipes.
- **Windows PATH resolution** — ensure `whichSync` correctly handles `PATHEXT` and directory skipping to match standard executable discovery.
<!-- opentrace:jid=j-8fdf1bb2-b668-4da4-9804-219e2372745e|sha=f6cf30ef34ee5be9fe7fc784c4a0237730cf4a7e -->