### PR TITLE
fix(ui): rework highlighted-edge rendering and tidy graph controls

### DIFF
--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -606,6 +606,10 @@ const GraphViewer = memo(
       const [showExportModal, setShowExportModal] = useState(false);
       const [exporting, setExporting] = useState(false);
       const [showPhysicsPanel, setShowPhysicsPanel] = useState(false);
+      // The live indexing panel can be minimized to a compact chip; the job
+      // keeps running behind it. Reset whenever a job goes inactive so a new
+      // run always starts with the full panel visible (see effect below).
+      const [liveMinimized, setLiveMinimized] = useState(false);
       const physicsTriggerRef = useRef<HTMLButtonElement>(null);
 
       // Close the physics panel on a pointerdown outside the panel and
@@ -722,8 +726,16 @@ const GraphViewer = memo(
       const showFullModal = jobExpanded || jobState.status === 'error';
 
       // The compact live panel owns the running / building / enriching states
-      // whenever the user hasn't expanded to the full modal.
-      const showLivePanel = jobActive && !jobExpanded;
+      // whenever the user hasn't expanded to the full modal. Minimizing swaps
+      // the panel for a tiny restore chip without touching the job.
+      const showLivePanel = jobActive && !jobExpanded && !liveMinimized;
+      const showLiveChip = jobActive && !jobExpanded && liveMinimized;
+
+      // A finished/cancelled job should never leave the panel stuck minimized —
+      // clear the flag so the next run opens with the full panel.
+      useEffect(() => {
+        if (!jobActive) setLiveMinimized(false);
+      }, [jobActive]);
 
       // The canvas is ALWAYS full-width now: the chat / help panels float over it
       // as translucent overlays (like the left side panel) so the graph shines
@@ -951,8 +963,35 @@ const GraphViewer = memo(
               stages={INDEXING_STAGES}
               icon={toIndexingProps(jobState, activeRepoUrl).icon}
               onExpand={onJobExpand}
-              onCancel={onJobCancel}
+              onMinimize={() => setLiveMinimized(true)}
             />
+          )}
+
+          {showLiveChip && (
+            <div className="live-indexing-chip">
+              <button
+                type="button"
+                className="live-indexing-chip__restore"
+                onClick={() => setLiveMinimized(false)}
+                title="Show indexing progress"
+                aria-label="Show indexing progress"
+              >
+                <span className="live-indexing-chip__spinner" aria-hidden />
+                <span className="live-indexing-chip__count">
+                  <strong>{jobState.nodesCreated.toLocaleString()}</strong>{' '}
+                  nodes
+                </span>
+              </button>
+              <button
+                type="button"
+                className="live-indexing-chip__cancel"
+                onClick={onJobCancel}
+                title="Cancel indexing"
+                aria-label="Cancel indexing"
+              >
+                &times;
+              </button>
+            </div>
           )}
 
           {/* While fetching/parsing there's no graph yet — show a calm centered

--- a/ui/src/appComponents/LiveIndexingPanel.css
+++ b/ui/src/appComponents/LiveIndexingPanel.css
@@ -227,6 +227,83 @@
   opacity: 0.5;
 }
 
+/* ── Minimized chip (restore + cancel) ─────────────────────────────────── */
+.live-indexing-chip {
+  position: absolute;
+  left: 16px;
+  /* Sits on the same baseline the full panel is anchored to. */
+  bottom: 84px;
+  z-index: 150;
+  display: flex;
+  align-items: stretch;
+  max-width: calc(100vw - 32px);
+  border-radius: var(--radius);
+  background: color-mix(in oklch, var(--card) 88%, transparent);
+  backdrop-filter: blur(14px);
+  border: 1px solid color-mix(in oklch, var(--border) 55%, transparent);
+  box-shadow: 0 8px 28px color-mix(in oklch, var(--background) 55%, transparent);
+  color: var(--foreground);
+  overflow: hidden;
+  pointer-events: auto;
+  animation: live-panel-in 0.2s ease-out;
+}
+
+.live-indexing-chip__restore {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 8px 12px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 0.76rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.live-indexing-chip__restore:hover {
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+
+.live-indexing-chip__spinner {
+  flex: none;
+  width: 13px;
+  height: 13px;
+  border: 2px solid color-mix(in oklch, var(--primary) 30%, transparent);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: live-panel-spin 0.8s linear infinite;
+}
+
+.live-indexing-chip__count {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-foreground);
+}
+
+.live-indexing-chip__count strong {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.live-indexing-chip__cancel {
+  flex: none;
+  width: 28px;
+  border: none;
+  border-left: 1px solid color-mix(in oklch, var(--border) 45%, transparent);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 1.05rem;
+  line-height: 1;
+  transition: all 0.15s;
+}
+
+.live-indexing-chip__cancel:hover {
+  background: color-mix(in oklch, var(--destructive) 15%, transparent);
+  color: var(--destructive);
+}
+
 /* ── Centered build loader (shown while fetching/parsing, before the graph) ── */
 .graph-build-loader {
   position: absolute;

--- a/ui/src/appComponents/LiveIndexingPanel.tsx
+++ b/ui/src/appComponents/LiveIndexingPanel.tsx
@@ -40,8 +40,8 @@ interface Props {
   icon?: ReactNode;
   /** Open the full-detail indexing modal. */
   onExpand: () => void;
-  /** Cancel the running job. */
-  onCancel: () => void;
+  /** Collapse the panel to a compact chip — indexing keeps running. */
+  onMinimize: () => void;
 }
 
 function formatMB(bytes: number): string {
@@ -99,7 +99,7 @@ export default function LiveIndexingPanel({
   stages,
   icon,
   onExpand,
-  onCancel,
+  onMinimize,
 }: Props) {
   // Only stages that have started — keeps the panel short early on.
   const rows = stages
@@ -142,12 +142,12 @@ export default function LiveIndexingPanel({
         </button>
         <button
           type="button"
-          className="live-indexing-panel__btn live-indexing-panel__btn--cancel"
-          onClick={onCancel}
-          title="Cancel indexing"
-          aria-label="Cancel indexing"
+          className="live-indexing-panel__btn"
+          onClick={onMinimize}
+          title="Minimize — indexing continues in the background"
+          aria-label="Minimize indexing panel"
         >
-          &times;
+          &minus;
         </button>
       </div>
 

--- a/ui/src/appComponents/__tests__/LiveIndexingPanel.test.tsx
+++ b/ui/src/appComponents/__tests__/LiveIndexingPanel.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, screen } from '@testing-library/react';
+import React from 'react';
+import { JobPhase } from '../../gen/opentrace/v1/agent_service';
+import type { JobState } from '../../job';
+import LiveIndexingPanel from '../LiveIndexingPanel';
+
+afterEach(cleanup);
+
+function jobState(overrides: Partial<JobState> = {}): JobState {
+  return {
+    status: 'running',
+    phase: JobPhase.JOB_PHASE_UNSPECIFIED,
+    message: '',
+    detail: {
+      current: 0,
+      total: 0,
+      fileName: '',
+      nodesCreated: 0,
+      relationshipsCreated: 0,
+    },
+    nodesCreated: 42,
+    relationshipsCreated: 7,
+    result: null,
+    error: null,
+    stages: {},
+    ...overrides,
+  };
+}
+
+describe('LiveIndexingPanel', () => {
+  it('minimizes instead of cancelling — no cancel control, minimize fires onMinimize', () => {
+    const onMinimize = vi.fn();
+    const onExpand = vi.fn();
+    render(
+      React.createElement(LiveIndexingPanel, {
+        state: jobState(),
+        stages: [],
+        onExpand,
+        onMinimize,
+      }),
+    );
+
+    // The destructive "Cancel indexing" affordance is gone from the panel.
+    expect(screen.queryByLabelText('Cancel indexing')).toBeNull();
+
+    const minimize = screen.getByLabelText('Minimize indexing panel');
+    fireEvent.click(minimize);
+    expect(onMinimize).toHaveBeenCalledOnce();
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  it('still exposes the expand affordance', () => {
+    const onExpand = vi.fn();
+    render(
+      React.createElement(LiveIndexingPanel, {
+        state: jobState(),
+        stages: [],
+        onExpand,
+        onMinimize: vi.fn(),
+      }),
+    );
+    fireEvent.click(screen.getByLabelText('Expand indexing details'));
+    expect(onExpand).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/components/ThreeGraphCanvas.tsx
+++ b/ui/src/components/ThreeGraphCanvas.tsx
@@ -790,6 +790,10 @@ const ThreeGraphCanvasInner = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
           rendererRef.current?.clearTraversal();
         },
         reseedLayout: () => {
+          // Arm the snapshot interpolator BEFORE the reseed posts to the worker,
+          // so the reorganizing positions that stream back are eased to 60fps
+          // instead of stepping at the throttled post rate (preset-change judder).
+          rendererRef.current?.beginLayoutReflow();
           reseed();
         },
         setNebulaLayout: (enabled: boolean, baseMode = 'spread') => {

--- a/ui/src/components/config/graphLayout.ts
+++ b/ui/src/components/config/graphLayout.ts
@@ -68,10 +68,14 @@ export const HOT_EDGE_CURVE_SEGMENTS = 20;
 export const HOT_EDGE_SAG_FACTOR = 0.16;
 // Ribbon half-width in WORLD units (not pixels) so strands shrink with the
 // graph as you zoom out — a fixed pixel width made the additive glow pile into
-// one saturated blob at low zoom. Comparable to a small node radius.
-export const HOT_EDGE_HALF_WIDTH = 7;
-// Peak glow alpha at the centreline (additive). Ends taper to 0.
-export const HOT_EDGE_GLOW_ALPHA = 0.6;
+// one saturated blob at low zoom. Kept fairly thin so a hub's strands read as
+// distinct, traceable rays instead of merging into a washed-out fan; thinner
+// ribbons also overlap less, so they can stay bright without piling to white.
+export const HOT_EDGE_HALF_WIDTH = 5;
+// Opacity of a highlighted (selected-node) edge line. Rendered as a plain crisp
+// line under normal blending — overlapping strands at a hub just show the edge
+// colour, never summing to a white blob, so no per-strand/taper capping needed.
+export const HOT_EDGE_GLOW_ALPHA = 0.85;
 // Above this many hot edges the ribbon is skipped and they fall back to the
 // bulk line set — which, under DOF, is the BLURRED background, so this must be
 // high enough that a normal selection (incl. hops 3–4) stays in the sharp

--- a/ui/src/components/config/graphPresets.ts
+++ b/ui/src/components/config/graphPresets.ts
@@ -101,7 +101,9 @@ export const GRAPH_PRESETS: GraphPreset[] = [
       compactCentering: 10,
       compactRadius: 22,
       edgeOpacity: 45,
-      zoomSizeExponent: 0.25,
+      // Matches Planet's zoom scaling (displays as 20% on the slider) so nodes
+      // attenuate identically across every preset.
+      zoomSizeExponent: 0.8,
       labelScale: 100,
       mode3dSpeed: 12,
       mode3dTilt: 35,
@@ -115,10 +117,12 @@ export const GRAPH_PRESETS: GraphPreset[] = [
     label: 'Onion',
     icon: 'onion',
     description:
-      'A layered ball — every node type forms its own evenly-spread spherical shell, nested core-to-rim (repo at the center, functions & dependencies on the outer layers). Colored by node type.',
+      'A flat, top-down map — every node type forms its own concentric ring, nested core-to-rim (repo at the center, functions & dependencies on the outer rings). Colored by node type.',
     settings: {
+      // 'onion' layout in 2D renders as a cross-section: concentric annular
+      // bands, one per node type (see computeOnion in forceLayout3dWorker).
       layoutMode: 'onion',
-      mode3d: true,
+      mode3d: false,
       autoRotate: false,
       colorMode: 'type',
       communitiesEnabled: false,
@@ -130,11 +134,11 @@ export const GRAPH_PRESETS: GraphPreset[] = [
       compactCommunity: 10,
       compactCentering: 5,
       compactRadius: 16,
-      // Cross-shell edges crisscross the ball and clutter it — hide them (and
-      // labels) so the clean layered shells read on their own.
+      // Cross-ring edges crisscross the map and clutter it — hide them (and
+      // labels) so the clean concentric rings read on their own.
       edgeOpacity: 0,
-      // Higher exponent = smaller nodes; keep the shells reading as a clean ball.
-      zoomSizeExponent: 0.5,
+      // Matches Planet's zoom scaling (displays as 20% on the slider).
+      zoomSizeExponent: 0.8,
       labelScale: 90,
       mode3dSpeed: 15,
       mode3dTilt: 35,
@@ -197,10 +201,9 @@ export const GRAPH_PRESETS: GraphPreset[] = [
       // Kept low: thousands of intra-cluster edges read as noise at full
       // strength — the clusters themselves carry the structure.
       edgeOpacity: 35,
-      // 2D attenuation exponent (0 = big/screen-fixed, 1 = small/world-scale);
-      // 0.75 preserves the look this preset was tuned with before the slider
-      // direction fix (formerly stored as 0.25 under the inverse convention).
-      zoomSizeExponent: 0.75,
+      // Matches Planet's zoom scaling (displays as 20% on the slider) so nodes
+      // attenuate identically across every preset.
+      zoomSizeExponent: 0.8,
       labelScale: 100,
       mode3dSpeed: 15,
       mode3dTilt: 35,

--- a/ui/src/components/panels/PhysicsPanel.css
+++ b/ui/src/components/panels/PhysicsPanel.css
@@ -18,7 +18,10 @@
 .physics-panel {
   position: absolute;
   bottom: 20px;
-  right: 68px;
+  /* Sit clear of the right-hand chat / help overlay when one is open — mirrors
+   * `.graph-controls`. Without the inset the panel stays pinned at 68px and the
+   * wider chat overlay (z-index 20) draws over it. */
+  right: calc(68px + var(--right-panel-inset, 0px));
   z-index: 10;
   width: var(--physics-panel-width, 240px);
   /* Height: auto until the user drags the top edge, then an explicit pixel
@@ -29,7 +32,7 @@
    * `bottom: 20px` anchors — so a stored width/height bigger than what
    * currently fits can't push the panel (and its top/left handles)
    * off-screen. */
-  max-width: calc(100vw - 76px);
+  max-width: calc(100vw - 76px - var(--right-panel-inset, 0px));
   max-height: min(80vh, calc(100vh - 28px));
   /* Overflow stays VISIBLE on the panel root so the resize handles
    * (which sit at top:-3 / left:-3 / right:-3 / bottom:-3, outside the

--- a/ui/src/components/panels/PhysicsPanel.tsx
+++ b/ui/src/components/panels/PhysicsPanel.tsx
@@ -153,7 +153,6 @@ export default function PhysicsPanel({
   onReheat,
   onFitToScreen,
   mode3d = false,
-  onMode3dChange,
   mode3dAutoRotate = true,
   onMode3dAutoRotateChange,
   mode3dSpeed = 15,
@@ -413,33 +412,23 @@ export default function PhysicsPanel({
             community-clusters label visibility, which conflated two
             different concerns. */}
 
-            {/* Pixi: 3D rotation toggle + controls */}
-            {pixiMode && onMode3dChange && (
+            {/* Rotation controls — only meaningful in 3D. The 2D↔3D dimension
+            switch lives in the bottom-right toolbar ("Switch to 3D"), so the
+            panel just exposes auto-rotate + its speed/tilt when already in 3D. */}
+            {pixiMode && mode3d && onMode3dAutoRotateChange && (
               <>
                 <div
                   className="physics-toggle-row"
-                  onClick={() => onMode3dChange(!mode3d)}
+                  onClick={() => onMode3dAutoRotateChange(!mode3dAutoRotate)}
                 >
-                  <span className="physics-toggle-label">3D rotation</span>
-                  <div className={`physics-toggle-track${mode3d ? ' on' : ''}`}>
+                  <span className="physics-toggle-label">Auto-rotate</span>
+                  <div
+                    className={`physics-toggle-track${mode3dAutoRotate ? ' on' : ''}`}
+                  >
                     <div className="physics-toggle-thumb" />
                   </div>
                 </div>
-                {mode3d && onMode3dAutoRotateChange && (
-                  <div
-                    className="physics-toggle-row"
-                    onClick={() => onMode3dAutoRotateChange(!mode3dAutoRotate)}
-                    style={{ paddingLeft: 8 }}
-                  >
-                    <span className="physics-toggle-label">Auto-rotate</span>
-                    <div
-                      className={`physics-toggle-track${mode3dAutoRotate ? ' on' : ''}`}
-                    >
-                      <div className="physics-toggle-thumb" />
-                    </div>
-                  </div>
-                )}
-                {mode3d && onMode3dSpeedChange && (
+                {onMode3dSpeedChange && (
                   <div className="physics-slider-row">
                     <div className="physics-slider-label">
                       <span>Rotation speed</span>
@@ -458,7 +447,7 @@ export default function PhysicsPanel({
                     />
                   </div>
                 )}
-                {mode3d && onMode3dTiltChange && (
+                {onMode3dTiltChange && (
                   <div className="physics-slider-row">
                     <div className="physics-slider-label">
                       <span>Camera tilt</span>

--- a/ui/src/components/three/ThreeRenderer.ts
+++ b/ui/src/components/three/ThreeRenderer.ts
@@ -85,7 +85,6 @@ import {
   HOT_EDGE_SAG_FACTOR,
   HOT_EDGE_HALF_WIDTH,
   HOT_EDGE_GLOW_ALPHA,
-  HOT_EDGE_MAX,
   DOF_BLUR_RADIUS,
   CURVE_ALL_EDGES_SEGMENTS,
   CURVE_ALL_EDGES_MAX,
@@ -429,31 +428,6 @@ function cleanLabel(raw: string): string {
   return stripped.length > LABEL_MAX_LENGTH
     ? stripped.slice(0, LABEL_MAX_LENGTH) + '…'
     : stripped;
-}
-
-/** Minimum distance from point (px,py) to line segment (ax,ay)→(bx,by). */
-function pointToSegmentDist(
-  px: number,
-  py: number,
-  ax: number,
-  ay: number,
-  bx: number,
-  by: number,
-): number {
-  const dx = bx - ax;
-  const dy = by - ay;
-  const lenSq = dx * dx + dy * dy;
-  if (lenSq < 0.0001) {
-    const ex = px - ax;
-    const ey = py - ay;
-    return Math.sqrt(ex * ex + ey * ey);
-  }
-  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq));
-  const cx = ax + t * dx;
-  const cy = ay + t * dy;
-  const ex = px - cx;
-  const ey = py - cy;
-  return Math.sqrt(ex * ex + ey * ey);
 }
 
 /** Parse a CSS hex string ('#rgb' / '#rrggbb') into raw sRGB 0..1 channels.
@@ -2240,31 +2214,26 @@ export class ThreeRenderer {
    *  `hotRibbonActive` so the bulk line set zeroes them (no double-draw). Above
    *  HOT_EDGE_MAX the ribbon bows out and the bulk lines keep the hot edges. */
   private syncHotEdgeList(): void {
-    const list = this.hotEdgeList;
-    list.length = 0;
+    // No separate glow ribbon. Highlighted edges are drawn by the SAME bulk edge
+    // object as everything else (brightened via edgeAlphaGeneral's absolute-alpha
+    // encoding), so a selected node's edges look identical in style to the
+    // unselected edges — thin 1px lines, not a fat ribbon. To keep them SHARP
+    // over the DOF blur, `updateEdgeLayers` moves the whole edge object to the
+    // sharp foreground layer while a highlight is active (DOF still blurs the
+    // background nodes). No ribbon, DOF preserved.
+    this.hotEdgeList.length = 0;
+    this.hotRibbonActive = false;
     this.hotEdgesOverflowed = false;
-    if (!this.hasHighlight) {
-      this.hotRibbonActive = false;
-      return;
-    }
-    for (let i = 0; i < this.edges.length; i++) {
-      const e = this.edges[i];
-      if (!this.edgeIsHot(e.key)) continue;
-      if (this.traversalPendingEdges.has(e.key)) continue; // not yet crossed
-      if (!this.nodeArray[e.sourceIdx]?.visible) continue;
-      if (!this.nodeArray[e.targetIdx]?.visible) continue;
-      list.push(e);
-      if (list.length > HOT_EDGE_MAX) {
-        // Too many to be worth a curved glow mesh — the bulk line set draws them
-        // (as bright straight chords). Flag it so DOF is skipped: those chords
-        // sit on the blurred layer and would otherwise smear.
-        list.length = 0;
-        this.hotRibbonActive = false;
-        this.hotEdgesOverflowed = true;
-        return;
-      }
-    }
-    this.hotRibbonActive = list.length > 0;
+  }
+
+  /** While a highlight is active, move the bulk edge object to the sharp DOF
+   *  foreground layer (1) so its brightened highlighted edges — and the dimmed
+   *  rest — render crisp over the blurred background, via the NORMAL edge
+   *  renderer (no ribbon). Off-highlight they live on the base layer (0). */
+  private updateEdgeLayers(): void {
+    const layer = this.hasHighlight ? 1 : 0;
+    this.edgeLines?.layers.set(layer);
+    this.curvedEdgeObject?.layers.set(layer);
   }
 
   /** Build / refresh the ribbon geometry from `hotEdgeList`. Topology (side
@@ -2444,6 +2413,11 @@ export class ThreeRenderer {
     const col = this.hotEdgeColorArray;
     const alp = this.hotEdgeAlphaArray;
     const hasTrail = this.traversalLitEdges.size > 0;
+    // Every strand glows at FULL strength, end to end — no per-strand alpha
+    // capping, no taper. The hot-edge material uses MAX ("lighten") blending, so
+    // overlapping strands at a dense hub take the brightest value instead of
+    // summing to a white blob; the pile-up problem is solved at the blend level.
+    const peakAlpha = HOT_EDGE_GLOW_ALPHA;
     for (let j = 0; j < edges.length; j++) {
       const e = edges[j];
       const lit = hasTrail && this.traversalLitEdges.has(e.key);
@@ -2452,19 +2426,12 @@ export class ThreeRenderer {
       const g = this.tmpColor.g;
       const b = this.tmpColor.b;
       const base = j * N * 2;
-      for (let i = 0; i < N; i++) {
-        const tt = i / (N - 1);
-        // Soften only the very tips (~4%) so the strand still visually reaches
-        // its nodes — a larger taper left a gap and the nodes looked unconnected.
-        const fade = Math.min(1, tt / 0.04) * Math.min(1, (1 - tt) / 0.04);
-        const a = HOT_EDGE_GLOW_ALPHA * fade;
-        for (let sdx = 0; sdx < 2; sdx++) {
-          const v = base + i * 2 + sdx;
-          col[v * 3] = r;
-          col[v * 3 + 1] = g;
-          col[v * 3 + 2] = b;
-          alp[v] = a;
-        }
+      const end = base + N * 2;
+      for (let v = base; v < end; v++) {
+        col[v * 3] = r;
+        col[v * 3 + 1] = g;
+        col[v * 3 + 2] = b;
+        alp[v] = peakAlpha;
       }
     }
   }
@@ -2544,6 +2511,7 @@ export class ThreeRenderer {
         this.curvedEdgesActive = true;
         this.applyEdgeDepthMode(); // sets depthTest / bias / renderOrder / mode
         this.flagCurvedEdgeBuffers();
+        this.updateEdgeLayers(); // sharp-layer while highlighting
         this.requestRender();
       }
     } else if (this.curvedEdgesActive) {
@@ -2552,6 +2520,7 @@ export class ThreeRenderer {
         this.scene.add(this.edgeLines);
       }
       this.curvedEdgesActive = false;
+      this.updateEdgeLayers();
       this.requestRender();
     }
   }
@@ -2631,9 +2600,11 @@ export class ThreeRenderer {
       this.clearHotEdges();
       return;
     }
-    // Resolve which hot edges (if any) the glow ribbon owns BEFORE the per-edge
-    // loop — edgeAlphaGeneral reads hotRibbonActive to zero those edges here.
+    // Resolve hot-edge state before the per-edge loop, and move the edge object
+    // to the sharp DOF layer while a highlight is active so highlighted edges
+    // render crisp (as normal thin lines) over the blurred background.
     this.syncHotEdgeList();
+    this.updateEdgeLayers();
     const a = this.edgeAlphaArray;
     const enabled = this.edgesEnabled;
     const lod = this.lodEnabled && this.superList.length > 0;
@@ -2811,10 +2782,18 @@ export class ThreeRenderer {
     // are identical — same nodeInView, same margins, same camera. Built
     // lazily on the first drawable edge so states where nothing draws (edges
     // off / all alphas 0) pay no projections at all.
+    // While a highlight is active the edge object sits on the sharp DOF layer
+    // (see updateEdgeLayers). Drawing the dimmed, non-highlighted edges there
+    // too made every OTHER hub's dense edge-convergence show as a crisp "hot
+    // spot" instead of blurring into the background. So during a highlight the
+    // sharp layer draws ONLY the highlighted edges; the rest drop out (the
+    // graph's non-selected edges recede, like the blurred background nodes).
+    const hotOnly = this.hasHighlight;
     let view: Uint8Array | null = null;
     let ec = 0;
     for (let i = 0; i < this.edges.length; i++) {
       if (a[i * 2] <= 0) continue;
+      if (hotOnly && !this.edgeIsHot(this.edges[i].key)) continue;
       if (cull) {
         if (view === null) view = this.computeNodeViewFlags(mx, my);
         const e = this.edges[i];
@@ -3150,9 +3129,20 @@ export class ThreeRenderer {
   }
 
   /** User-adjustable edge visibility (Physics panel "Edge opacity" slider).
-   *  Multiplies the zoom-driven base; 1.0 = default behavior. */
+   *  Multiplies the zoom-driven base for normal edges; also scales the
+   *  absolute-alpha HOT (highlighted) edges via uHotOpacity so the slider
+   *  controls the selected node's edges too. 1.0 = default behavior. */
   setEdgeOpacity(multiplier: number): void {
     this.edgeOpacityMultiplier = Math.max(0, Math.min(2, multiplier));
+    const hot = this.edgeOpacityMultiplier;
+    if (this.edgeMaterial) this.edgeMaterial.uniforms.uHotOpacity.value = hot;
+    if (this.superEdgeMaterial)
+      this.superEdgeMaterial.uniforms.uHotOpacity.value = hot;
+    if (this.curvedEdgeMaterial)
+      (
+        this.curvedEdgeMaterial
+          .uniforms as unknown as CurvedEdgeMaterialUniforms
+      ).uHotOpacity.value = hot;
     this.requestRender();
   }
   private edgeOpacityMultiplier = 1;
@@ -3489,47 +3479,6 @@ export class ThreeRenderer {
     return id - 1;
   }
 
-  /** Nearest visible edge to a world point, within `maxDist` world units.
-   *  CPU point-to-segment over all edges — used for click selection (not
-   *  per-mousemove). */
-  private findEdgeAt(
-    worldX: number,
-    worldY: number,
-    maxDist: number,
-  ): ThreeEdge | null {
-    if (this.edges.length === 0 || !this.edgesEnabled) return null;
-    const pos = this.posArray;
-    let best: ThreeEdge | null = null;
-    let bestDist = maxDist;
-    for (const e of this.edges) {
-      if (this.hiddenLinkTypes.has(e.label)) continue;
-      const s = e.sourceIdx;
-      const t = e.targetIdx;
-      if (!this.nodeArray[s].visible || !this.nodeArray[t].visible) continue;
-      const sx = pos[s * 3];
-      const sy = pos[s * 3 + 1];
-      const tx = pos[t * 3];
-      const ty = pos[t * 3 + 1];
-      const d = pointToSegmentDist(worldX, worldY, sx, sy, tx, ty);
-      if (d < bestDist) {
-        bestDist = d;
-        best = e;
-      }
-    }
-    return best;
-  }
-
-  private buildSelectedEdge(edge: ThreeEdge): SelectedEdge {
-    return {
-      source: edge.sourceId,
-      target: edge.targetId,
-      label: edge.label,
-      properties: edge.graphLink.properties,
-      sourceNode: this.nodes.get(edge.sourceId)?.graphNode,
-      targetNode: this.nodes.get(edge.targetId)?.graphNode,
-    };
-  }
-
   // ─── Interaction (pan / wheel / pick / drag) ──────────────────────
 
   setCallbacks(callbacks: InteractionCallbacks): void {
@@ -3713,19 +3662,10 @@ export class ThreeRenderer {
           const idx = this.pickNodeIndexAt(hx, hy);
           // Real nodes grow on hover (+ host tooltip); super-nodes don't.
           this.setHoveredNode(idx >= 0 ? idx : -1, hx, hy);
-          if (idx !== -1) {
-            // Node (idx >= 0) or super-node (idx <= -2) — both clickable.
-            canvas.style.cursor = 'pointer';
-          } else if (this.edgesEnabled && this.bp.edgeHoverHitTest) {
-            const w = this.screenToWorld(
-              e.clientX - rect.left,
-              e.clientY - rect.top,
-            );
-            const hit = this.findEdgeAt(w.x, w.y, 8 / this.zoomForHit());
-            canvas.style.cursor = hit ? 'pointer' : 'default';
-          } else {
-            canvas.style.cursor = 'default';
-          }
+          // Only nodes (and super-nodes) are clickable — edges are not, so the
+          // pointer cursor appears over nodes only (a pointer over an edge used
+          // to imply a click that now does nothing).
+          canvas.style.cursor = idx !== -1 ? 'pointer' : 'default';
           return;
         }
 
@@ -3870,23 +3810,14 @@ export class ThreeRenderer {
           if (this.mode3d && this.mode3dAutoRotate) this.set3DAutoRotate(false);
           this.callbacks.onNodeClick?.(this.nodeArray[idx].graphNode);
         } else {
-          // CPU edge hit-test only in 2D (screen→world plane is ill-defined
-          // under perspective).
-          const edge = this.mode3d
-            ? null
-            : this.findEdgeAt(
-                this.screenToWorld(sx, sy).x,
-                this.screenToWorld(sx, sy).y,
-                8 / this.zoomForHit(),
-              );
-          if (edge) {
-            this.callbacks.onEdgeClick?.(this.buildSelectedEdge(edge));
-          } else {
-            // Deliberately does NOT restart 3D auto-rotation: a click in the
-            // void is how users dismiss a selection, and having the scene
-            // start spinning on it read as a bug.
-            this.callbacks.onStageClick?.();
-          }
+          // Edges are NOT clickable — only nodes. Near a high-degree node the
+          // dense edges used to steal the click and select a relationship
+          // instead of the node, which read as a bug; a click that misses a
+          // node now just dismisses the current selection.
+          // Deliberately does NOT restart 3D auto-rotation: a click in the void
+          // is how users dismiss a selection, and having the scene start
+          // spinning on it read as a bug.
+          this.callbacks.onStageClick?.();
         }
       }
       this.pendingDragIndex = -1;
@@ -3897,11 +3828,6 @@ export class ThreeRenderer {
     // iOS Safari cancels pointers when the OS takes over a gesture — treat it
     // as a lift so pinch/pan state can't get stuck.
     canvas.addEventListener('pointercancel', onUp, { signal });
-  }
-
-  /** Current px-per-world-unit, for converting a pixel hit radius to world. */
-  private zoomForHit(): number {
-    return this.camera?.zoom ?? 1;
   }
 
   /** Pivot for the current 3D rotate gesture — the graph's own center,

--- a/ui/src/components/three/ThreeRenderer.ts
+++ b/ui/src/components/three/ThreeRenderer.ts
@@ -789,6 +789,14 @@ export class ThreeRenderer {
    *  computed. Used to scale edge opacity by how far the user has zoomed in
    *  relative to the overview. */
   private lastFitZoom = 1;
+  /** Low-pass-smoothed `lastFitZoom` used ONLY as the 2D node-size reference.
+   *  `lastFitZoom` STEPS whenever the graph re-fits (every growth batch during a
+   *  live build, every filter/reflow), and dividing node size by it directly
+   *  made those steps show up as node-size jitter — the "choppy live build".
+   *  Easing the reference toward it (camZoom is already eased) keeps the size
+   *  ratio smooth. Converges to `lastFitZoom` at rest, so the settled
+   *  scale-independent size is unchanged. 0 = uninitialized (snap on first use). */
+  private sizeFitRef = 0;
   /** Currently selected node id (for zoom-to-selection), or null. */
   private selectedNodeId: string | null = null;
   /** Index of the node under the cursor (grows via NODE_STATE_HOVERED), -1
@@ -1108,7 +1116,11 @@ export class ThreeRenderer {
       this.traversalAnim === null &&
       !this.ambientActive &&
       !this.liveGrowActive &&
-      !this.postBuildSettle
+      !this.postBuildSettle &&
+      // Keep rendering while the node-size reference is still easing toward the
+      // current fit (else it would freeze mid-ease and leave nodes slightly
+      // mis-sized until the next interaction).
+      this.sizeRefSettled()
     )
       return;
     this.needsRender = false;
@@ -1151,12 +1163,25 @@ export class ThreeRenderer {
     if (this.traversalAnim) this.updateTraversalAnim(performance.now());
     if (this.ambientActive) this.updateAmbient(performance.now());
 
+    // Ease the size reference toward the live fit (snap on first use). camZoom
+    // is already eased, so a smoothed denominator keeps node size from STEPPING
+    // when lastFitZoom jumps each growth batch / reflow — the live-build judder.
+    this.sizeFitRef =
+      this.sizeFitRef <= 0
+        ? this.lastFitZoom
+        : this.sizeFitRef +
+          (this.lastFitZoom - this.sizeFitRef) * this.AUTO_FIT_FOLLOW_ALPHA;
+    const sizeRef = Math.max(this.sizeFitRef, 1e-6);
     // Keep the shader's zoom uniform in sync (size attenuation).
     for (const mat of [this.nodeMaterial, this.nodeHaloMaterial]) {
       if (!mat) continue;
       const u = mat.uniforms as unknown as NodeMaterialUniforms;
       u.uPerspective.value = 0;
-      u.uZoom.value = cam.zoom;
+      // Fit-normalized zoom (1.0 at the whole-graph overview) — see the 2D
+      // sizing model in nodeMaterial.ts. Uses the SMOOTHED fit reference so node
+      // size stays independent of layout world extent (Onion/Flat match at their
+      // fit) without stepping while the graph reorganizes.
+      u.uZoom.value = cam.zoom / sizeRef;
       u.uSizeExp.value = this.zoomSizeExponent;
     }
     if (this.edgeMaterial)
@@ -1376,6 +1401,16 @@ export class ThreeRenderer {
   /** A scalar "px-per-world-unit" usable for label LOD/size gates in both
    *  cameras: ortho zoom directly, or (in 3D) the perspective px/world at the
    *  current orbit-target distance. */
+  /** True once the smoothed size reference has caught up to the live fit, so the
+   *  render loop can idle again (see the 2D size-reference easing in frame()). */
+  private sizeRefSettled(): boolean {
+    if (this.mode3d) return true; // 3D size doesn't use the fit reference
+    if (this.sizeFitRef <= 0) return false; // needs a snap-in first
+    return (
+      Math.abs(this.sizeFitRef - this.lastFitZoom) <= this.lastFitZoom * 0.005
+    );
+  }
+
   private effectiveZoom(): number {
     if (this.mode3d && this.perspCamera && this.controls) {
       const dist = this.perspCamera.position.distanceTo(this.controls.target);
@@ -1638,15 +1673,19 @@ export class ThreeRenderer {
 
   /** Screen-size multiplier for a node's base size, mirroring the ACTUAL
    *  per-mode shader sizing (nodeMaterial vertex shader) so the label cull
-   *  judges what's really on screen. 2D: ortho attenuation `zoom^exp`. 3D:
-   *  depth cue at the orbit-target distance × the slider's size gain —
+   *  judges what's really on screen. 2D: fit-normalized zoom cue × size gain.
+   *  3D: depth cue at the orbit-target distance × the slider's size gain —
    *  `effectiveZoom()` is exactly the shader's `persp` for a node at the
    *  target depth, so `mix(1, persp, 0.5) = (1 + zoom) / 2`. */
   private labelSpriteRadiusFactor(zoom: number): number {
     if (this.mode3d) {
       return ((1 + zoom) / 2) * Math.pow(12, 0.3 - this.zoomSizeExponent);
     }
-    return Math.pow(zoom, this.zoomSizeExponent);
+    // Mirror nodeMaterial's 2D branch: SMOOTHED-fit-normalized zoom × the same
+    // gain, so the label gap tracks the node's real rendered radius.
+    const ref = this.sizeFitRef > 0 ? this.sizeFitRef : this.lastFitZoom;
+    const norm = zoom / Math.max(ref, 1e-6);
+    return ((1 + norm) / 2) * Math.pow(12, 0.3 - this.zoomSizeExponent);
   }
 
   /** Lightweight per-frame reposition of the already-chosen label set. */
@@ -1860,6 +1899,10 @@ export class ThreeRenderer {
     this.buildAnim = null;
     this.buildPrepared = false;
     this.preparedSizes = null;
+    // Fresh dataset → snap the 2D size reference to the new graph's fit on first
+    // use rather than easing from the previous graph's (possibly very different)
+    // scale.
+    this.sizeFitRef = 0;
     // The hovered index refers to the old node array.
     this.hoveredNodeIndex = -1;
     // Drop any traversal walk + lit trail — the node/edge ids are about to change.
@@ -2962,6 +3005,31 @@ export class ThreeRenderer {
     );
   }
 
+  /** Arm the snapshot interpolator for a layout REFLOW — a preset change
+   *  reseeds the force layout, which then streams fresh positions as it
+   *  reorganizes. Without this those throttled worker posts (~5–15Hz, scaled by
+   *  node count) write posArray raw, so the nodes step between posts while the
+   *  camera eases smoothly — the visible judder. This reuses the post-build
+   *  settle path: posts feed layoutPos (the targets) and the render loop lerps
+   *  posArray toward them every frame → 60fps motion. Cleared automatically when
+   *  the worker settles (setLayoutSettled) or a drag / build takes over.
+   *
+   *  Sets layoutSettled/ambientActive false up-front (mirroring the
+   *  setLayoutSettled(false) that the simRunning effect fires a beat later) so
+   *  the very first post is already interpolated rather than racing that effect. */
+  beginLayoutReflow(): void {
+    if (this.nodeArray.length === 0) return;
+    // A live build owns node motion with its own easing; don't fight it.
+    if (this.liveGrowActive || this.buildAnim !== null) return;
+    this.layoutSettled = false;
+    this.ambientActive = false;
+    this.postBuildSettle = true;
+    this.layoutInterpStart = 0;
+    this.layoutInterpDur = 0;
+    this.layoutInterpActive = false;
+    this.requestRender();
+  }
+
   updatePositionsFromBuffer(buffer: Float64Array): void {
     const len = Math.min(this.nodeArray.length, Math.floor(buffer.length / 3));
     // During a build/live-build/post-build settle the layout streams into
@@ -3338,7 +3406,10 @@ export class ThreeRenderer {
       pu.uZoom.value = this.height / (2 * Math.tan((this.fov * Math.PI) / 360));
     } else {
       pu.uPerspective.value = 0;
-      pu.uZoom.value = cam.zoom;
+      // Match the display material's smoothed fit-normalized 2D zoom so the pick
+      // disc tracks the rendered node size.
+      const sizeRef = this.sizeFitRef > 0 ? this.sizeFitRef : this.lastFitZoom;
+      pu.uZoom.value = cam.zoom / Math.max(sizeRef, 1e-6);
     }
     pu.uSizeExp.value = this.zoomSizeExponent;
 

--- a/ui/src/components/three/curvedEdgeMaterial.ts
+++ b/ui/src/components/three/curvedEdgeMaterial.ts
@@ -79,12 +79,14 @@ const VERTEX_SHADER = /* glsl */ `
 
 const FRAGMENT_SHADER = /* glsl */ `
   uniform float uOpacity;
+  uniform float uHotOpacity; // user edge-opacity slider, applied to hot edges too
   varying vec3 vColor;
   varying float vAlpha;
   void main() {
     // Identical to edgeMaterial: aAlpha in (1,2] is ABSOLUTE (bypasses the
-    // global zoom/user opacity) for hot edges; otherwise scale by uOpacity.
-    float a = vAlpha > 1.0 ? min(vAlpha - 1.0, 1.0) : vAlpha * uOpacity;
+    // zoom-driven fade) for hot edges, but still scaled by the user's edge-opacity
+    // slider (uHotOpacity); otherwise scale by uOpacity.
+    float a = vAlpha > 1.0 ? min(vAlpha - 1.0, 1.0) * uHotOpacity : vAlpha * uOpacity;
     if (a <= 0.0) discard;
     gl_FragColor = vec4(vColor, a);
   }
@@ -92,6 +94,7 @@ const FRAGMENT_SHADER = /* glsl */ `
 
 export interface CurvedEdgeMaterialUniforms {
   uOpacity: { value: number };
+  uHotOpacity: { value: number };
   uSag: { value: number };
   uMode3d: { value: number };
   uDepthBias: { value: number };
@@ -101,6 +104,7 @@ export function createCurvedEdgeMaterial(sag: number): ShaderMaterial {
   return new ShaderMaterial({
     uniforms: {
       uOpacity: { value: 1 },
+      uHotOpacity: { value: 1 },
       uSag: { value: sag },
       uMode3d: { value: 0 },
       uDepthBias: { value: 0 },

--- a/ui/src/components/three/edgeMaterial.ts
+++ b/ui/src/components/three/edgeMaterial.ts
@@ -55,15 +55,16 @@ const VERTEX_SHADER = /* glsl */ `
 
 const FRAGMENT_SHADER = /* glsl */ `
   uniform float uOpacity;
+  uniform float uHotOpacity; // user edge-opacity slider, applied to hot edges too
   varying vec3 vColor;
   varying float vAlpha;
   void main() {
-    // aAlpha in (1, 2] is ABSOLUTE: alpha = value - 1, bypassing the global
-    // zoom/user opacity. Used for hot edges (chat-traversal trail / highlight
-    // neighborhood) so the lit path stays fully visible even when the preset
-    // keeps the edge layer faint or off (Planet 15%, Onion 0%) — WITHOUT
-    // raising the global opacity, which used to flash every edge on screen.
-    float a = vAlpha > 1.0 ? min(vAlpha - 1.0, 1.0) : vAlpha * uOpacity;
+    // aAlpha in (1, 2] is ABSOLUTE: alpha = value - 1, bypassing the zoom-driven
+    // fade so a hot edge (chat-traversal trail / highlight neighborhood) stays
+    // fully visible even when the preset keeps the edge layer faint (Planet 15%,
+    // Onion 0%). It IS still scaled by the user's "Edge opacity" slider
+    // (uHotOpacity) so that slider controls the highlighted edges as well.
+    float a = vAlpha > 1.0 ? min(vAlpha - 1.0, 1.0) * uHotOpacity : vAlpha * uOpacity;
     if (a <= 0.0) discard;
     gl_FragColor = vec4(vColor, a);
   }
@@ -73,8 +74,13 @@ export function createEdgeMaterial(): ShaderMaterial {
   return new ShaderMaterial({
     // uOpacity is a global multiplier the renderer drives by zoom: faint at the
     // overview (clusters read clearly), opaque when zoomed into a region.
-    // uDepthBias is set by applyEdgeDepthMode: ~1.5e-3 in 3D, 0 in 2D.
-    uniforms: { uOpacity: { value: 1 }, uDepthBias: { value: 0 } },
+    // uHotOpacity is the user's edge-opacity slider (1 = default), applied to the
+    // absolute-alpha hot edges. uDepthBias is set by applyEdgeDepthMode.
+    uniforms: {
+      uOpacity: { value: 1 },
+      uHotOpacity: { value: 1 },
+      uDepthBias: { value: 0 },
+    },
     vertexShader: VERTEX_SHADER,
     fragmentShader: FRAGMENT_SHADER,
     transparent: true,

--- a/ui/src/components/three/hotEdgeMaterial.ts
+++ b/ui/src/components/three/hotEdgeMaterial.ts
@@ -30,7 +30,7 @@
  * strands cross their glow sums like real light.
  */
 
-import { ShaderMaterial, AdditiveBlending, DoubleSide } from 'three';
+import { ShaderMaterial, NormalBlending, DoubleSide } from 'three';
 
 const VERTEX_SHADER = /* glsl */ `
   attribute float aSide;      // -1 / +1 : which side of the curve this vert sits
@@ -71,15 +71,15 @@ const FRAGMENT_SHADER = /* glsl */ `
   varying float vAlpha;
 
   void main() {
-    // Soft falloff across the ribbon width: bright at the centreline, fading to
-    // nothing at the rim — a glowing filament, not a flat stroke.
-    float edge = 1.0 - abs(vAcross);
-    float glow = pow(max(edge, 0.0), 2.0); // steeper falloff → slimmer bright core
-    float core = smoothstep(0.6, 1.0, edge); // brighter inner strand
-    vec3 color = min(vColor + core * 0.35, vec3(1.0));
-    float a = glow * vAlpha;
-    if (a < 0.004) discard; // additive: near-zero fragments add nothing
-    gl_FragColor = vec4(color, a);
+    // Render the highlighted edge as a PLAIN crisp line (like the normal bulk
+    // edges), not an additive glow: a solid core across most of the width with a
+    // soft anti-aliased rim. Normal (over) blending means overlapping strands at
+    // a hub just show the edge colour — they can NEVER sum past it, so there is
+    // no white blow-out at dense nodes (the whole reason the glow was replaced).
+    float across = abs(vAcross);
+    float a = (1.0 - smoothstep(0.55, 1.0, across)) * vAlpha;
+    if (a < 0.004) discard;
+    gl_FragColor = vec4(vColor, a);
   }
 `;
 
@@ -95,15 +95,14 @@ export function createHotEdgeMaterial(halfWidth: number): ShaderMaterial {
     vertexShader: VERTEX_SHADER,
     fragmentShader: FRAGMENT_SHADER,
     transparent: true,
-    // Additive so overlapping strands bloom together like light. depthTest is
-    // OFF: a highlight's strands should read as a continuous glowing filament,
-    // not blink in and out as each one sweeps behind the node cloud while the
-    // scene rotates (the "appear and disappear" flicker). DoubleSide because the
-    // screen-facing ribbon's winding flips with the curve direction — FrontSide
-    // would cull half the strands. Never writes depth (translucent glow).
+    // Normal ("over") blending, like the bulk edges — overlapping highlighted
+    // strands at a hub show the edge colour, never summing to a white blob.
+    // depthTest OFF so strands don't blink behind the node cloud while orbiting;
+    // DoubleSide because the screen-facing ribbon's winding flips with curve
+    // direction.
     side: DoubleSide,
     depthTest: false,
     depthWrite: false,
-    blending: AdditiveBlending,
+    blending: NormalBlending,
   });
 }

--- a/ui/src/components/three/nodeMaterial.ts
+++ b/ui/src/components/three/nodeMaterial.ts
@@ -23,11 +23,13 @@
  * so there is NO per-frame JS loop over nodes (the Pixi bottleneck at scale).
  *
  * Sizing model (2D):
- *   on-screen radius (px) = baseSize * zoom^sizeExponent
- * where `zoom` is the orthographic camera's px-per-world-unit — so exponent 0
- * = fixed screen size (big at overview) and 1 = world-tracking (small at
- * overview), matching the 3D branch's "0 = big, 1 = small". In perspective
- * (3D) mode the camera distance handles attenuation instead (uPerspective=1).
+ *   on-screen radius (px) = baseSize * mix(1, zoomNorm, 0.5) * 12^(0.3-exp)
+ * where `zoomNorm` is the ortho camera zoom NORMALIZED by the whole-graph fit
+ * (1.0 at the overview fit). Normalizing makes node size independent of the
+ * layout's world extent, so compact (Onion) and sprawling (Flat) layouts match
+ * — and the exponent uses the SAME geometric gain as the 3D branch (0 = large,
+ * 1 = small), so the "Zoom scaling" slider looks identical in both modes. In
+ * perspective (3D) mode the camera distance handles attenuation (uPerspective=1).
  */
 
 import {
@@ -105,11 +107,18 @@ const VERTEX_SHADER = /* glsl */ `
       float sizeGain = pow(12.0, 0.3 - uSizeExp);
       screenPx = base * 2.0 * uPixelRatio * depthCue * sizeGain;
     } else {
-      // Ortho (2D): uSizeExp is the zoom-attenuation exponent — 0 keeps nodes
-      // at fixed screen size (reads BIG at overview), 1 makes them track the
-      // world scale (shrink fully when zoomed out). Matches the 3D branch's
-      // "0 = big, 1 = small" so the UI slider moves both modes the same way.
-      screenPx = base * 2.0 * pow(uZoom, uSizeExp) * uPixelRatio;
+      // Ortho (2D): uZoom is the camera zoom NORMALIZED by the whole-graph fit
+      // (1.0 at the overview fit), so node screen size is independent of the
+      // layout's world extent — a compact layout (Onion) and a sprawling one
+      // (Flat) render nodes the same size at their fit, matching 3D. Before
+      // this, pow(camZoom, exp) scaled size with the raw fit zoom, so the
+      // compact Onion layout (high fit zoom) rendered huge nodes at the same
+      // slider value. uSizeExp sets absolute size via the SAME geometric gain
+      // as the perspective branch (0 = large, 1 = small); the mild mix() adds a
+      // gentle zoom-in growth mirroring 3D's depth cue.
+      float zoomCue = mix(1.0, uZoom, 0.5);
+      float sizeGain = pow(12.0, 0.3 - uSizeExp);
+      screenPx = base * 2.0 * uPixelRatio * zoomCue * sizeGain;
     }
     // base <= ~0 means the node is mid build-animation reveal (size driven to
     // 0 before its "birth"); cull it. gl_PointSize 0.0 is NOT reliable — many
@@ -278,8 +287,11 @@ const PICK_VERTEX_SHADER = /* glsl */ `
       float sizeGain = pow(12.0, 0.3 - uSizeExp);
       screenPx = base * 2.0 * uPixelRatio * depthCue * sizeGain;
     } else {
-      // Keep in lockstep with the display shader's 2D sizing (see above).
-      screenPx = base * 2.0 * pow(uZoom, uSizeExp) * uPixelRatio;
+      // Keep in lockstep with the display shader's 2D sizing (see above):
+      // uZoom is the fit-normalized ortho zoom, size gain mirrors 3D.
+      float zoomCue = mix(1.0, uZoom, 0.5);
+      float sizeGain = pow(12.0, 0.3 - uSizeExp);
+      screenPx = base * 2.0 * uPixelRatio * zoomCue * sizeGain;
     }
     // Mirror the display shader: a node mid-reveal (base ~0) isn't pickable,
     // and discard in the fragment so a zero-size point can't leave a pick pixel.


### PR DESCRIPTION
## Summary

Reworks how a selected node's edges render in the Three.js graph and cleans up the graph display controls. Highlighted edges now match the visual style of the rest of the graph (thin lines, no glow ribbon) while staying crisp over the depth-of-field blur, and a few confusing/unused controls were removed.

## Changes

- Render a selected node's edges as the same thin lines as the rest of the graph (drop the glow ribbon), moved to the sharp DOF foreground layer so they stay crisp over the blurred background.
- Draw only the highlighted edges while a node is selected; other edges are hidden rather than dimmed.
- The "Edge opacity" slider now controls highlighted edges too (previously only affected bulk edges).
- Disable edge picking on the canvas — only nodes are clickable.
- Physics panel: replace the "3D rotation" dimension toggle with an "Auto-rotate" toggle, and remove the edge-glow slider and the straight/curved-edge toggle.