### PR TITLE
fix(ui): run LadybugDB engine on main thread to avoid nested worker timeout

### DIFF
--- a/ui/src/store/__tests__/ladybugStore.test.ts
+++ b/ui/src/store/__tests__/ladybugStore.test.ts
@@ -30,24 +30,29 @@ describe('REL_PAIRS', () => {
   });
 });
 
-// Helper: build a store with WASM init bypassed and a mock conn that
-// resolves every query() call into a trivial result.
-function makeStoreWithMockConn() {
-  const store = new LadybugGraphStore();
+// Helper: build a store with WASM init bypassed and a mock engine whose
+// query()/exec() both funnel through one spy, so assertions can inspect every
+// Cypher statement the store dispatched (regardless of rows-vs-no-rows).
+function makeStoreWithMockEngine() {
+  const engineCall = vi.fn().mockResolvedValue([]);
+  const engine = {
+    init: vi.fn().mockResolvedValue(undefined),
+    query: (cypher: string) => engineCall(cypher),
+    exec: (cypher: string) => engineCall(cypher),
+    fsWrite: vi.fn().mockResolvedValue(undefined),
+    fsUnlink: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const store = new LadybugGraphStore(engine);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const s = store as any;
   s.ready = Promise.resolve();
-  const connQuery = vi.fn().mockImplementation(async () => ({
-    getAllObjects: async () => [],
-    close: async () => {},
-  }));
-  s.conn = { query: connQuery };
-  return { store, s, connQuery };
+  return { store, s, connQuery: engineCall };
 }
 
 describe('LadybugGraphStore clearGraph abort behavior', () => {
   it('aborts queued query()/exec() tasks when clearGraph fires', async () => {
-    const { store, s, connQuery } = makeStoreWithMockConn();
+    const { store, s, connQuery } = makeStoreWithMockEngine();
 
     // Hold the queue open so pending tasks can't run until we say so.
     let releaseGate: () => void = () => {};
@@ -82,7 +87,7 @@ describe('LadybugGraphStore clearGraph abort behavior', () => {
   });
 
   it('allows queries enqueued after clearGraph to run normally', async () => {
-    const { store, s, connQuery } = makeStoreWithMockConn();
+    const { store, s, connQuery } = makeStoreWithMockEngine();
 
     // Fire clearGraph first (bumps gen 0 → 1, completes its DDL).
     await store.clearGraph();
@@ -96,7 +101,7 @@ describe('LadybugGraphStore clearGraph abort behavior', () => {
   });
 
   it('bumps the generation counter on clearGraph', async () => {
-    const { store, s } = makeStoreWithMockConn();
+    const { store, s } = makeStoreWithMockEngine();
 
     expect(s.generation).toBe(0);
     await store.clearGraph();
@@ -108,7 +113,7 @@ describe('LadybugGraphStore clearGraph abort behavior', () => {
 
 describe('LadybugGraphStore deleteRepo', () => {
   it('issues scoped Cypher deletes (rels first, then each repo-scoped table)', async () => {
-    const { store, connQuery } = makeStoreWithMockConn();
+    const { store, connQuery } = makeStoreWithMockEngine();
 
     await store.deleteRepo('alice/foo');
 
@@ -176,21 +181,18 @@ describe('LadybugGraphStore deleteRepo', () => {
   });
 
   it('prunes in-memory state keyed by the repo but spares other repos', async () => {
-    const { store, s, connQuery } = makeStoreWithMockConn();
+    const { store, s, connQuery } = makeStoreWithMockEngine();
 
     // The post-delete pass runs two Dependency reads in order: the
     // orphan-sweep query (distinguished by `count(r)`) which should see
     // no orphans here because lodash is still referenced by bob/bar, and
     // the dedup-set rebuild which returns surviving rows.
-    connQuery.mockImplementation(async (cypher: string) => ({
-      getAllObjects: async () => {
-        if (!cypher.includes('(n:Dependency)')) return [];
-        if (cypher.includes('count(r)')) return []; // orphan sweep
-        if (cypher.includes('RETURN n.id')) return [{ id: 'pkg:npm:lodash' }];
-        return [];
-      },
-      close: async () => {},
-    }));
+    connQuery.mockImplementation(async (cypher: string) => {
+      if (!cypher.includes('(n:Dependency)')) return [];
+      if (cypher.includes('count(r)')) return []; // orphan sweep
+      if (cypher.includes('RETURN n.id')) return [{ id: 'pkg:npm:lodash' }];
+      return [];
+    });
 
     // Seed state that would exist after an index run of two repos plus a
     // shared package.
@@ -298,7 +300,7 @@ describe('LadybugGraphStore deleteRepo', () => {
   });
 
   it('does not bump the generation counter', async () => {
-    const { store, s } = makeStoreWithMockConn();
+    const { store, s } = makeStoreWithMockEngine();
 
     expect(s.generation).toBe(0);
     await store.deleteRepo('alice/foo');
@@ -306,7 +308,7 @@ describe('LadybugGraphStore deleteRepo', () => {
   });
 
   it('is a no-op for an empty repoId', async () => {
-    const { store, connQuery } = makeStoreWithMockConn();
+    const { store, connQuery } = makeStoreWithMockEngine();
 
     await store.deleteRepo('');
     expect(connQuery).not.toHaveBeenCalled();
@@ -318,24 +320,21 @@ describe('LadybugGraphStore deleteRepo', () => {
     // repos), but the in-memory set may be stale if we were populated from
     // one subset of repos and a later reindex needs to see the full
     // ground truth. The guard only works if the set matches the DB.
-    const { store, s, connQuery } = makeStoreWithMockConn();
-    connQuery.mockImplementation(async (cypher: string) => ({
-      getAllObjects: async () => {
-        if (!cypher.includes('(n:Dependency)')) return [];
-        // Orphan sweep (distinguished by `count(r)`): none here — the
-        // focus of this test is the rebuild path, not the sweep.
-        if (cypher.includes('count(r)')) return [];
-        if (cypher.includes('RETURN n.id')) {
-          return [
-            { id: 'pkg:npm:lodash' },
-            { id: 'pkg:npm:react' },
-            { id: 'pkg:pypi:requests' },
-          ];
-        }
-        return [];
-      },
-      close: async () => {},
-    }));
+    const { store, s, connQuery } = makeStoreWithMockEngine();
+    connQuery.mockImplementation(async (cypher: string) => {
+      if (!cypher.includes('(n:Dependency)')) return [];
+      // Orphan sweep (distinguished by `count(r)`): none here — the
+      // focus of this test is the rebuild path, not the sweep.
+      if (cypher.includes('count(r)')) return [];
+      if (cypher.includes('RETURN n.id')) {
+        return [
+          { id: 'pkg:npm:lodash' },
+          { id: 'pkg:npm:react' },
+          { id: 'pkg:pypi:requests' },
+        ];
+      }
+      return [];
+    });
 
     // Seed a stale set that disagrees with the DB (missing one entry,
     // with an extra ghost entry left over from a deleted repo).
@@ -359,22 +358,19 @@ describe('LadybugGraphStore deleteRepo', () => {
     // was exclusively owned by this repo (Dependencies are only ever
     // created paired with an edge) and is safe to delete. Shared
     // dependencies still have edges from other repos and must survive.
-    const { store, connQuery } = makeStoreWithMockConn();
-    connQuery.mockImplementation(async (cypher: string) => ({
-      getAllObjects: async () => {
-        if (!cypher.includes('(n:Dependency)')) return [];
-        // Orphan sweep: one package exclusively used by alice/foo.
-        if (cypher.includes('count(r)')) {
-          return [{ id: 'pkg:npm:only-used-by-alice' }];
-        }
-        // Dedup rebuild (runs after the sweep): the shared survivor.
-        if (cypher.includes('RETURN n.id')) {
-          return [{ id: 'pkg:npm:lodash' }];
-        }
-        return [];
-      },
-      close: async () => {},
-    }));
+    const { store, connQuery } = makeStoreWithMockEngine();
+    connQuery.mockImplementation(async (cypher: string) => {
+      if (!cypher.includes('(n:Dependency)')) return [];
+      // Orphan sweep: one package exclusively used by alice/foo.
+      if (cypher.includes('count(r)')) {
+        return [{ id: 'pkg:npm:only-used-by-alice' }];
+      }
+      // Dedup rebuild (runs after the sweep): the shared survivor.
+      if (cypher.includes('RETURN n.id')) {
+        return [{ id: 'pkg:npm:lodash' }];
+      }
+      return [];
+    });
 
     await store.deleteRepo('alice/foo');
 
@@ -431,7 +427,7 @@ describe('LadybugGraphStore deleteRepo', () => {
     // returns early and never issues the DELETE. Guards against
     // accidentally running `DELETE n ... WHERE n.id IN []` which some
     // Cypher engines either reject or interpret unfavorably.
-    const { store, connQuery } = makeStoreWithMockConn();
+    const { store, connQuery } = makeStoreWithMockEngine();
 
     await store.deleteRepo('alice/foo');
 

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -531,6 +531,19 @@ export class LadybugGraphStore implements GraphStore {
   // --- Serialization queue (lbug-wasm wraps single-threaded C++ engine) ---
   private queue: Promise<void> = Promise.resolve();
 
+  /** Monotonic counter for COPY-FROM temp filenames. The engine's virtual
+   *  filesystem is process-wide, so a fixed path (e.g. /nodes_Function.csv)
+   *  would collide if two import/flush operations ran in close succession —
+   *  one COPY could read the other's bytes, or an unlink could remove a file
+   *  before the other's COPY runs. Unique names make the paths collision-proof
+   *  regardless of caller serialization. */
+  private copySeq = 0;
+
+  /** A unique temp path for a CSV about to be COPY'd in. */
+  private tmpCsvPath(label: string): string {
+    return `/${label}_${++this.copySeq}.csv`;
+  }
+
   /** Monotonic counter bumped by clearGraph(). Each queued task captures the
    *  current value at enqueue; when it runs, a mismatch means clearGraph fired
    *  in the meantime and the task is aborted. Keeps clearGraph fast by letting
@@ -1793,7 +1806,7 @@ export class LadybugGraphStore implements GraphStore {
       }
 
       const csv = generateTypedNodeCSV(type, nodes);
-      const csvPath = `/import_nodes_${type}.csv`;
+      const csvPath = this.tmpCsvPath(`import_nodes_${type}`);
       await this.engine.fsWrite(csvPath, CSV_ENCODER.encode(csv));
       try {
         await this.exec(`COPY ${type} FROM '${csvPath}' (HEADER=true)`);
@@ -1878,7 +1891,7 @@ export class LadybugGraphStore implements GraphStore {
           ) {
             const chunk = bucket.slice(offset, offset + FLUSH_CHUNK_SIZE);
             const csv = generateRelCSV(chunk);
-            const csvPath = `/rels_${key}.csv`;
+            const csvPath = this.tmpCsvPath(`rels_${key}`);
             await this.engine.fsWrite(csvPath, CSV_ENCODER.encode(csv));
             try {
               await this.exec(
@@ -1922,7 +1935,7 @@ export class LadybugGraphStore implements GraphStore {
       }
       if (snippets.size > 0) {
         const csv = generateSourceTextCSV(snippets, fakeCache);
-        const csvPath = '/import_source_text.csv';
+        const csvPath = this.tmpCsvPath('import_source_text');
         await this.engine.fsWrite(csvPath, CSV_ENCODER.encode(csv));
         try {
           await this.exec(`COPY SourceText FROM '${csvPath}' (HEADER=true)`);
@@ -2151,7 +2164,7 @@ export class LadybugGraphStore implements GraphStore {
         lines.push(`${csvEscape(id)},${csvEscape(`[${vec.join(',')}]`)}`);
       }
       const csv = lines.join('\n');
-      const path = '/vectors_embed.csv';
+      const path = this.tmpCsvPath('vectors_embed');
       await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
       await this.exec(`COPY NodeVector FROM '${path}' (HEADER=true)`);
       await this.engine.fsUnlink(path);
@@ -2257,7 +2270,7 @@ export class LadybugGraphStore implements GraphStore {
       for (let offset = 0; offset < bucket.length; offset += FLUSH_CHUNK_SIZE) {
         const chunk = bucket.slice(offset, offset + FLUSH_CHUNK_SIZE);
         const csv = generateTypedNodeCSV(type, chunk);
-        const path = `/nodes_${type}.csv`;
+        const path = this.tmpCsvPath(`nodes_${type}`);
         await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
         await this.exec(`COPY ${type} FROM '${path}' (HEADER=true)`);
         await this.engine.fsUnlink(path);
@@ -2281,7 +2294,7 @@ export class LadybugGraphStore implements GraphStore {
       ) {
         const chunk = new Map(entries.slice(offset, offset + FLUSH_CHUNK_SIZE));
         const csv = generateSourceTextCSV(chunk, this.sourceCache);
-        const path = '/source_text.csv';
+        const path = this.tmpCsvPath('source_text');
         await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
         await this.exec(`COPY SourceText FROM '${path}' (HEADER=true)`);
         await this.engine.fsUnlink(path);
@@ -2305,7 +2318,7 @@ export class LadybugGraphStore implements GraphStore {
           lines.push(`${csvEscape(id)},${csvEscape(`[${vec.join(',')}]`)}`);
         }
         const csv = lines.join('\n');
-        const path = '/vectors.csv';
+        const path = this.tmpCsvPath('vectors');
         await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
         await this.exec(`COPY NodeVector FROM '${path}' (HEADER=true)`);
         await this.engine.fsUnlink(path);
@@ -2343,7 +2356,7 @@ export class LadybugGraphStore implements GraphStore {
         ) {
           const chunk = bucket.slice(offset, offset + FLUSH_CHUNK_SIZE);
           const csv = generateRelCSV(chunk);
-          const path = `/rels_${key}.csv`;
+          const path = this.tmpCsvPath(`rels_${key}`);
           await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
           try {
             await this.exec(`COPY RELATES_${key} FROM '${path}' (HEADER=true)`);

--- a/ui/src/store/ladybugStore.ts
+++ b/ui/src/store/ladybugStore.ts
@@ -50,10 +50,11 @@ async function getParquetWasm(): Promise<
   return _parquetMod;
 }
 
-import lbug from '@ladybugdb/wasm-core';
-
-type Database = InstanceType<typeof lbug.Database>;
-type Connection = InstanceType<typeof lbug.Connection>;
+// The LadybugDB engine itself runs on the MAIN thread (see lbugEngine.ts).
+// This store runs inside `storeWorker` and reaches the engine over an
+// injected RPC surface — never importing `@ladybugdb/wasm-core` directly, so
+// the engine's worker is spawned from main and is never a nested worker.
+import type { LbugEngine } from './lbugEngine';
 import type {
   ImportBatchRequest,
   ImportBatchResponse,
@@ -483,8 +484,7 @@ async function parquetToArrow(
 // ---- Store implementation ----
 
 export class LadybugGraphStore implements GraphStore {
-  private db!: Database;
-  private conn!: Connection;
+  private engine: LbugEngine;
   private ready: Promise<void> | null = null;
   private embedder: Embedder | null = null;
   private sourceCache = new Map<
@@ -537,7 +537,13 @@ export class LadybugGraphStore implements GraphStore {
    *  it skip work that's about to be invalidated anyway. */
   private generation = 0;
 
-  constructor() {
+  /**
+   * @param engine LadybugDB engine RPC surface. In production this is a shim
+   *   (installed by `storeWorker`) that forwards each call to the real
+   *   main-thread engine; tests inject a mock.
+   */
+  constructor(engine: LbugEngine) {
+    this.engine = engine;
     // Don't init WASM here — the constructor runs at app startup.
     // WASM loads lazily on first DB operation via ensureReady().
   }
@@ -557,20 +563,8 @@ export class LadybugGraphStore implements GraphStore {
 
   private async initModule(): Promise<void> {
     const t0 = performance.now();
-    lbug.setWorkerPath('/lbug_wasm_worker.js');
-    await lbug.init();
-    // Buffer pool size note: lbug accepts a `bufferPoolSize` argument
-    // here, but in WASM the linear memory is a single shared heap —
-    // reserving more for the page cache leaves less for everything
-    // else (CSV temp files, query state, parser tables). An explicit
-    // 512 MB reservation broke ingest even for small repos, so we
-    // let the engine's auto-sizing decide. To genuinely fit larger
-    // graphs the right move is to reduce extraction depth or use
-    // server mode rather than push this number up.
-    this.db = new lbug.Database(':memory:');
-    await this.db.init();
-    this.conn = new lbug.Connection(this.db);
-    await this.conn.init();
+    // Boots the engine worker (on the main thread) and opens the connection.
+    await this.engine.init();
     await this.initSchema();
 
     console.log(
@@ -584,8 +578,7 @@ export class LadybugGraphStore implements GraphStore {
 
   private async initSchema(): Promise<void> {
     for (const stmt of SCHEMA_STATEMENTS) {
-      const result = await this.conn.query(stmt);
-      await result.close();
+      await this.engine.exec(stmt);
     }
     // Create FTS indexes on code-bearing node types for content search
     await this.createFTSIndexes();
@@ -596,18 +589,15 @@ export class LadybugGraphStore implements GraphStore {
   /** Install VECTOR extension and create the NodeVector table for persistent embeddings. */
   private async initVectorSchema(): Promise<void> {
     try {
-      const r1 = await this.conn.query('INSTALL VECTOR');
-      await r1.close();
-      const r2 = await this.conn.query('LOAD EXTENSION VECTOR');
-      await r2.close();
+      await this.engine.exec('INSTALL VECTOR');
+      await this.engine.exec('LOAD EXTENSION VECTOR');
     } catch {
       // Already installed/loaded — safe to ignore
     }
     try {
-      const r = await this.conn.query(
+      await this.engine.exec(
         'CREATE NODE TABLE IF NOT EXISTS NodeVector(id STRING PRIMARY KEY, vec FLOAT[384])',
       );
-      await r.close();
     } catch {
       // Table may already exist
     }
@@ -616,10 +606,9 @@ export class LadybugGraphStore implements GraphStore {
   /** Create the vector index on NodeVector. Call once after all embeddings are loaded. */
   private async createVectorIndex(): Promise<void> {
     try {
-      const r = await this.conn.query(
+      await this.engine.exec(
         `CALL CREATE_VECTOR_INDEX('NodeVector', 'nodevec_idx', 'vec', metric := 'cosine')`,
       );
-      await r.close();
       this.hasVectorIndex = true;
     } catch {
       // Index may already exist — check if we can query it
@@ -631,20 +620,17 @@ export class LadybugGraphStore implements GraphStore {
   private async createFTSIndexes(): Promise<void> {
     // LadybugDB requires the FTS extension to be installed and loaded
     try {
-      const r1 = await this.conn.query('INSTALL FTS');
-      await r1.close();
-      const r2 = await this.conn.query('LOAD EXTENSION FTS');
-      await r2.close();
+      await this.engine.exec('INSTALL FTS');
+      await this.engine.exec('LOAD EXTENSION FTS');
     } catch {
       // Already installed/loaded — safe to ignore
     }
 
     // Create FTS index on the SourceText table (name + source content)
     try {
-      const result = await this.conn.query(
+      await this.engine.exec(
         `CALL CREATE_FTS_INDEX('SourceText', 'search_idx_source', ['name', 'source_text'], stemmer := 'porter')`,
       );
-      await result.close();
     } catch {
       // Index may already exist on re-init — safe to ignore
     }
@@ -654,18 +640,16 @@ export class LadybugGraphStore implements GraphStore {
    *  LadybugDB FTS indexes are static — new rows require a rebuild. */
   private async rebuildSourceFTS(): Promise<void> {
     try {
-      const r = await this.conn.query(
+      await this.engine.exec(
         `CALL DROP_FTS_INDEX('SourceText', 'search_idx_source')`,
       );
-      await r.close();
     } catch {
       // Index may not exist yet — safe to ignore
     }
     try {
-      const r = await this.conn.query(
+      await this.engine.exec(
         `CALL CREATE_FTS_INDEX('SourceText', 'search_idx_source', ['name', 'source_text'], stemmer := 'porter')`,
       );
-      await r.close();
     } catch {
       // Empty table is fine — index will be rebuilt on next flush
     }
@@ -673,7 +657,7 @@ export class LadybugGraphStore implements GraphStore {
 
   /**
    * Execute a Cypher query and return all result rows as objects.
-   * Uses conn.query() + getAllObjects() for row extraction.
+   * Delegates row extraction to the engine (engine.query()).
    * Serialized through a queue to prevent concurrent calls.
    *
    * If clearGraph() fires between the enqueue and the run, the task
@@ -690,14 +674,9 @@ export class LadybugGraphStore implements GraphStore {
             return;
           }
           const qt0 = performance.now();
-          const result = await this.conn.query(cypher);
-          try {
-            const rows = await result.getAllObjects();
-            logQuery(cypher, rows.length, performance.now() - qt0);
-            resolve(rows);
-          } finally {
-            await result.close();
-          }
+          const rows = await this.engine.query(cypher);
+          logQuery(cypher, rows.length, performance.now() - qt0);
+          resolve(rows);
         })
         .catch((err) => {
           reject(err);
@@ -719,8 +698,7 @@ export class LadybugGraphStore implements GraphStore {
             reject(abortError('Exec aborted: store was cleared'));
             return;
           }
-          const result = await this.conn.query(cypher);
-          await result.close();
+          await this.engine.exec(cypher);
           resolve();
         })
         .catch((err) => {
@@ -739,8 +717,7 @@ export class LadybugGraphStore implements GraphStore {
     return new Promise<void>((resolve, reject) => {
       this.queue = this.queue
         .then(async () => {
-          const result = await this.conn.query(cypher);
-          await result.close();
+          await this.engine.exec(cypher);
           resolve();
         })
         .catch((err) => {
@@ -841,31 +818,18 @@ export class LadybugGraphStore implements GraphStore {
   /** Close the database connection and release WASM resources. */
   async dispose(): Promise<void> {
     try {
-      await this.conn?.close();
-    } catch {
-      /* ignore */
-    }
-    try {
-      await this.db?.close();
-    } catch {
-      /* ignore */
-    }
-    try {
-      await lbug.close();
+      await this.engine.close();
     } catch {
       /* ignore */
     }
   }
 
-  /** Current WASM linear memory size in MB (for diagnostics). */
+  /** Current WASM linear memory size in MB (for diagnostics).
+   *  The engine's linear memory now lives behind the main-thread engine
+   *  worker boundary and isn't directly measurable from here, so this
+   *  reports -1 ("unknown"). */
   getWasmMemoryMB(): number {
-    try {
-      const mem = (lbug as unknown as { wasmMemory?: WebAssembly.Memory })
-        .wasmMemory;
-      return mem ? mem.buffer.byteLength / (1024 * 1024) : -1;
-    } catch {
-      return -1;
-    }
+    return -1;
   }
 
   /** Set an embedder for generating query embeddings during search. */
@@ -1830,11 +1794,11 @@ export class LadybugGraphStore implements GraphStore {
 
       const csv = generateTypedNodeCSV(type, nodes);
       const csvPath = `/import_nodes_${type}.csv`;
-      await lbug.FS.writeFile(csvPath, CSV_ENCODER.encode(csv));
+      await this.engine.fsWrite(csvPath, CSV_ENCODER.encode(csv));
       try {
         await this.exec(`COPY ${type} FROM '${csvPath}' (HEADER=true)`);
       } finally {
-        await lbug.FS.unlink(csvPath);
+        await this.engine.fsUnlink(csvPath);
       }
 
       // Rebuild nodeTypeMap, BM25 index, and node cache for this type
@@ -1915,7 +1879,7 @@ export class LadybugGraphStore implements GraphStore {
             const chunk = bucket.slice(offset, offset + FLUSH_CHUNK_SIZE);
             const csv = generateRelCSV(chunk);
             const csvPath = `/rels_${key}.csv`;
-            await lbug.FS.writeFile(csvPath, CSV_ENCODER.encode(csv));
+            await this.engine.fsWrite(csvPath, CSV_ENCODER.encode(csv));
             try {
               await this.exec(
                 `COPY RELATES_${key} FROM '${csvPath}' (HEADER=true)`,
@@ -1926,7 +1890,7 @@ export class LadybugGraphStore implements GraphStore {
                 err,
               );
             }
-            await lbug.FS.unlink(csvPath);
+            await this.engine.fsUnlink(csvPath);
           }
         }
       } catch (err) {
@@ -1959,11 +1923,11 @@ export class LadybugGraphStore implements GraphStore {
       if (snippets.size > 0) {
         const csv = generateSourceTextCSV(snippets, fakeCache);
         const csvPath = '/import_source_text.csv';
-        await lbug.FS.writeFile(csvPath, CSV_ENCODER.encode(csv));
+        await this.engine.fsWrite(csvPath, CSV_ENCODER.encode(csv));
         try {
           await this.exec(`COPY SourceText FROM '${csvPath}' (HEADER=true)`);
         } finally {
-          await lbug.FS.unlink(csvPath);
+          await this.engine.fsUnlink(csvPath);
         }
 
         // Repopulate sourceCache so fetchSource can serve code views
@@ -2188,9 +2152,9 @@ export class LadybugGraphStore implements GraphStore {
       }
       const csv = lines.join('\n');
       const path = '/vectors_embed.csv';
-      await lbug.FS.writeFile(path, CSV_ENCODER.encode(csv));
+      await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
       await this.exec(`COPY NodeVector FROM '${path}' (HEADER=true)`);
-      await lbug.FS.unlink(path);
+      await this.engine.fsUnlink(path);
     }
 
     if (!this.hasVectorIndex) {
@@ -2294,9 +2258,9 @@ export class LadybugGraphStore implements GraphStore {
         const chunk = bucket.slice(offset, offset + FLUSH_CHUNK_SIZE);
         const csv = generateTypedNodeCSV(type, chunk);
         const path = `/nodes_${type}.csv`;
-        await lbug.FS.writeFile(path, CSV_ENCODER.encode(csv));
+        await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
         await this.exec(`COPY ${type} FROM '${path}' (HEADER=true)`);
-        await lbug.FS.unlink(path);
+        await this.engine.fsUnlink(path);
       }
     }
 
@@ -2318,9 +2282,9 @@ export class LadybugGraphStore implements GraphStore {
         const chunk = new Map(entries.slice(offset, offset + FLUSH_CHUNK_SIZE));
         const csv = generateSourceTextCSV(chunk, this.sourceCache);
         const path = '/source_text.csv';
-        await lbug.FS.writeFile(path, CSV_ENCODER.encode(csv));
+        await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
         await this.exec(`COPY SourceText FROM '${path}' (HEADER=true)`);
-        await lbug.FS.unlink(path);
+        await this.engine.fsUnlink(path);
       }
       for (const id of newSnippets.keys()) {
         this.flushedSourceIds.add(id);
@@ -2342,9 +2306,9 @@ export class LadybugGraphStore implements GraphStore {
         }
         const csv = lines.join('\n');
         const path = '/vectors.csv';
-        await lbug.FS.writeFile(path, CSV_ENCODER.encode(csv));
+        await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
         await this.exec(`COPY NodeVector FROM '${path}' (HEADER=true)`);
-        await lbug.FS.unlink(path);
+        await this.engine.fsUnlink(path);
       }
       // Create vector index if not yet created
       if (!this.hasVectorIndex) {
@@ -2380,7 +2344,7 @@ export class LadybugGraphStore implements GraphStore {
           const chunk = bucket.slice(offset, offset + FLUSH_CHUNK_SIZE);
           const csv = generateRelCSV(chunk);
           const path = `/rels_${key}.csv`;
-          await lbug.FS.writeFile(path, CSV_ENCODER.encode(csv));
+          await this.engine.fsWrite(path, CSV_ENCODER.encode(csv));
           try {
             await this.exec(`COPY RELATES_${key} FROM '${path}' (HEADER=true)`);
           } catch (err) {
@@ -2404,7 +2368,7 @@ export class LadybugGraphStore implements GraphStore {
               }
             }
           }
-          await lbug.FS.unlink(path);
+          await this.engine.fsUnlink(path);
         }
       }
     }

--- a/ui/src/store/lbugEngine.ts
+++ b/ui/src/store/lbugEngine.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Main-thread owner of the LadybugDB WASM engine.
+ *
+ * The lbug engine internally spawns its own Web Worker (via the `threads`
+ * library) the first time `init()` runs. That worker MUST be spawned from a
+ * context that supports `new Worker()` — and historically that was the main
+ * thread. When the LadybugGraphStore moved into `storeWorker` (#399), the lbug
+ * engine worker became a *nested* worker (worker-spawned-from-a-worker). On
+ * browsers/contexts with weak nested-worker support (older Safari, some
+ * in-app WebViews) the nested worker spawns but never reaches `expose()`, so
+ * the `threads` library times out after 60s:
+ *
+ *   "Timeout: Did not receive an init message from worker after 60000ms.
+ *    Make sure the worker calls expose()."
+ *
+ * (Sentry OSS-OPENTRACE-1G.)
+ *
+ * The fix: keep the engine here, on the main thread, so its worker is a
+ * top-level worker again. `storeWorker` reaches it over `postMessage` through
+ * the `LbugEngine` RPC surface below — the same shim pattern the embedder
+ * already uses. The heavy JS scaffolding (CSV build, BM25, deflate, Parquet,
+ * DTO mapping) stays in `storeWorker`; only the raw engine ops cross back.
+ */
+
+import lbug from '@ladybugdb/wasm-core';
+
+type Database = InstanceType<typeof lbug.Database>;
+type Connection = InstanceType<typeof lbug.Connection>;
+
+/**
+ * The minimal LadybugDB engine surface that LadybugGraphStore depends on.
+ * Implemented here for real (main thread) and as a postMessage shim inside
+ * `storeWorker`. Keeping it this narrow is what lets the store stay in the
+ * worker while the engine lives on main.
+ */
+export interface LbugEngine {
+  /** Boot the engine worker, open the in-memory database, open a connection. */
+  init(): Promise<void>;
+  /** Run a Cypher query and return all rows as plain objects. */
+  query(cypher: string): Promise<Record<string, unknown>[]>;
+  /** Run a Cypher statement that returns no rows (DDL, COPY, CALL ...). */
+  exec(cypher: string): Promise<void>;
+  /** Write bytes into the engine's virtual filesystem (for COPY FROM). */
+  fsWrite(path: string, data: Uint8Array): Promise<void>;
+  /** Remove a file from the engine's virtual filesystem. */
+  fsUnlink(path: string): Promise<void>;
+  /** Tear down the connection, database, and engine worker. Idempotent. */
+  close(): Promise<void>;
+}
+
+class MainThreadLbugEngine implements LbugEngine {
+  private db: Database | null = null;
+  private conn: Connection | null = null;
+  private closed = false;
+
+  async init(): Promise<void> {
+    lbug.setWorkerPath('/lbug_wasm_worker.js');
+    await lbug.init();
+    // Buffer pool size note: lbug accepts a `bufferPoolSize` argument here,
+    // but in WASM the linear memory is a single shared heap — reserving more
+    // for the page cache leaves less for everything else (CSV temp files,
+    // query state, parser tables). An explicit 512 MB reservation broke ingest
+    // even for small repos, so we let the engine's auto-sizing decide. To
+    // genuinely fit larger graphs the right move is to reduce extraction depth
+    // or use server mode rather than push this number up.
+    this.db = new lbug.Database(':memory:');
+    await this.db.init();
+    this.conn = new lbug.Connection(this.db);
+    await this.conn.init();
+    this.closed = false;
+  }
+
+  async query(cypher: string): Promise<Record<string, unknown>[]> {
+    if (!this.conn) throw new Error('LbugEngine.query before init()');
+    const result = await this.conn.query(cypher);
+    try {
+      return await result.getAllObjects();
+    } finally {
+      await result.close();
+    }
+  }
+
+  async exec(cypher: string): Promise<void> {
+    if (!this.conn) throw new Error('LbugEngine.exec before init()');
+    const result = await this.conn.query(cypher);
+    await result.close();
+  }
+
+  async fsWrite(path: string, data: Uint8Array): Promise<void> {
+    await lbug.FS.writeFile(path, data);
+  }
+
+  async fsUnlink(path: string): Promise<void> {
+    await lbug.FS.unlink(path);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      await this.conn?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await this.db?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await lbug.close();
+    } catch {
+      /* ignore */
+    }
+    this.conn = null;
+    this.db = null;
+  }
+}
+
+/** Construct a main-thread LadybugDB engine. */
+export function createLbugEngine(): LbugEngine {
+  return new MainThreadLbugEngine();
+}

--- a/ui/src/store/storeWorker.ts
+++ b/ui/src/store/storeWorker.ts
@@ -32,6 +32,7 @@
 
 import { LadybugGraphStore } from './ladybugStore';
 import type { Embedder } from '../runner/browser/enricher/embedder/types';
+import type { LbugEngine } from './lbugEngine';
 import type { ImportBatchRequest, SourceFile } from './types';
 
 type CallMessage = {
@@ -47,18 +48,44 @@ type EmbedReplyMessage = {
   vectors: number[][];
 };
 type EmbedErrorMessage = { seq: number; type: 'embed-error'; message: string };
+type EngineReplyMessage = {
+  seq: number;
+  type: 'engine-reply';
+  value: unknown;
+};
+type EngineErrorMessage = {
+  seq: number;
+  type: 'engine-error';
+  message: string;
+};
 
 type InMessage =
   | CallMessage
   | SetEmbedderMessage
   | EmbedReplyMessage
-  | EmbedErrorMessage;
+  | EmbedErrorMessage
+  | EngineReplyMessage
+  | EngineErrorMessage;
+
+type EngineMethod =
+  | 'init'
+  | 'query'
+  | 'exec'
+  | 'fsWrite'
+  | 'fsUnlink'
+  | 'close';
 
 type OutMessage =
   | { seq: number; type: 'result'; value: unknown }
   | { seq: number; type: 'error'; message: string }
   | { seq: number; type: 'progress'; value: string }
-  | { seq: number; type: 'embed-request'; texts: string[] };
+  | { seq: number; type: 'embed-request'; texts: string[] }
+  | {
+      seq: number;
+      type: 'engine-request';
+      method: EngineMethod;
+      args: unknown[];
+    };
 
 const post = (msg: OutMessage, transfer?: Transferable[]): void => {
   if (transfer && transfer.length > 0) {
@@ -68,7 +95,41 @@ const post = (msg: OutMessage, transfer?: Transferable[]): void => {
   }
 };
 
-const store = new LadybugGraphStore();
+// --- Engine shim ---
+// The LadybugDB engine runs on the MAIN thread (so its internal worker is a
+// top-level worker, never nested — see lbugEngine.ts). Each engine call posts
+// an `engine-request` to main, which runs it against the real engine and
+// replies `engine-reply` / `engine-error`. Mirrors the embedder shim below.
+let nextEngineSeq = 1;
+const pendingEngine = new Map<
+  number,
+  { resolve: (v: unknown) => void; reject: (err: Error) => void }
+>();
+function engineCall(
+  method: EngineMethod,
+  args: unknown[],
+  transfer?: Transferable[],
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const seq = nextEngineSeq++;
+    pendingEngine.set(seq, { resolve, reject });
+    post({ seq, type: 'engine-request', method, args }, transfer);
+  });
+}
+const engineShim: LbugEngine = {
+  init: () => engineCall('init', []) as Promise<void>,
+  query: (cypher) =>
+    engineCall('query', [cypher]) as Promise<Record<string, unknown>[]>,
+  exec: (cypher) => engineCall('exec', [cypher]) as Promise<void>,
+  // Transfer the CSV buffer zero-copy to main; the caller (flush/import) hands
+  // off a freshly-encoded array it never reads again.
+  fsWrite: (path, data) =>
+    engineCall('fsWrite', [path, data], [data.buffer]) as Promise<void>,
+  fsUnlink: (path) => engineCall('fsUnlink', [path]) as Promise<void>,
+  close: () => engineCall('close', []) as Promise<void>,
+};
+
+const store = new LadybugGraphStore(engineShim);
 
 // --- Embedder shim ---
 // When the main-thread proxy calls setEmbedder(), we install this shim
@@ -235,6 +296,22 @@ self.onmessage = (e: MessageEvent<InMessage>) => {
     const p = pendingEmbeds.get(msg.seq);
     if (p) {
       pendingEmbeds.delete(msg.seq);
+      p.reject(new Error(msg.message));
+    }
+    return;
+  }
+  if (msg.type === 'engine-reply') {
+    const p = pendingEngine.get(msg.seq);
+    if (p) {
+      pendingEngine.delete(msg.seq);
+      p.resolve(msg.value);
+    }
+    return;
+  }
+  if (msg.type === 'engine-error') {
+    const p = pendingEngine.get(msg.seq);
+    if (p) {
+      pendingEngine.delete(msg.seq);
       p.reject(new Error(msg.message));
     }
     return;

--- a/ui/src/store/workerStore.ts
+++ b/ui/src/store/workerStore.ts
@@ -34,6 +34,7 @@
 
 import type { GraphData, GraphStats } from '@opentrace/components/utils';
 import type { Embedder } from '../runner/browser/enricher/embedder/types';
+import { createLbugEngine, type LbugEngine } from './lbugEngine';
 import type {
   GraphStore,
   ImportBatchRequest,
@@ -45,11 +46,25 @@ import type {
   TraverseResult,
 } from './types';
 
+type EngineMethod =
+  | 'init'
+  | 'query'
+  | 'exec'
+  | 'fsWrite'
+  | 'fsUnlink'
+  | 'close';
+
 type InMessage =
   | { seq: number; type: 'result'; value: unknown }
   | { seq: number; type: 'error'; message: string }
   | { seq: number; type: 'progress'; value: string }
-  | { seq: number; type: 'embed-request'; texts: string[] };
+  | { seq: number; type: 'embed-request'; texts: string[] }
+  | {
+      seq: number;
+      type: 'engine-request';
+      method: EngineMethod;
+      args: unknown[];
+    };
 
 interface PendingRequest {
   resolve: (value: unknown) => void;
@@ -62,6 +77,11 @@ export class WorkerGraphStore implements GraphStore {
   private pending = new Map<number, PendingRequest>();
   private nextSeq = 1;
   private embedder: Embedder | null = null;
+  // The LadybugDB engine is owned here, on the main thread, so its internal
+  // worker is a top-level worker rather than one nested inside storeWorker
+  // (which broke on browsers without worker-in-worker support — Sentry
+  // OSS-OPENTRACE-1G). storeWorker reaches it via `engine-request` messages.
+  private engine: LbugEngine = createLbugEngine();
   private nodesImportedSinceClear = 0;
 
   constructor() {
@@ -254,11 +274,21 @@ export class WorkerGraphStore implements GraphStore {
 
   async dispose(): Promise<void> {
     try {
+      // Drives ladybugStore.dispose() in the worker, which calls
+      // engine.close() back over RPC — closing the engine while the worker
+      // is still alive to relay the request.
       await this.call<void>('dispose', []);
     } catch {
       // ignore — worker may already be dead
     }
     this.worker.terminate();
+    // Belt-and-suspenders: if the RPC close didn't land (worker wedged),
+    // close the engine directly. engine.close() is idempotent.
+    try {
+      await this.engine.close();
+    } catch {
+      // ignore — engine may already be closed
+    }
     const err = new Error('WorkerGraphStore disposed');
     for (const req of this.pending.values()) req.reject(err);
     this.pending.clear();
@@ -291,6 +321,10 @@ export class WorkerGraphStore implements GraphStore {
   private onMessage(msg: InMessage): void {
     if (msg.type === 'embed-request') {
       void this.handleEmbedRequest(msg.seq, msg.texts);
+      return;
+    }
+    if (msg.type === 'engine-request') {
+      void this.handleEngineRequest(msg.seq, msg.method, msg.args);
       return;
     }
     const req = this.pending.get(msg.seq);
@@ -329,6 +363,48 @@ export class WorkerGraphStore implements GraphStore {
       this.worker.postMessage({
         seq,
         type: 'embed-error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private async handleEngineRequest(
+    seq: number,
+    method: EngineMethod,
+    args: unknown[],
+  ): Promise<void> {
+    try {
+      let value: unknown;
+      switch (method) {
+        case 'init':
+          value = await this.engine.init();
+          break;
+        case 'query':
+          value = await this.engine.query(args[0] as string);
+          break;
+        case 'exec':
+          value = await this.engine.exec(args[0] as string);
+          break;
+        case 'fsWrite':
+          value = await this.engine.fsWrite(
+            args[0] as string,
+            args[1] as Uint8Array,
+          );
+          break;
+        case 'fsUnlink':
+          value = await this.engine.fsUnlink(args[0] as string);
+          break;
+        case 'close':
+          value = await this.engine.close();
+          break;
+        default:
+          throw new Error(`unknown engine method '${method}'`);
+      }
+      this.worker.postMessage({ seq, type: 'engine-reply', value });
+    } catch (err) {
+      this.worker.postMessage({
+        seq,
+        type: 'engine-error',
         message: err instanceof Error ? err.message : String(err),
       });
     }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -75,8 +75,12 @@ function resolveEnvDir(): string {
  * Also sets the correct MIME type for .wasm files so WebAssembly
  * streaming compilation works (requires application/wasm).
  *
- * Uses "credentialless" instead of "require-corp" so cross-origin
- * fetches (e.g. api.github.com) still work without CORS attributes.
+ * Uses "require-corp" to match production (oss.opentrace.ai). Safari does
+ * not honor "credentialless", so a dev server sending it leaves Safari
+ * without cross-origin isolation — `window.crossOriginIsolated` is false and
+ * the browser-support gate in main.tsx blocks the app. Production's
+ * cross-origin assets (HF model CDN, oss.opentrace.ai archive proxy,
+ * code-host APIs) already coexist with require-corp via CORS, so dev matches.
  */
 function crossOriginIsolation(): Plugin {
   const publicDir = resolve(__dirname, 'public');
@@ -88,7 +92,7 @@ function crossOriginIsolation(): Plugin {
     next: () => void,
   ) {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-    res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
 
     // Serve .wasm files directly with correct MIME type.
     // Vite's static handler sets the wrong Content-Type for .wasm and


### PR DESCRIPTION
## Fix Safari/WebView timeout by moving LadybugDB to main thread
🐛 **Bug Fix** · ✨ **Improvement** · ♻️ **Refactor**

Moves the LadybugDB engine from `storeWorker` to the main thread to prevent nested worker initialization failures. 

This fix resolves 60-second timeouts in Safari and WebViews where worker-in-worker support is unreliable. Heavy data processing remains in the worker, while raw engine operations are proxied via a new RPC interface.

### Complexity
🟡 Moderate · `6 files changed, 413 insertions(+), 157 deletions(-)`

This PR restructures the communication between the application's main thread and its background store worker. While it follows existing architectural patterns for shimming services into workers, it touches the core database lifecycle and changes infrastructure-level security headers in the Vite configuration.

### Tests
🧪 Existing unit tests were refactored to use a mock engine, maintaining coverage of the store's query queueing and state management.

### Review focus
Pay particular attention to the following areas:

- **RPC Bridge Integrity** — verify that query results and errors are correctly serialized and returned across the worker boundary.
- **Zero-copy Transfers** — ensure CSV buffers in `fsWrite` are correctly included in the `postMessage` transfer list to avoid performance regressions.
- **COEP Header Alignment** — check that the shift to `require-corp` in the dev server doesn't block local assets in environments that were relying on `credentialless`.
<!-- opentrace:jid=fc85cc38-d60d-4db1-95b5-a52221c62925|sha=8f8f599aa94dc5a7b04eb5190b58283f0035ee23 -->