### PR TITLE
test: codehub-agent blast-radius review

### DIFF
--- a/agent/src/opentrace_agent/benchmarks/agent.py
+++ b/agent/src/opentrace_agent/benchmarks/agent.py
@@ -972,3 +972,5 @@ def run_swe_bench_cli(
         if verbose:
             click.echo()
         click.echo(report.summary(verbose=verbose))
+
+# codehub-agent blast-radius smoke test (PR will be closed)

--- a/agent/src/opentrace_agent/benchmarks/agent.py
+++ b/agent/src/opentrace_agent/benchmarks/agent.py
@@ -974,3 +974,4 @@ def run_swe_bench_cli(
         click.echo(report.summary(verbose=verbose))
 
 # codehub-agent blast-radius smoke test (PR will be closed)
+# retrigger


### PR DESCRIPTION
## Add smoke test comment for blast radius check
🔧 **Chore**

Adds a placeholder comment to the benchmark agent script for a blast-radius smoke test. 

This change is intended for testing automation and will be closed.

### Complexity
🟢 Trivial · `1 file changed, 2 insertions(+)`

This is a single-line comment addition to a benchmark script with no impact on logic or execution.
<!-- opentrace:jid=j-12698901-c58b-40ae-b821-6f0d92cfb2ae|sha=0f2723269825e8e5e5a52f5f52830fe26d2b68b5 -->