### PR TITLE
fix(ui): PR review accuracy — SHA-pinned content, per-field truncation, verdict guardrail + model refresh

### DIFF
--- a/ui/src/appComponents/ChatPanel.tsx
+++ b/ui/src/appComponents/ChatPanel.tsx
@@ -70,6 +70,20 @@ import { useConversation } from '../chat/useConversation';
 import PRListPanel from './PRListPanel';
 import './ChatPanel.css';
 
+/**
+ * Resolve the model to select for a provider. A stored choice can predate
+ * a model-list update (e.g. a retired Claude 4.x ID) — fall back to the
+ * provider default rather than pinning the dropdown to an option that no
+ * longer exists. Local models are free-text, so any stored value is valid.
+ */
+function resolveModelChoice(pid: string): string {
+  const stored = loadModelChoice(pid);
+  const isKnown =
+    pid === 'local' ||
+    (stored != null && PROVIDERS[pid].models.some((m) => m.id === stored));
+  return isKnown && stored != null ? stored : PROVIDERS[pid].defaultModel;
+}
+
 function TokenUsageFooter({ usage }: { usage: TokenUsage }) {
   return (
     <div className="token-usage">
@@ -136,10 +150,9 @@ export default function ChatPanel({
   }, [panelWidth, onWidthChange]);
 
   const [providerId, setProviderId] = useState(loadProviderChoice);
-  const [modelId, setModelId] = useState(() => {
-    const pid = loadProviderChoice();
-    return loadModelChoice(pid) ?? PROVIDERS[pid].defaultModel;
-  });
+  const [modelId, setModelId] = useState(() =>
+    resolveModelChoice(loadProviderChoice()),
+  );
   const [apiKey, setApiKey] = useState(() => loadApiKey(loadProviderChoice()));
   // Live value of the auto-detect key field (cloud mode). Held separately
   // from `apiKey` so we can detect the provider as the user types without
@@ -300,8 +313,7 @@ export default function ChatPanel({
     const key = loadApiKey(id);
     setApiKey(key);
     setKeyDraft(key);
-    const savedModel = loadModelChoice(id);
-    setModelId(savedModel ?? PROVIDERS[id].defaultModel);
+    setModelId(resolveModelChoice(id));
     if (id === 'local') setLocalUrl(loadLocalUrl());
     setShowSettings(true);
   };
@@ -327,8 +339,7 @@ export default function ChatPanel({
     if (detected && detected !== providerId) {
       setProviderId(detected);
       saveProviderChoice(detected);
-      const savedModel = loadModelChoice(detected);
-      setModelId(savedModel ?? PROVIDERS[detected].defaultModel);
+      setModelId(resolveModelChoice(detected));
     }
   };
 
@@ -338,8 +349,7 @@ export default function ChatPanel({
   const pickProviderKeepKey = (id: string) => {
     setProviderId(id);
     saveProviderChoice(id);
-    const savedModel = loadModelChoice(id);
-    setModelId(savedModel ?? PROVIDERS[id].defaultModel);
+    setModelId(resolveModelChoice(id));
   };
 
   // Provider inferred from the current draft key (null while empty or

--- a/ui/src/chat/__tests__/prTools.test.ts
+++ b/ui/src/chat/__tests__/prTools.test.ts
@@ -387,6 +387,89 @@ describe('makePRTools', () => {
         deletions: 1,
       });
     });
+
+    it('drops file entries instead of emitting broken JSON when over budget', async () => {
+      const prId = 'owner/repo/pr/10';
+      const hugeFiles = Array.from({ length: 300 }, (_, i) => ({
+        node: { id: `f${i}`, type: 'File', name: `f${i}.ts` },
+        relationship: {
+          id: `r${i}`,
+          type: 'CHANGES',
+          source_id: prId,
+          target_id: `f${i}`,
+          properties: {
+            path: `src/deeply/nested/directory/structure/${'x'.repeat(80)}/f${i}.ts`,
+            status: 'modified',
+            additions: 1,
+            deletions: 1,
+          },
+        },
+        depth: 1,
+      }));
+      const store = createMockStore({
+        getNode: vi.fn().mockResolvedValue({
+          id: prId,
+          type: 'PullRequest',
+          name: '#10',
+          properties: {},
+        }),
+        traverse: vi.fn().mockResolvedValue(hugeFiles),
+      });
+      const tools = makePRTools(store);
+      const tool = tools.find((t) => t.name === 'get_pull_request')!;
+      const raw = (await tool.invoke({ prId })) as string;
+      // Must parse — the old path sliced the stringified JSON mid-stream
+      const result = JSON.parse(raw);
+      expect(raw.length).toBeLessThanOrEqual(16_000);
+      expect(result.file_count).toBe(300);
+      expect(result.files.length).toBeLessThan(300);
+      expect(result.files_omitted).toBe(300 - result.files.length);
+      expect(result.note).toContain(`of 300 files`);
+    });
+  });
+
+  describe('summarize_pr_changes', () => {
+    it('keys blast radius by file path, not graph node ID', async () => {
+      const prId = 'owner/repo/pr/11';
+      const changes = [
+        {
+          node: { id: 'owner/repo/src/a.ts', type: 'File', name: 'a.ts' },
+          relationship: {
+            id: 'r1',
+            type: 'CHANGES',
+            source_id: prId,
+            target_id: 'owner/repo/src/a.ts',
+            properties: { path: 'src/a.ts', status: 'modified' },
+          },
+          depth: 1,
+        },
+      ];
+      const dependents = [
+        {
+          node: { id: 'caller1', type: 'Function', name: 'callerFn' },
+          relationship: {
+            id: 'd1',
+            type: 'CALLS',
+            source_id: 'caller1',
+            target_id: 'owner/repo/src/a.ts',
+          },
+          depth: 1,
+        },
+      ];
+      const traverse = vi
+        .fn()
+        .mockResolvedValueOnce(changes) // PR --CHANGES--> files
+        .mockResolvedValueOnce(dependents); // incoming for the file
+      const store = createMockStore({ traverse });
+      const tools = makePRTools(store);
+      const tool = tools.find((t) => t.name === 'summarize_pr_changes')!;
+      const result = JSON.parse((await tool.invoke({ prId })) as string);
+      expect(result.blast_radius['src/a.ts']).toEqual({
+        dependents: 1,
+        sample: ['Function:callerFn'],
+      });
+      expect(result.blast_radius['owner/repo/src/a.ts']).toBeUndefined();
+    });
   });
 
   describe('submit_review_summary', () => {

--- a/ui/src/chat/__tests__/prTools.test.ts
+++ b/ui/src/chat/__tests__/prTools.test.ts
@@ -174,7 +174,10 @@ describe('makePRTools', () => {
       const result = JSON.parse(
         (await tool.invoke({ prId, filePath, version: 'base' })) as string,
       );
-      expect(result.base_content).toBe('original code');
+      // Content is line-numbered and flagged as an indexed-snapshot read
+      expect(result.base_content).toContain('original code');
+      expect(result.base_content).toMatch(/^\s*1\t/);
+      expect(result.base_content_note).toContain('indexed snapshot');
     });
 
     it('calls prClient.getFileContent when available', async () => {
@@ -192,6 +195,197 @@ describe('makePRTools', () => {
       const tool = tools.find((t) => t.name === 'get_pr_file_change')!;
       await tool.invoke({ prId, filePath, version: 'base' });
       expect(prClient.getFileContent).toHaveBeenCalledWith(filePath, 'main');
+    });
+
+    it('prefers immutable SHAs over branch names', async () => {
+      const prClient = createMockPRClient();
+      const store = createMockStore({
+        traverse: vi.fn().mockResolvedValue(traverseResult),
+        getNode: vi.fn().mockResolvedValue({
+          id: prId,
+          type: 'PullRequest',
+          name: '#1',
+          properties: {
+            baseBranch: 'main',
+            headBranch: 'feat',
+            baseSha: 'base123',
+            headSha: 'head456',
+          },
+        }),
+      });
+      const tools = makePRTools(store, prClient);
+      const tool = tools.find((t) => t.name === 'get_pr_file_change')!;
+      await tool.invoke({ prId, filePath, version: 'all' });
+      expect(prClient.getFileContent).toHaveBeenCalledWith(filePath, 'base123');
+      expect(prClient.getFileContent).toHaveBeenCalledWith(filePath, 'head456');
+    });
+
+    it('reads camelCase branch props written by the indexer', async () => {
+      const prClient = createMockPRClient();
+      const store = createMockStore({
+        traverse: vi.fn().mockResolvedValue(traverseResult),
+        getNode: vi.fn().mockResolvedValue({
+          id: prId,
+          type: 'PullRequest',
+          name: '#1',
+          // what indexPRIntoGraph actually writes — used to be dropped
+          properties: { baseBranch: 'main', headBranch: 'feat' },
+        }),
+      });
+      const tools = makePRTools(store, prClient);
+      const tool = tools.find((t) => t.name === 'get_pr_file_change')!;
+      const result = JSON.parse(
+        (await tool.invoke({ prId, filePath, version: 'new' })) as string,
+      );
+      expect(prClient.getFileContent).toHaveBeenCalledWith(filePath, 'feat');
+      expect(result.new_content).toContain('file content');
+    });
+
+    it('retries via head repo for fork PRs when base repo misses the ref', async () => {
+      const getFileContent = vi
+        .fn()
+        .mockResolvedValueOnce(null) // base repo does not have the fork commit
+        .mockResolvedValueOnce('fork content');
+      const prClient = createMockPRClient({ getFileContent });
+      const store = createMockStore({
+        traverse: vi.fn().mockResolvedValue(traverseResult),
+        getNode: vi.fn().mockResolvedValue({
+          id: prId,
+          type: 'PullRequest',
+          name: '#1',
+          properties: { headSha: 'head456', headRepo: 'fork/repo' },
+        }),
+      });
+      const tools = makePRTools(store, prClient);
+      const tool = tools.find((t) => t.name === 'get_pr_file_change')!;
+      const result = JSON.parse(
+        (await tool.invoke({ prId, filePath, version: 'new' })) as string,
+      );
+      expect(getFileContent).toHaveBeenNthCalledWith(
+        2,
+        filePath,
+        'head456',
+        'fork/repo',
+      );
+      expect(result.new_content).toContain('fork content');
+    });
+
+    it('pages new_content with startLine and flags truncation', async () => {
+      const bigFile = Array.from(
+        { length: 3000 },
+        (_, i) => `line ${i + 1} ${'x'.repeat(20)}`,
+      ).join('\n');
+      const prClient = createMockPRClient({
+        getFileContent: vi.fn().mockResolvedValue(bigFile),
+      });
+      const store = createMockStore({
+        traverse: vi.fn().mockResolvedValue(traverseResult),
+        getNode: vi.fn().mockResolvedValue({
+          id: prId,
+          type: 'PullRequest',
+          name: '#1',
+          properties: { headSha: 'head456' },
+        }),
+      });
+      const tools = makePRTools(store, prClient);
+      const tool = tools.find((t) => t.name === 'get_pr_file_change')!;
+
+      const first = JSON.parse(
+        (await tool.invoke({ prId, filePath, version: 'new' })) as string,
+      );
+      expect(first.new_content_truncated).toBe(true);
+      expect(first.new_content_lines).toMatch(/^1-\d+ of 3000$/);
+      const next = Number(first.new_content_note.match(/startLine=(\d+)/)![1]);
+      expect(next).toBeGreaterThan(1);
+
+      const second = JSON.parse(
+        (await tool.invoke({
+          prId,
+          filePath,
+          version: 'new',
+          startLine: next,
+        })) as string,
+      );
+      expect(second.new_content).toContain(`line ${next} `);
+      expect(second.new_content_lines.startsWith(`${next}-`)).toBe(true);
+    });
+
+    it('slices an explicit line range', async () => {
+      const content = Array.from({ length: 100 }, (_, i) => `l${i + 1}`).join(
+        '\n',
+      );
+      const prClient = createMockPRClient({
+        getFileContent: vi.fn().mockResolvedValue(content),
+      });
+      const store = createMockStore({
+        traverse: vi.fn().mockResolvedValue(traverseResult),
+        getNode: vi.fn().mockResolvedValue({
+          id: prId,
+          type: 'PullRequest',
+          name: '#1',
+          properties: { headSha: 'h' },
+        }),
+      });
+      const tools = makePRTools(store, prClient);
+      const tool = tools.find((t) => t.name === 'get_pr_file_change')!;
+      const result = JSON.parse(
+        (await tool.invoke({
+          prId,
+          filePath,
+          version: 'new',
+          startLine: 10,
+          endLine: 12,
+        })) as string,
+      );
+      expect(result.new_content_lines).toBe('10-12 of 100');
+      expect(result.new_content).toContain('l10');
+      expect(result.new_content).toContain('l12');
+      expect(result.new_content).not.toContain('l13');
+      expect(result.new_content_truncated).toBeUndefined();
+    });
+  });
+
+  describe('get_pull_request', () => {
+    it('returns a complete compact file list', async () => {
+      const prId = 'owner/repo/pr/9';
+      const manyFiles = Array.from({ length: 120 }, (_, i) => ({
+        node: { id: `f${i}`, type: 'File', name: `f${i}.ts` },
+        relationship: {
+          id: `r${i}`,
+          type: 'CHANGES',
+          source_id: prId,
+          target_id: `f${i}`,
+          properties: {
+            path: `src/f${i}.ts`,
+            status: 'modified',
+            additions: 1,
+            deletions: 1,
+            patch: '@@ -1 +1 @@\n+x'.repeat(50),
+          },
+        },
+        depth: 1,
+      }));
+      const store = createMockStore({
+        getNode: vi.fn().mockResolvedValue({
+          id: prId,
+          type: 'PullRequest',
+          name: '#9',
+          properties: {},
+        }),
+        traverse: vi.fn().mockResolvedValue(manyFiles),
+      });
+      const tools = makePRTools(store);
+      const tool = tools.find((t) => t.name === 'get_pull_request')!;
+      const result = JSON.parse((await tool.invoke({ prId })) as string);
+      expect(result.file_count).toBe(120);
+      expect(result.files).toHaveLength(120);
+      // Compact entries — no patch payloads in the listing
+      expect(result.files[0]).toEqual({
+        path: 'src/f0.ts',
+        status: 'modified',
+        additions: 1,
+        deletions: 1,
+      });
     });
   });
 

--- a/ui/src/chat/prTools.ts
+++ b/ui/src/chat/prTools.ts
@@ -24,12 +24,71 @@ import { z } from 'zod';
 import type { GraphStore } from '../store/types';
 import type { PRClient } from '../pr/client';
 
-const MAX_RESULT_CHARS = 6000;
-const MAX_SOURCE_CHARS = 8000;
+const MAX_RESULT_CHARS = 16_000;
+/** Per-field budgets for get_pr_file_change. Each field is bounded
+ *  independently and flagged when cut — never truncate the combined JSON
+ *  mid-stream, or the model reviews half a payload without knowing it. */
+const MAX_DIFF_CHARS = 12_000;
+const MAX_CONTENT_CHARS = 16_000;
+/** Safety net for the combined get_pr_file_change payload. */
+const MAX_FILE_CHANGE_CHARS = 48_000;
+/** Max compact file entries returned by get_pull_request. */
+const MAX_FILE_ENTRIES = 300;
 
 function truncate(text: string, limit: number): string {
   if (text.length <= limit) return text;
   return text.slice(0, limit) + `\n...[truncated, ${text.length} chars total]`;
+}
+
+/**
+ * Slice file content to a 1-based inclusive line range, numbered cat -n
+ * style so the model can cite exact new-file line numbers, bounded by a
+ * character budget. Reports the range served and where to resume.
+ */
+function packContent(
+  content: string,
+  startLine: number | undefined,
+  endLine: number | undefined,
+  budget: number,
+): {
+  text: string;
+  lines: string;
+  truncated: boolean;
+  next_start_line?: number;
+} {
+  const all = content.split('\n');
+  const total = all.length;
+  const start = Math.min(Math.max(1, startLine ?? 1), total);
+  const end = Math.min(total, endLine && endLine >= start ? endLine : total);
+  const out: string[] = [];
+  let used = 0;
+  let last = start - 1;
+  for (let i = start; i <= end; i++) {
+    const line = `${String(i).padStart(5)}\t${all[i - 1]}`;
+    if (used + line.length + 1 > budget) break;
+    out.push(line);
+    used += line.length + 1;
+    last = i;
+  }
+  const truncated = last < end;
+  return {
+    text: out.join('\n'),
+    lines: `${start}-${last} of ${total}`,
+    truncated,
+    ...(truncated ? { next_start_line: last + 1 } : {}),
+  };
+}
+
+/** Read a string property from a node's properties bag. */
+function strProp(
+  props: Record<string, unknown> | undefined,
+  ...keys: string[]
+): string | undefined {
+  for (const k of keys) {
+    const v = props?.[k];
+    if (typeof v === 'string' && v) return v;
+  }
+  return undefined;
 }
 
 export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
@@ -59,13 +118,33 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
         if (!node)
           return JSON.stringify({ error: 'PR not found in graph', id: prId });
 
-        // Traverse 2 hops: PR --CHANGES--> File --*--> neighbors
-        const modifies = await store.traverse(prId, 'outgoing', 2, 'CHANGES');
+        const modifies = await store.traverse(prId, 'outgoing', 1, 'CHANGES');
+        // Compact entries — one small object per file so even huge PRs
+        // return a complete file list instead of a truncated JSON blob.
+        const files = modifies.map((r) => {
+          const p = (r.relationship.properties ?? {}) as Record<
+            string,
+            unknown
+          >;
+          return {
+            path: p.path,
+            status: p.status,
+            additions: p.additions,
+            deletions: p.deletions,
+          };
+        });
+        const omitted = Math.max(0, files.length - MAX_FILE_ENTRIES);
         return truncate(
           JSON.stringify({
             pr: node,
-            modified_files: modifies,
-            file_count: modifies.length,
+            files: files.slice(0, MAX_FILE_ENTRIES),
+            file_count: files.length,
+            ...(omitted
+              ? {
+                  files_omitted: omitted,
+                  note: `Showing first ${MAX_FILE_ENTRIES} of ${files.length} files`,
+                }
+              : {}),
           }),
           MAX_RESULT_CHARS,
         );
@@ -74,7 +153,7 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
         name: 'get_pull_request',
         description:
           'Get details of a specific PullRequest node from the graph, ' +
-          'including all files it modifies via CHANGES relationships (with diff status and line counts). ' +
+          'with a complete compact list of every changed file (path, status, +/- line counts). ' +
           'Use get_pr_file_change to inspect the actual diff or file contents for individual files.',
         schema: z.object({
           prId: z
@@ -87,16 +166,29 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
       async ({ prId }) => {
         // Traverse: PR --CHANGES--> File --incoming(CALLS, IMPORTS, etc.)--> callers
         const modifies = await store.traverse(prId, 'outgoing', 1, 'CHANGES');
-        const blastRadius: Record<string, unknown[]> = {};
-        for (const rel of modifies) {
+        const blastRadius: Record<string, unknown> = {};
+        // Compact per-file summary (count + sample) so large PRs don't
+        // overflow into mid-JSON truncation.
+        const scanned = modifies.slice(0, 100);
+        for (const rel of scanned) {
           const fileId = rel.relationship.target_id;
           if (!fileId) continue;
           const incoming = await store.traverse(fileId, 'incoming', 2);
-          blastRadius[fileId] = incoming;
+          blastRadius[fileId] = {
+            dependents: incoming.length,
+            sample: incoming
+              .slice(0, 10)
+              .map((d) => `${d.node.type}:${d.node.name || d.node.id}`),
+          };
         }
         return truncate(
           JSON.stringify({
             modified_files: modifies.length,
+            ...(modifies.length > scanned.length
+              ? {
+                  note: `Blast radius computed for first ${scanned.length} of ${modifies.length} files`,
+                }
+              : {}),
             blast_radius: blastRadius,
           }),
           MAX_RESULT_CHARS,
@@ -116,7 +208,7 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
       },
     ),
     tool(
-      async ({ prId, filePath, version }) => {
+      async ({ prId, filePath, version, startLine, endLine }) => {
         // Find the CHANGES edge for this file
         const changes = await store.traverse(prId, 'outgoing', 1, 'CHANGES');
         const match = changes.find((r) => {
@@ -127,13 +219,16 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
         });
 
         if (!match) {
-          return JSON.stringify({
-            error: `No CHANGES edge found for file "${filePath}" in this PR`,
-            available_files: changes.map(
-              (r) =>
-                (r.relationship.properties as Record<string, unknown>)?.path,
-            ),
-          });
+          return truncate(
+            JSON.stringify({
+              error: `No CHANGES edge found for file "${filePath}" in this PR`,
+              available_files: changes.map(
+                (r) =>
+                  (r.relationship.properties as Record<string, unknown>)?.path,
+              ),
+            }),
+            MAX_RESULT_CHARS,
+          );
         }
 
         const edgeProps = match.relationship.properties as Record<
@@ -142,52 +237,130 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
         >;
         const patch = (edgeProps?.patch as string) || null;
         const status = edgeProps?.status as string;
+        const previousPath = (edgeProps?.previous_path as string) || null;
 
-        // Get branch refs from the PR node properties
+        // Resolve refs from the PR node. Prefer immutable SHAs — branch
+        // names move after indexing, and fork head branches don't exist
+        // in the base repo at all.
         const prNode = await store.getNode(prId);
-        const baseBranch = (prNode?.properties?.base_branch as string) || null;
-        const headBranch = (prNode?.properties?.head_branch as string) || null;
+        const prProps = prNode?.properties as
+          | Record<string, unknown>
+          | undefined;
+        const baseRef = strProp(
+          prProps,
+          'baseSha',
+          'base_sha',
+          'baseBranch',
+          'base_branch',
+        );
+        const headRef = strProp(
+          prProps,
+          'headSha',
+          'head_sha',
+          'headBranch',
+          'head_branch',
+        );
+        const headRepo = strProp(prProps, 'headRepo', 'head_repo');
 
-        // Build response based on requested version
+        // Build response based on requested version. Every content field
+        // is bounded and flagged individually — a silently truncated blob
+        // makes the model review code it never saw.
         const result: Record<string, unknown> = {
           path: filePath,
           status,
           additions: edgeProps?.additions,
           deletions: edgeProps?.deletions,
+          ...(previousPath ? { previous_path: previousPath } : {}),
         };
 
         if (version === 'diff' || version === 'all') {
-          result.diff = patch ?? '(no patch available)';
+          if (!patch) {
+            result.diff =
+              '(no patch available — file may be binary or the diff was too large for the provider)';
+          } else {
+            result.diff = truncate(patch, MAX_DIFF_CHARS);
+            if (patch.length > MAX_DIFF_CHARS) {
+              result.diff_truncated = true;
+              result.diff_note =
+                'Diff truncated. Use version "new" with startLine/endLine to read the full changed regions.';
+            }
+          }
         }
 
         if (version === 'base' || version === 'all') {
+          const basePath =
+            status === 'renamed' && previousPath ? previousPath : filePath;
+          let content: string | null = null;
           if (status === 'added') {
             result.base_content = null;
-          } else if (prClient && baseBranch) {
-            result.base_content =
-              (await prClient.getFileContent(filePath, baseBranch)) ??
-              '(file not found at base branch)';
           } else {
-            // Fall back to indexed source when no client available
-            const fileId = match.relationship.target_id;
-            const source = await store.fetchSource(fileId);
-            result.base_content = source?.content ?? '(source not available)';
+            if (prClient && baseRef) {
+              content = await prClient.getFileContent(basePath, baseRef);
+            }
+            if (content == null) {
+              // Fall back to indexed source when no client/ref available
+              const fileId = match.relationship.target_id;
+              const source = await store.fetchSource(fileId);
+              content = source?.content ?? null;
+              if (content != null) {
+                result.base_content_note =
+                  'Served from the indexed snapshot, not the PR base commit — may be stale.';
+              }
+            }
+            if (content == null) {
+              result.base_content = '(base content not available)';
+            } else {
+              const packed = packContent(
+                content,
+                startLine,
+                endLine,
+                MAX_CONTENT_CHARS,
+              );
+              result.base_content = packed.text;
+              result.base_content_lines = packed.lines;
+              if (packed.truncated) {
+                result.base_content_truncated = true;
+                result.base_content_note = `Call again with startLine=${packed.next_start_line} to continue.`;
+              }
+            }
           }
         }
 
         if (version === 'new' || version === 'all') {
           if (status === 'removed') {
             result.new_content = null;
-          } else if (prClient && headBranch) {
-            result.new_content =
-              (await prClient.getFileContent(filePath, headBranch)) ??
-              '(file not found at head branch)';
-          } else {
+          } else if (!prClient || !headRef) {
             result.new_content = '(PR client not available)';
+          } else {
+            let content = await prClient.getFileContent(filePath, headRef);
+            if (content == null && headRepo) {
+              // Fork PR — head commit lives in the fork repo
+              content = await prClient.getFileContent(
+                filePath,
+                headRef,
+                headRepo,
+              );
+            }
+            if (content == null) {
+              result.new_content = `(file not found at PR head "${headRef}")`;
+            } else {
+              const packed = packContent(
+                content,
+                startLine,
+                endLine,
+                MAX_CONTENT_CHARS,
+              );
+              result.new_content = packed.text;
+              result.new_content_lines = packed.lines;
+              if (packed.truncated) {
+                result.new_content_truncated = true;
+                result.new_content_note = `Call again with startLine=${packed.next_start_line} to continue.`;
+              }
+            }
           }
         }
 
-        return truncate(JSON.stringify(result), MAX_SOURCE_CHARS);
+        return truncate(JSON.stringify(result), MAX_FILE_CHANGE_CHARS);
       },
       {
         name: 'get_pr_file_change',
@@ -195,6 +368,9 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
           'Get the diff, base (original), or new (changed) content of a specific file in a PR. ' +
           'Use version "diff" for just the patch, "base" for the original file before the PR, ' +
           '"new" for the file after the PR changes are applied, or "all" for everything. ' +
+          'Content is returned with 1-based line numbers (use these exact numbers for review comments). ' +
+          'Large files are paged: when a *_truncated flag appears, call again with startLine set to the ' +
+          'reported next_start_line. ' +
           'This is the primary tool for inspecting PR file changes — use it instead of load_source ' +
           'when reviewing PRs.',
         schema: z.object({
@@ -211,6 +387,19 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
             .describe(
               'Which version to return: "diff" for the patch, "base" for the original, ' +
                 '"new" for the changed version, "all" for everything',
+            ),
+          startLine: z
+            .number()
+            .optional()
+            .describe(
+              'First line (1-based, inclusive) of base/new content to return. ' +
+                'Use to page through files flagged *_truncated.',
+            ),
+          endLine: z
+            .number()
+            .optional()
+            .describe(
+              'Last line (1-based, inclusive) of base/new content to return',
             ),
         }),
       },

--- a/ui/src/chat/prTools.ts
+++ b/ui/src/chat/prTools.ts
@@ -133,21 +133,33 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
             deletions: p.deletions,
           };
         });
-        const omitted = Math.max(0, files.length - MAX_FILE_ENTRIES);
-        return truncate(
-          JSON.stringify({
-            pr: node,
-            files: files.slice(0, MAX_FILE_ENTRIES),
-            file_count: files.length,
-            ...(omitted
-              ? {
-                  files_omitted: omitted,
-                  note: `Showing first ${MAX_FILE_ENTRIES} of ${files.length} files`,
-                }
-              : {}),
-          }),
-          MAX_RESULT_CHARS,
-        );
+        const shown = files.slice(0, MAX_FILE_ENTRIES);
+        const result: {
+          pr: unknown;
+          files: typeof files;
+          file_count: number;
+          files_omitted?: number;
+          note?: string;
+        } = {
+          pr: node,
+          files: shown,
+          file_count: files.length,
+        };
+        const annotateOmitted = () => {
+          result.files_omitted = files.length - result.files.length;
+          result.note = `Showing first ${result.files.length} of ${files.length} files`;
+        };
+        if (shown.length < files.length) annotateOmitted();
+
+        // Never slice the stringified JSON — that hands the model a broken
+        // payload. Drop trailing file entries until the JSON fits instead.
+        let json = JSON.stringify(result);
+        while (json.length > MAX_RESULT_CHARS && result.files.length > 0) {
+          result.files.pop();
+          annotateOmitted();
+          json = JSON.stringify(result);
+        }
+        return json;
       },
       {
         name: 'get_pull_request',
@@ -166,33 +178,48 @@ export function makePRTools(store: GraphStore, prClient?: PRClient | null) {
       async ({ prId }) => {
         // Traverse: PR --CHANGES--> File --incoming(CALLS, IMPORTS, etc.)--> callers
         const modifies = await store.traverse(prId, 'outgoing', 1, 'CHANGES');
-        const blastRadius: Record<string, unknown> = {};
-        // Compact per-file summary (count + sample) so large PRs don't
-        // overflow into mid-JSON truncation.
+        // Compact per-file summary (count + sample), keyed by file path —
+        // graph node IDs mean little to the model.
+        const entries: [string, unknown][] = [];
         const scanned = modifies.slice(0, 100);
         for (const rel of scanned) {
           const fileId = rel.relationship.target_id;
           if (!fileId) continue;
+          const props = rel.relationship.properties as
+            | Record<string, unknown>
+            | undefined;
+          const path = (props?.path as string) || fileId;
           const incoming = await store.traverse(fileId, 'incoming', 2);
-          blastRadius[fileId] = {
-            dependents: incoming.length,
-            sample: incoming
-              .slice(0, 10)
-              .map((d) => `${d.node.type}:${d.node.name || d.node.id}`),
-          };
+          entries.push([
+            path,
+            {
+              dependents: incoming.length,
+              sample: incoming
+                .slice(0, 10)
+                .map((d) => `${d.node.type}:${d.node.name || d.node.id}`),
+            },
+          ]);
         }
-        return truncate(
+
+        // Never slice the stringified JSON — drop trailing entries until
+        // the payload fits so the model always gets valid JSON.
+        const build = (count: number) =>
           JSON.stringify({
             modified_files: modifies.length,
-            ...(modifies.length > scanned.length
+            ...(count < modifies.length
               ? {
-                  note: `Blast radius computed for first ${scanned.length} of ${modifies.length} files`,
+                  note: `Blast radius computed for first ${count} of ${modifies.length} files`,
                 }
               : {}),
-            blast_radius: blastRadius,
-          }),
-          MAX_RESULT_CHARS,
-        );
+            blast_radius: Object.fromEntries(entries.slice(0, count)),
+          });
+        let count = entries.length;
+        let json = build(count);
+        while (json.length > MAX_RESULT_CHARS && count > 0) {
+          count--;
+          json = build(count);
+        }
+        return json;
       },
       {
         name: 'summarize_pr_changes',

--- a/ui/src/chat/providers.ts
+++ b/ui/src/chat/providers.ts
@@ -37,38 +37,34 @@ export interface ProviderInfo {
 const anthropic: ProviderInfo = {
   name: 'Anthropic Claude',
   id: 'anthropic',
-  defaultModel: 'claude-sonnet-4-6',
+  defaultModel: 'claude-opus-4-8',
   models: [
-    { id: 'claude-opus-4-6', name: 'Claude Opus 4.6' },
-    { id: 'claude-opus-4-5-20250529', name: 'Claude Opus 4.5' },
-    { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' },
-    { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5' },
-    { id: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' },
+    { id: 'claude-opus-4-8', name: 'Claude Opus 4.8' },
+    { id: 'claude-sonnet-5', name: 'Claude Sonnet 5' },
+    { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5' },
   ],
 };
 
 const openai: ProviderInfo = {
   name: 'OpenAI',
   id: 'openai',
-  defaultModel: 'gpt-4.1-mini',
+  defaultModel: 'gpt-5.4-mini',
   models: [
-    { id: 'o3', name: 'o3' },
-    { id: 'o4-mini', name: 'o4-mini' },
-    { id: 'gpt-4.1', name: 'GPT-4.1' },
-    { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini' },
-    { id: 'gpt-4o', name: 'GPT-4o' },
-    { id: 'gpt-4o-mini', name: 'GPT-4o Mini' },
+    { id: 'gpt-5.5', name: 'GPT-5.5' },
+    { id: 'gpt-5.4', name: 'GPT-5.4' },
+    { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini' },
   ],
 };
 
 const gemini: ProviderInfo = {
   name: 'Google Gemini',
   id: 'gemini',
-  defaultModel: 'gemini-2.5-flash',
+  defaultModel: 'gemini-3.5-flash',
   models: [
+    { id: 'gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
+    { id: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro (Preview)' },
+    { id: 'gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash-Lite' },
     { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro' },
-    { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash' },
-    { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash' },
   ],
 };
 

--- a/ui/src/chat/subagents.ts
+++ b/ui/src/chat/subagents.ts
@@ -282,10 +282,11 @@ After your prose review, you MUST end your response with a fenced code block tag
 \`\`\`
 
 Rules for the structured block:
-- "verdict": Use APPROVE if the code is good, REQUEST_CHANGES if there are must-fix issues, COMMENT for informational review
-- "comments": Include one entry per actionable finding. Use the exact file path and line number from the source code. Omit path/line if the comment is general.
+- "verdict": Use APPROVE only if the code is good AND you inspected every changed file; REQUEST_CHANGES if there are must-fix issues; COMMENT for informational review
+- "comments": Include one entry per actionable finding. "line" must be a line number in the NEW version of the file (right side of the diff), taken from content you actually read — never estimate it. Omit path/line if the comment is general.
 - "summary": A concise paragraph suitable as the PR review body on GitHub
-- Always include this block, even if there are no issues (empty comments array, APPROVE verdict)`;
+- Always include this block, even if there are no issues (empty comments array, APPROVE verdict)
+- Graph data and load_source reflect the indexed snapshot, which may predate the PR — when they disagree with PR file tools, trust the PR file tools. Only make claims about code you actually read.`;
 
 // ---- Helpers ----
 

--- a/ui/src/components/chat/results/ReviewResult.tsx
+++ b/ui/src/components/chat/results/ReviewResult.tsx
@@ -16,61 +16,19 @@
 
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
-import type { PRReviewComment } from '../types';
 import { markdownComponents } from '../markdownComponents';
 import './ReviewResult.css';
 
-export interface ReviewData {
-  summary: string;
-  verdict: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
-  comments: PRReviewComment[];
-}
-
-// eslint-disable-next-line react-refresh/only-export-components
-export function parseReviewResult(text: string): ReviewData | null {
-  // Try ```json:review first, then any ```json block containing review fields
-  const patterns = [
-    /```json:review\s*\n([\s\S]*?)```/g,
-    /```json\s*\n([\s\S]*?)```/g,
-  ];
-
-  for (const pattern of patterns) {
-    const matches = text.matchAll(pattern);
-    for (const match of matches) {
-      try {
-        const data = JSON.parse(match[1]);
-        // Must have summary + verdict to be a review block (not some other JSON)
-        if (data.summary && data.verdict) {
-          return {
-            summary: data.summary,
-            verdict: data.verdict,
-            comments: Array.isArray(data.comments) ? data.comments : [],
-          };
-        }
-      } catch {
-        continue;
-      }
-    }
-  }
-  return null;
-}
-
-// eslint-disable-next-line react-refresh/only-export-components
-export function stripReviewBlock(text: string): string {
-  // Remove ```json:review blocks first, then any ```json block that contains review fields
-  let result = text.replace(/```json:review\s*\n[\s\S]*?```/, '');
-  // Only strip plain ```json blocks if they contain review structure
-  result = result.replace(/```json\s*\n([\s\S]*?)```/g, (full, inner) => {
-    try {
-      const data = JSON.parse(inner);
-      if (data.summary && data.verdict) return '';
-    } catch {
-      /* not valid JSON, keep it */
-    }
-    return full;
-  });
-  return result.trim();
-}
+// Parsing logic lives in a React-free module so the review runner can
+// share it; re-export to keep existing import paths working.
+/* eslint-disable react-refresh/only-export-components */
+export {
+  parseReviewResult,
+  stripReviewBlock,
+  type ReviewData,
+} from '../../../pr/reviewParse';
+/* eslint-enable react-refresh/only-export-components */
+import type { ReviewData } from '../../../pr/reviewParse';
 
 const VERDICT_LABELS: Record<string, string> = {
   APPROVE: 'Approve',

--- a/ui/src/pr/__tests__/githubPR.test.ts
+++ b/ui/src/pr/__tests__/githubPR.test.ts
@@ -129,6 +129,90 @@ describe('fetchGitHubPRDetail', () => {
     expect(detail.files[0].status).toBe('added');
     expect(detail.body).toBe('desc');
   });
+
+  it('captures base/head SHAs and fork head repo', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          number: 1,
+          title: 'PR',
+          state: 'open',
+          user: { login: 'a' },
+          html_url: '',
+          created_at: '',
+          updated_at: '',
+          base: { ref: 'main', sha: 'base123', repo: { full_name: 'o/r' } },
+          head: { ref: 'feat', sha: 'head456', repo: { full_name: 'fork/r' } },
+          body: '',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse([]));
+
+    const detail = await fetchGitHubPRDetail('o', 'r', 1, 'tok');
+    expect(detail.base_sha).toBe('base123');
+    expect(detail.head_sha).toBe('head456');
+    expect(detail.head_repo).toBe('fork/r');
+  });
+
+  it('omits head_repo for same-repo PRs', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          number: 1,
+          title: 'PR',
+          state: 'open',
+          user: { login: 'a' },
+          html_url: '',
+          created_at: '',
+          updated_at: '',
+          base: { ref: 'main', sha: 'b', repo: { full_name: 'o/r' } },
+          head: { ref: 'feat', sha: 'h', repo: { full_name: 'o/r' } },
+          body: '',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse([]));
+
+    const detail = await fetchGitHubPRDetail('o', 'r', 1, 'tok');
+    expect(detail.head_repo).toBeUndefined();
+  });
+
+  it('paginates the files listing past 100 entries', async () => {
+    const fileEntry = (i: number) => ({
+      filename: `src/f${i}.ts`,
+      status: 'modified',
+      additions: 1,
+      deletions: 1,
+      patch: '@@',
+    });
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          number: 1,
+          title: 'PR',
+          state: 'open',
+          user: { login: 'a' },
+          html_url: '',
+          created_at: '',
+          updated_at: '',
+          base: { ref: 'main' },
+          head: { ref: 'feat' },
+          body: '',
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(Array.from({ length: 100 }, (_, i) => fileEntry(i))),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(Array.from({ length: 50 }, (_, i) => fileEntry(100 + i))),
+      );
+
+    const detail = await fetchGitHubPRDetail('o', 'r', 1, 'tok');
+    expect(detail.files).toHaveLength(150);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('page=2'),
+      expect.anything(),
+    );
+  });
 });
 
 describe('createGitHubReview', () => {
@@ -139,6 +223,95 @@ describe('createGitHubReview', () => {
       expect.stringContaining('/reviews'),
       expect.objectContaining({ method: 'POST' }),
     );
+  });
+
+  // "@@ -1,3 +5,4 @@" — right side covers lines 5-8
+  const patch = '@@ -1,3 +5,4 @@\n line5\n+line6\n+line7\n line8';
+  const fileDiffs = [
+    {
+      path: 'src/a.ts',
+      status: 'modified' as const,
+      additions: 2,
+      deletions: 0,
+      patch,
+    },
+  ];
+
+  function sentPayload() {
+    const [, init] = mockFetch.mock.calls[0];
+    return JSON.parse(init.body);
+  }
+
+  it('keeps comments on exact diff lines', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1 }));
+    await createGitHubReview(
+      'o',
+      'r',
+      1,
+      'tok',
+      'body',
+      'COMMENT',
+      [{ body: 'exact', path: 'src/a.ts', line: 6 }],
+      fileDiffs,
+    );
+    expect(sentPayload().comments).toEqual([
+      { body: 'exact', path: 'src/a.ts', line: 6, side: 'RIGHT' },
+    ]);
+  });
+
+  it('snaps comments within 3 lines of the diff', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1 }));
+    await createGitHubReview(
+      'o',
+      'r',
+      1,
+      'tok',
+      'body',
+      'COMMENT',
+      [
+        { body: 'near', path: 'src/a.ts', line: 10 }, // 2 away from line 8
+      ],
+      fileDiffs,
+    );
+    const payload = sentPayload();
+    expect(payload.comments).toHaveLength(1);
+    expect(payload.comments[0].line).toBe(8);
+    expect(payload.comments[0].body).toContain('(re: line 10)');
+  });
+
+  it('folds far-away comments into the review body instead of relocating', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1 }));
+    await createGitHubReview(
+      'o',
+      'r',
+      1,
+      'tok',
+      'body',
+      'COMMENT',
+      [{ body: 'way off', path: 'src/a.ts', line: 200 }],
+      fileDiffs,
+    );
+    const payload = sentPayload();
+    expect(payload.comments).toBeUndefined();
+    expect(payload.body).toContain('Additional comments');
+    expect(payload.body).toContain('`src/a.ts:200` — way off');
+  });
+
+  it('folds comments on files without patch data into the body', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1 }));
+    await createGitHubReview(
+      'o',
+      'r',
+      1,
+      'tok',
+      'body',
+      'COMMENT',
+      [{ body: 'binary file note', path: 'assets/logo.png', line: 1 }],
+      fileDiffs,
+    );
+    const payload = sentPayload();
+    expect(payload.comments).toBeUndefined();
+    expect(payload.body).toContain('binary file note');
   });
 });
 

--- a/ui/src/pr/__tests__/indexer.test.ts
+++ b/ui/src/pr/__tests__/indexer.test.ts
@@ -76,6 +76,51 @@ describe('indexPRIntoGraph', () => {
     expect(prNode.name).toBe('#42: Test PR');
   });
 
+  it('stores base/head SHAs and fork repo when present', async () => {
+    const store = createMockStore({
+      importBatch: vi.fn().mockResolvedValue({
+        nodes_created: 0,
+        relationships_created: 0,
+      }),
+    });
+    await indexPRIntoGraph(
+      store,
+      makePR({
+        base_sha: 'abc123',
+        head_sha: 'def456',
+        head_repo: 'fork/repo',
+      }),
+      meta,
+    );
+
+    const batch = (store.importBatch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    const prNode = batch.nodes.find(
+      (n: { type: string }) => n.type === 'PullRequest',
+    );
+    expect(prNode.properties.baseSha).toBe('abc123');
+    expect(prNode.properties.headSha).toBe('def456');
+    expect(prNode.properties.headRepo).toBe('fork/repo');
+  });
+
+  it('omits SHA properties when the client did not provide them', async () => {
+    const store = createMockStore({
+      importBatch: vi.fn().mockResolvedValue({
+        nodes_created: 0,
+        relationships_created: 0,
+      }),
+    });
+    await indexPRIntoGraph(store, makePR(), meta);
+
+    const batch = (store.importBatch as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    const prNode = batch.nodes.find(
+      (n: { type: string }) => n.type === 'PullRequest',
+    );
+    expect('baseSha' in prNode.properties).toBe(false);
+    expect('headRepo' in prNode.properties).toBe(false);
+  });
+
   it('creates TARGETS_REPO edge to Repo node', async () => {
     const store = createMockStore({
       importBatch: vi.fn().mockResolvedValue({
@@ -134,8 +179,8 @@ describe('indexPRIntoGraph', () => {
     });
   });
 
-  it('truncates patch at MAX_PATCH_CHARS (5000)', async () => {
-    const longPatch = 'x'.repeat(6000);
+  it('truncates patch at MAX_PATCH_CHARS (50000)', async () => {
+    const longPatch = 'x'.repeat(60_000);
     const pr = makePR({
       files: [
         {

--- a/ui/src/pr/__tests__/reviewParse.test.ts
+++ b/ui/src/pr/__tests__/reviewParse.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseReviewResult,
+  stripReviewBlock,
+  enforceInspectionCoverage,
+} from '../reviewParse';
+
+function reviewText(verdict: string, summary = 'Looks good.'): string {
+  return (
+    'Prose review here.\n\n```json:review\n' +
+    JSON.stringify({ summary, verdict, comments: [] }, null, 2) +
+    '\n```'
+  );
+}
+
+describe('parseReviewResult', () => {
+  it('parses a json:review block', () => {
+    const data = parseReviewResult(reviewText('APPROVE'));
+    expect(data).not.toBeNull();
+    expect(data!.verdict).toBe('APPROVE');
+    expect(data!.summary).toBe('Looks good.');
+  });
+
+  it('returns null when no review block exists', () => {
+    expect(parseReviewResult('just prose')).toBeNull();
+  });
+});
+
+describe('stripReviewBlock', () => {
+  it('removes the review block but keeps prose', () => {
+    const stripped = stripReviewBlock(reviewText('COMMENT'));
+    expect(stripped).toBe('Prose review here.');
+  });
+});
+
+describe('enforceInspectionCoverage', () => {
+  it('downgrades APPROVE when files were not inspected', () => {
+    const result = enforceInspectionCoverage(reviewText('APPROVE'), [
+      'src/a.ts',
+      'src/b.ts',
+    ]);
+    const data = parseReviewResult(result)!;
+    expect(data.verdict).toBe('COMMENT');
+    expect(data.summary).toContain('downgraded from APPROVE');
+    expect(data.summary).toContain('src/a.ts');
+  });
+
+  it('leaves APPROVE untouched when everything was inspected', () => {
+    const text = reviewText('APPROVE');
+    expect(enforceInspectionCoverage(text, [])).toBe(text);
+  });
+
+  it('leaves non-APPROVE verdicts untouched', () => {
+    const text = reviewText('REQUEST_CHANGES');
+    expect(enforceInspectionCoverage(text, ['src/a.ts'])).toBe(text);
+  });
+
+  it('handles plain json fencing', () => {
+    const text =
+      '```json\n' +
+      JSON.stringify({ summary: 'ok', verdict: 'APPROVE', comments: [] }) +
+      '\n```';
+    const result = enforceInspectionCoverage(text, ['x.ts']);
+    expect(parseReviewResult(result)!.verdict).toBe('COMMENT');
+  });
+
+  it('caps the listed files at 10 with a +N more suffix', () => {
+    const files = Array.from({ length: 14 }, (_, i) => `src/f${i}.ts`);
+    const result = enforceInspectionCoverage(reviewText('APPROVE'), files);
+    const data = parseReviewResult(result)!;
+    expect(data.summary).toContain('(+4 more)');
+  });
+});

--- a/ui/src/pr/client.ts
+++ b/ui/src/pr/client.ts
@@ -169,8 +169,15 @@ export class PRClient {
     }
   }
 
-  /** Fetch a file's content at a given git ref (branch, tag, or SHA). */
-  async getFileContent(path: string, ref: string): Promise<string | null> {
+  /** Fetch a file's content at a given git ref (branch, tag, or SHA).
+   *  `repoOverride` ("owner/repo") targets a different repository — used
+   *  for fork PRs whose head commits live outside the base repo. Only
+   *  honored for GitHub. */
+  async getFileContent(
+    path: string,
+    ref: string,
+    repoOverride?: string,
+  ): Promise<string | null> {
     switch (this.meta.provider) {
       case 'gitlab':
         return fetchGitLabFileContent(
@@ -196,14 +203,14 @@ export class PRClient {
           ref,
           this.token,
         );
-      default:
-        return fetchGitHubFileContent(
-          this.meta.owner,
-          this.meta.repo,
-          path,
-          ref,
-          this.token,
-        );
+      default: {
+        let owner = this.meta.owner;
+        let repo = this.meta.repo;
+        if (repoOverride?.includes('/')) {
+          [owner, repo] = repoOverride.split('/', 2) as [string, string];
+        }
+        return fetchGitHubFileContent(owner, repo, path, ref, this.token);
+      }
     }
   }
 

--- a/ui/src/pr/githubPR.ts
+++ b/ui/src/pr/githubPR.ts
@@ -48,9 +48,13 @@ function parsePatchLines(patch: string): Set<number> {
   return validLines;
 }
 
+/** A comment relocated further than this many lines would land on code the
+ *  reviewer wasn't talking about — fold it into the review body instead. */
+const MAX_SNAP_DISTANCE = 3;
+
 /**
- * Find the closest valid line in the diff to a given target line.
- * Returns undefined if no valid lines exist.
+ * Find the closest valid line in the diff to a given target line, within
+ * MAX_SNAP_DISTANCE. Returns undefined if none is close enough.
  */
 function snapToValidLine(
   target: number,
@@ -67,16 +71,7 @@ function snapToValidLine(
       closest = line;
     }
   }
-  return closest;
-}
-
-/** Return the first (lowest) line number in the set, or undefined. */
-function firstValidLine(validLines: Set<number>): number | undefined {
-  let min: number | undefined;
-  for (const line of validLines) {
-    if (min === undefined || line < min) min = line;
-  }
-  return min;
+  return minDist <= MAX_SNAP_DISTANCE ? closest : undefined;
 }
 
 function headers(token?: string): Record<string, string> {
@@ -118,6 +113,8 @@ function mapFileStatus(status: string): PRFileDiff['status'] {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function toPRSummary(pr: any): PRSummary {
+  const baseRepo = pr.base?.repo?.full_name;
+  const headRepo = pr.head?.repo?.full_name;
   return {
     number: pr.number,
     title: pr.title,
@@ -128,6 +125,9 @@ function toPRSummary(pr: any): PRSummary {
     updated_at: pr.updated_at,
     base_branch: pr.base?.ref ?? '',
     head_branch: pr.head?.ref ?? '',
+    base_sha: pr.base?.sha,
+    head_sha: pr.head?.sha,
+    head_repo: headRepo && headRepo !== baseRepo ? headRepo : undefined,
     draft: pr.draft,
   };
 }
@@ -152,15 +152,25 @@ export async function fetchGitHubPRDetail(
   number: number,
   token?: string,
 ): Promise<PRDetail> {
-  const [pr, files] = await Promise.all([
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pr = await ghFetch<any>(
+    `/repos/${owner}/${repo}/pulls/${number}`,
+    token,
+  );
+
+  // GitHub lists at most 3000 files per PR, 100 per page — paginate so
+  // large PRs don't silently lose files past the first page.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const files: any[] = [];
+  for (let page = 1; page <= 30; page++) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ghFetch<any>(`/repos/${owner}/${repo}/pulls/${number}`, token),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ghFetch<any[]>(
-      `/repos/${owner}/${repo}/pulls/${number}/files?per_page=100`,
+    const batch = await ghFetch<any[]>(
+      `/repos/${owner}/${repo}/pulls/${number}/files?per_page=100&page=${page}`,
       token,
-    ),
-  ]);
+    );
+    files.push(...batch);
+    if (batch.length < 100) break;
+  }
 
   return {
     ...toPRSummary(pr),
@@ -206,16 +216,21 @@ export async function createGitHubReview(
     }
 
     // GitHub's reviews endpoint requires a valid `line` on every comment.
-    // Resolve each comment to a line visible in the diff; drop comments
-    // whose file has no patch data (binary files, etc.).
+    // Resolve each comment to a line visible in the diff; comments that
+    // can't be anchored nearby (or whose file has no patch data) are
+    // folded into the review body rather than relocated or dropped.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const resolved: any[] = [];
+    const unanchored: PRReviewComment[] = [];
 
     for (const c of comments) {
       const validLines = c.path ? patchLinesByPath.get(c.path) : undefined;
-      if (!validLines?.size) continue; // no patch for this file — skip
+      if (!validLines?.size || !c.line) {
+        unanchored.push(c);
+        continue;
+      }
 
-      if (c.line && validLines.has(c.line)) {
+      if (validLines.has(c.line)) {
         // Exact match — use it directly
         resolved.push({
           body: c.body,
@@ -223,8 +238,8 @@ export async function createGitHubReview(
           line: c.line,
           side: c.side ?? 'RIGHT',
         });
-      } else if (c.line) {
-        // Snap to closest visible diff line
+      } else {
+        // Snap to a nearby visible diff line, if one is close enough
         const snapped = snapToValidLine(c.line, validLines);
         if (snapped !== undefined) {
           resolved.push({
@@ -233,23 +248,25 @@ export async function createGitHubReview(
             line: snapped,
             side: c.side ?? 'RIGHT',
           });
-        }
-      } else {
-        // No line provided — pin to first line of the file's diff
-        const first = firstValidLine(validLines);
-        if (first !== undefined) {
-          resolved.push({
-            body: c.body,
-            path: c.path,
-            line: first,
-            side: 'RIGHT',
-          });
+        } else {
+          unanchored.push(c);
         }
       }
     }
 
     if (resolved.length) {
       payload.comments = resolved;
+    }
+    if (unanchored.length) {
+      const lines = unanchored.map((c) => {
+        const loc = c.path
+          ? `\`${c.path}${c.line ? `:${c.line}` : ''}\` — `
+          : '';
+        return `- ${loc}${c.body}`;
+      });
+      payload.body =
+        `${body}\n\n**Additional comments** (outside the visible diff):\n` +
+        lines.join('\n');
     }
   }
   await ghFetch(`/repos/${owner}/${repo}/pulls/${number}/reviews`, token, {

--- a/ui/src/pr/indexer.ts
+++ b/ui/src/pr/indexer.ts
@@ -31,8 +31,10 @@ import type {
 import type { PRDetail, PRFileDiff } from './types';
 import type { RepoMeta } from './types';
 
-/** Max characters of unified diff to store per file edge. */
-const MAX_PATCH_CHARS = 5000;
+/** Max characters of unified diff to store per file edge. Generous — a
+ *  truncated patch means the review agent literally cannot see part of
+ *  the change, so only guard against pathological blobs. */
+const MAX_PATCH_CHARS = 50_000;
 
 function truncatePatch(patch: string | undefined): string | undefined {
   if (!patch) return undefined;
@@ -82,6 +84,9 @@ export async function indexPRIntoGraph(
           createdAt: pr.created_at,
           baseBranch: pr.base_branch,
           headBranch: pr.head_branch,
+          ...(pr.base_sha ? { baseSha: pr.base_sha } : {}),
+          ...(pr.head_sha ? { headSha: pr.head_sha } : {}),
+          ...(pr.head_repo ? { headRepo: pr.head_repo } : {}),
           additions: pr.additions,
           deletions: pr.deletions,
           filesChanged: pr.files.length,

--- a/ui/src/pr/reviewParse.ts
+++ b/ui/src/pr/reviewParse.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure helpers for the structured `json:review` block emitted by the code
+ * review agent. Kept free of React so both UI components and the review
+ * runner can share them.
+ */
+
+import type { PRReviewComment } from './types';
+
+export interface ReviewData {
+  summary: string;
+  verdict: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+  comments: PRReviewComment[];
+}
+
+export function parseReviewResult(text: string): ReviewData | null {
+  // Try ```json:review first, then any ```json block containing review fields
+  const patterns = [
+    /```json:review\s*\n([\s\S]*?)```/g,
+    /```json\s*\n([\s\S]*?)```/g,
+  ];
+
+  for (const pattern of patterns) {
+    const matches = text.matchAll(pattern);
+    for (const match of matches) {
+      try {
+        const data = JSON.parse(match[1]);
+        // Must have summary + verdict to be a review block (not some other JSON)
+        if (data.summary && data.verdict) {
+          return {
+            summary: data.summary,
+            verdict: data.verdict,
+            comments: Array.isArray(data.comments) ? data.comments : [],
+          };
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+export function stripReviewBlock(text: string): string {
+  // Remove ```json:review blocks first, then any ```json block that contains review fields
+  let result = text.replace(/```json:review\s*\n[\s\S]*?```/, '');
+  // Only strip plain ```json blocks if they contain review structure
+  result = result.replace(/```json\s*\n([\s\S]*?)```/g, (full, inner) => {
+    try {
+      const data = JSON.parse(inner);
+      if (data.summary && data.verdict) return '';
+    } catch {
+      /* not valid JSON, keep it */
+    }
+    return full;
+  });
+  return result.trim();
+}
+
+/**
+ * Downgrade an APPROVE verdict when the agent never inspected some of the
+ * PR's changed files — an approval of code it hasn't seen is meaningless.
+ * Rewrites the `json:review` block in place (verdict → COMMENT, note
+ * appended to the summary); returns the text unchanged for any other
+ * verdict or when nothing was skipped.
+ */
+export function enforceInspectionCoverage(
+  text: string,
+  uninspectedFiles: string[],
+): string {
+  if (!uninspectedFiles.length) return text;
+  const review = parseReviewResult(text);
+  if (!review || review.verdict !== 'APPROVE') return text;
+
+  const shown = uninspectedFiles.slice(0, 10);
+  const more = uninspectedFiles.length - shown.length;
+  const note =
+    ` Note: verdict downgraded from APPROVE — ${uninspectedFiles.length} changed ` +
+    `file(s) were not inspected during this review: ${shown.join(', ')}` +
+    (more > 0 ? ` (+${more} more)` : '') +
+    '.';
+
+  const patched: ReviewData = {
+    ...review,
+    verdict: 'COMMENT',
+    summary: review.summary + note,
+  };
+  const block = '```json:review\n' + JSON.stringify(patched, null, 2) + '\n```';
+
+  // Replace the existing review block (either fencing style) with the
+  // patched one; if the block can't be located, append instead.
+  if (/```json:review\s*\n[\s\S]*?```/.test(text)) {
+    return text.replace(/```json:review\s*\n[\s\S]*?```/, block);
+  }
+  let replaced = false;
+  const result = text.replace(/```json\s*\n([\s\S]*?)```/g, (full, inner) => {
+    if (replaced) return full;
+    try {
+      const data = JSON.parse(inner);
+      if (data.summary && data.verdict) {
+        replaced = true;
+        return block;
+      }
+    } catch {
+      /* not valid JSON, keep it */
+    }
+    return full;
+  });
+  return replaced ? result : text + '\n\n' + block;
+}

--- a/ui/src/pr/reviewRunner.ts
+++ b/ui/src/pr/reviewRunner.ts
@@ -28,6 +28,7 @@ import { makePRTools } from '../chat/prTools';
 import type { GraphStore } from '../store/types';
 import type { PRClient } from './client';
 import type { PRDetail } from './types';
+import { enforceInspectionCoverage } from './reviewParse';
 
 const STEP_LABELS: Record<string, string> = {
   search_graph: 'Searching graph',
@@ -46,12 +47,12 @@ const CODE_REVIEWER_PROMPT = `You are a code review agent. Your job is to review
 ## Workflow
 
 1. **Identify scope**: Use get_pull_request to find the PR and its changed files.
-2. **Inspect changes**: Use get_pr_file_change on each changed file to get the diff, original (base), and/or new file content. Use version "all" for thorough review, or "diff" for a quick scan.
+2. **Inspect changes**: Use get_pr_file_change on EVERY changed file. Start with version "diff" to see what changed, then version "new" (with startLine/endLine around the changed regions) to read the changed code in full context. If a result carries a *_truncated flag, call again with the reported next_start_line — never review from a partial payload.
 3. **Understand context**: Use traverse_graph (incoming + outgoing) to understand how changed code fits into the broader architecture — what calls it, what it depends on.
 4. **Inspect related code**: Use get_node and load_source on related (unchanged) components to check for consistency and convention adherence.
 5. **Synthesize review**: Produce a structured code review.
 
-IMPORTANT: When reviewing PR file changes, always use get_pr_file_change — it gives you the diff, the original file, and the new file with changes applied. Only use load_source for unchanged files that you need for context.
+IMPORTANT: When reviewing PR file changes, always use get_pr_file_change — it gives you the diff, the original file, and the new file with changes applied. Only use load_source for unchanged files that you need for context. Graph data and load_source reflect the indexed snapshot, which may predate this PR — when they disagree with get_pr_file_change output, trust get_pr_file_change. Only make claims about code you have actually read in this session.
 
 ## Review Categories
 
@@ -105,8 +106,8 @@ After your prose review, you MUST end your response with a fenced code block tag
 \`\`\`
 
 Rules for the structured block:
-- "verdict": Use APPROVE if the code is good, REQUEST_CHANGES if there are must-fix issues, COMMENT for informational review
-- "comments": Include one entry per actionable finding. Use the exact file path and line number from the source code. Omit path/line if the comment is general.
+- "verdict": Use APPROVE only if the code is good AND you inspected every changed file; REQUEST_CHANGES if there are must-fix issues; COMMENT for informational review
+- "comments": Include one entry per actionable finding. "line" must be a line number in the NEW version of the file (right side of the diff) — take it from the line-numbered new_content or the diff hunks, never estimate it. Omit path/line if the comment is general.
 - "summary": A concise paragraph suitable as the PR review body on GitHub
 - Always include this block, even if there are no issues (empty comments array, APPROVE verdict)`;
 
@@ -160,6 +161,7 @@ export async function runPRReview(
     `Analyze all changed files for bugs, security issues, performance problems, and code quality.`;
 
   const allMessages: BaseMessage[] = [];
+  const inspectedFiles = new Set<string>();
 
   const stream = await agent.stream(
     { messages: [new HumanMessage(query)] },
@@ -177,11 +179,23 @@ export async function runPRReview(
         allMessages.push(msg);
 
         if (nodeName === 'agent') {
-          const toolCalls = (msg as { tool_calls?: Array<{ name: string }> })
-            .tool_calls;
+          const toolCalls = (
+            msg as {
+              tool_calls?: Array<{
+                name: string;
+                args?: Record<string, unknown>;
+              }>;
+            }
+          ).tool_calls;
           if (toolCalls?.length) {
             for (const tc of toolCalls) {
               callbacks.onProgress(STEP_LABELS[tc.name] ?? tc.name);
+              if (
+                tc.name === 'get_pr_file_change' &&
+                typeof tc.args?.filePath === 'string'
+              ) {
+                inspectedFiles.add(tc.args.filePath);
+              }
             }
           }
         }
@@ -189,9 +203,16 @@ export async function runPRReview(
     }
   }
 
-  return extractFinalResponse(
+  const response = extractFinalResponse(
     allMessages as Array<{
       content: string | Array<{ type: string; text?: string }>;
     }>,
   );
+
+  // An APPROVE is only credible if the agent actually looked at every
+  // changed file — downgrade to COMMENT when it skipped some.
+  const uninspected = pr.files
+    .map((f) => f.path)
+    .filter((p) => !inspectedFiles.has(p));
+  return enforceInspectionCoverage(response, uninspected);
 }

--- a/ui/src/pr/types.ts
+++ b/ui/src/pr/types.ts
@@ -26,6 +26,13 @@ export interface PRSummary {
   updated_at: string;
   base_branch: string;
   head_branch: string;
+  /** Immutable commit SHAs; prefer these over branch names when fetching
+   *  file content — branches move and fork branches don't exist in the
+   *  base repo. */
+  base_sha?: string;
+  head_sha?: string;
+  /** Head repo full name (owner/repo) when the PR comes from a fork. */
+  head_repo?: string;
   draft?: boolean;
 }
 


### PR DESCRIPTION
## Improve PR review accuracy with SHA-pinning and content paging
🐛 **Bug Fix** · ✨ **Improvement** · ♻️ **Refactor** · 🧪 **Tests**

Fixes architectural data gaps and truncation issues that caused the PR review agent to hallucinate or miss changes. It introduces immutable SHA-pinned fetches, line-numbered content paging for large files, and a safety guardrail that prevents unvalidated approvals.

- Fixes a property mismatch that prevented the agent from receiving file content.
- Pins fetches to SHAs and adds support for fork PRs.
- Implements line-numbered paging and per-field truncation for large files.
- Adds a verdict guardrail to downgrade approvals of uninspected files.
- Refreshes LLM provider model lists and UI fallback logic.

### Complexity
🟠 High · `15 files changed, 1013 insertions(+), 176 deletions(-)`

This PR spans the entire PR review lifecycle: from how data is indexed in the graph, to how tools fetch and paginate content, up to the agent's prompt and the final validation of the review verdict. It introduces new foundational patterns like SHA-pinning and line-based content paging that are critical for LLM accuracy and requires careful coordination between the backend graph, the GitHub client, and the agent runner.

### Tests
🧪 Includes extensive new tests for content paging, SHA resolution, fork retries, and the verdict enforcement guardrail.

### Review focus
Pay particular attention to the following areas:

- **Line-numbering logic** — Verify `packContent` in `prTools.ts` correctly generates 1-based line numbers that align with GitHub's expectations for review comments.
- **Verdict downgrade logic** — Ensure `enforceInspectionCoverage` in `reviewParse.ts` robustly handles different JSON fencing styles (`json:review` vs `json`).
- **Fork PR threading** — Check that `headRepo` is correctly captured by the indexer and utilized by `PRClient` to target the correct repository for fork head commits.

---

<details>
<summary><strong>Additional details</strong></summary>

### Data Flow & Persistence
Previously, the indexer wrote `baseSha`/`headSha` to the graph, but the review tools looked for `base_sha`/`head_sha`, leading to a silent fallback to branch names (which shift) or "PR client not available" errors. This PR standardizes on `camelCase` for graph properties while providing a `strProp` helper in the tools to handle legacy or mismatched keys gracefully.

### Truncation Strategy
We moved away from a global `truncate()` on the final JSON string, which often produced unparseable blobs. The new `get_pr_file_change` tool implements per-field budgets:
1. **Diffs** are truncated with a note to use the "new" version for full context.
2. **File Content** is paged using a 1-based line range.
3. Each field carries a `*_truncated` flag, allowing the agent to detect partial data and request the next page using `startLine`.

### Review Integrity
The `enforceInspectionCoverage` helper acts as a late-stage guardrail. During the agent's execution loop, we track every file passed to `get_pr_file_change`. If the agent emits an `APPROVE` verdict but the tracking set doesn't cover all files in `pr.files`, the verdict is programmatically downgraded to `COMMENT` to prevent the agent from "approving" code it never saw.

</details>
<!-- opentrace:jid=e3c7f5d4-a729-4007-ae7d-ab15e2f1c651|sha=2ec945e1bd02094a9c7a8b556f7f2b6863ec0508 -->