### PR TITLE
fix(ui): graph edge coverage and viewer interaction fixes

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -100,6 +100,20 @@ function AppInner({
   const [chatHighlightNodes, setChatHighlightNodes] = useState<Set<string>>(
     () => new Set(),
   );
+  // Ref mirror so the stable stage-click handler can check for active chat
+  // highlights without re-creating (and thus re-rendering the memoized
+  // GraphViewer) every time the highlight set changes.
+  const chatHighlightNodesRef = useRef(chatHighlightNodes);
+  chatHighlightNodesRef.current = chatHighlightNodes;
+  // Clicking empty canvas drops chat-driven highlights + the traversal trail,
+  // so the user no longer has to close the chat or start a new conversation to
+  // clear them. No-op when nothing is highlighted (avoids re-allocating an
+  // empty Set and re-firing downstream highlight effects on every void click).
+  const handleStageDeselect = useCallback(() => {
+    if (chatHighlightNodesRef.current.size === 0) return;
+    setChatHighlightNodes(new Set());
+    graphViewerRef.current?.clearChatTraversal();
+  }, []);
   const hasRepoParam = useRef(
     new URLSearchParams(window.location.search).has('repo'),
   );
@@ -345,6 +359,7 @@ function AppInner({
           showHelp={showHelp}
           onToggleHelp={handleToggleHelp}
           chatHighlightNodes={chatHighlightNodes}
+          onStageClick={handleStageDeselect}
           animationSettings={animationSettings}
           graphFullscreen={isMobile ? graphFullscreen : undefined}
           onToggleGraphFullscreen={

--- a/ui/src/appComponents/GraphViewer.tsx
+++ b/ui/src/appComponents/GraphViewer.tsx
@@ -159,6 +159,10 @@ export interface GraphViewerProps {
   onToggleHelp: () => void;
   /** Node IDs found by chat tool results — highlighted when no other selection is active */
   chatHighlightNodes?: Set<string>;
+  /** Called when the user clicks empty canvas (the "void"), in addition to the
+   *  built-in selection clear. Lets the owner drop chat-driven highlights so a
+   *  void click deselects everything without closing or resetting the chat. */
+  onStageClick?: () => void;
   /** Animation settings from SettingsDrawer */
   animationSettings?: import('@opentrace/components').AnimationSettings;
   /** Additional React elements rendered in the toolbar's actions area (right side).
@@ -197,6 +201,7 @@ const GraphViewer = memo(
         showHelp,
         onToggleHelp,
         chatHighlightNodes,
+        onStageClick: onStageClickProp,
         animationSettings,
         toolbarActions,
         graphFullscreen,
@@ -245,6 +250,14 @@ const GraphViewer = memo(
           v.settings.compactRadius,
         ],
       );
+
+      // Void-click handler: run the built-in selection clear, then let the owner
+      // (App) drop chat-driven highlights too, so a click on empty canvas
+      // deselects everything at once.
+      const handleStageClick = useCallback(() => {
+        v.onStageClick();
+        onStageClickProp?.();
+      }, [v.onStageClick, onStageClickProp]);
 
       const {
         graphData,
@@ -627,6 +640,15 @@ const GraphViewer = memo(
             physicsTriggerRef.current.contains(target)
           )
             return;
+          // A click on the graph canvas should ONLY dismiss the panel — not
+          // select or deselect a node. The renderer starts every click from
+          // its own `pointerdown`, so swallowing this capture-phase event
+          // before it reaches the canvas leaves the renderer's `pointerDown`
+          // false and the following `pointerup` a no-op. Other outside clicks
+          // (toolbar buttons, pills) still fall through and behave normally.
+          if (target.closest('canvas')) {
+            e.stopPropagation();
+          }
           setShowPhysicsPanel(false);
         };
         document.addEventListener('pointerdown', onPointerDown, true);
@@ -1053,7 +1075,7 @@ const GraphViewer = memo(
             communityData={communityData}
             onNodeClick={v.onNodeClick}
             onEdgeClick={v.onLinkClick}
-            onStageClick={v.onStageClick}
+            onStageClick={handleStageClick}
             onNodeHover={onNodeHover}
             labelsVisible={v.settings.labelsVisible}
             edgesEnabled={effectiveEdgesVisible}
@@ -1083,6 +1105,7 @@ const GraphViewer = memo(
               presets={GRAPH_PRESETS}
               activePresetId={activePresetId}
               onSelectPreset={handleSelectPreset}
+              rightInset={rightPanelInset}
             />
           )}
 

--- a/ui/src/appComponents/ViewPresetBar.tsx
+++ b/ui/src/appComponents/ViewPresetBar.tsx
@@ -61,9 +61,13 @@ export default function ViewPresetBar({
   const measureRef = useRef<() => void>(() => {});
   // `measure` is created once (in the mount effect) but must read the LATEST
   // inset — a right panel opening/closing re-renders this component, and the
-  // per-render effect below re-runs `measure`, which reads this ref.
+  // per-render effect below re-runs `measure` (via rAF, after this ref syncs),
+  // which reads this ref. Written in an effect (not during render) so measure()
+  // still sees the current value on the next scheduled pass.
   const rightInsetRef = useRef(rightInset);
-  rightInsetRef.current = rightInset;
+  useEffect(() => {
+    rightInsetRef.current = rightInset;
+  }, [rightInset]);
 
   useEffect(() => {
     const host = barRef.current?.parentElement;

--- a/ui/src/appComponents/ViewPresetBar.tsx
+++ b/ui/src/appComponents/ViewPresetBar.tsx
@@ -23,6 +23,11 @@ interface ViewPresetBarProps {
   /** Currently-applied preset id, or null/'custom' when hand-tweaked. */
   activePresetId: string | null;
   onSelectPreset: (id: string) => void;
+  /** Width (px) of an open right-hand overlay panel (chat / help). The graph
+   *  viewport is full-width and these panels float over its right edge, so the
+   *  bar must keep this much clearance from the host's right edge or it lands
+   *  UNDER the panel (the preset chips covering the chat header). 0 when none. */
+  rightInset?: number;
 }
 
 /** Shape/placement ladder, compacted by MEASURED proximity, not by fixed
@@ -45,6 +50,7 @@ export default function ViewPresetBar({
   presets,
   activePresetId,
   onSelectPreset,
+  rightInset = 0,
 }: ViewPresetBarProps) {
   const barRef = useRef<HTMLDivElement>(null);
   const [anchor, setAnchor] = useState<Anchor>({
@@ -53,6 +59,11 @@ export default function ViewPresetBar({
     right: 12,
   });
   const measureRef = useRef<() => void>(() => {});
+  // `measure` is created once (in the mount effect) but must read the LATEST
+  // inset — a right panel opening/closing re-renders this component, and the
+  // per-render effect below re-runs `measure`, which reads this ref.
+  const rightInsetRef = useRef(rightInset);
+  rightInsetRef.current = rightInset;
 
   useEffect(() => {
     const host = barRef.current?.parentElement;
@@ -102,11 +113,12 @@ export default function ViewPresetBar({
         }
       }
 
-      // The bar is positioned inside the HOST (graph viewport), which can be
-      // narrower than the window-spanning header when a side panel is open —
-      // clamp the corridor's right edge to the host so the bar never lands
-      // outside (or gets clipped by) its own containing block.
-      const rightEdge = Math.min(clusterLeft, hostBox.right - 12);
+      // The bar is positioned inside the HOST (graph viewport). The graph is
+      // full-width and the chat/help panels float over its right edge, so clamp
+      // the corridor's right edge to the host MINUS any open panel — otherwise
+      // the bar lands under the panel (the chips covering the chat header).
+      const inset = rightInsetRef.current;
+      const rightEdge = Math.min(clusterLeft, hostBox.right - inset - 12);
 
       // Nearest header content LEFT of the corridor (typically the
       // node/edge counts badge) — the element the user watches the bar
@@ -138,11 +150,12 @@ export default function ViewPresetBar({
         right = Math.round(hostBox.right - rightEdge + 12);
       } else if (mode === 'under') {
         top = Math.round(headerBox.height) + 8;
-        right = 12;
+        right = inset + 12;
       } else {
-        // Compact shapes hang at the corner just below the action cluster.
+        // Compact shapes hang at the corner just below the action cluster,
+        // kept clear of any open right panel so they don't cover it.
         top = Math.round(clusterBottom - hostBox.top) + 6;
-        right = 12;
+        right = inset + 12;
       }
       // Referential bail-out: measure runs per render/mutation — identical
       // values must NOT produce a new state object (render loop otherwise).

--- a/ui/src/components/config/graphLayout.ts
+++ b/ui/src/components/config/graphLayout.ts
@@ -55,6 +55,13 @@ export const EDGE_OPACITY_DEFAULT = 0.78; // normal state
 // opacity. Kept airy so the lit path reads as a soft glow, not a heavy web.
 export const EDGE_OPACITY_HIGHLIGHTED = 0.5; // when part of a selected neighborhood
 export const EDGE_OPACITY_DIMMED = 0.08; // when another node is selected
+// While a selection/highlight is active, floor the hot-edge multiplier
+// (uHotOpacity) to this so the lit neighborhood is clearly visible even on
+// presets that keep the ambient edge layer faint (Planet 15%, Onion 0%) —
+// otherwise `EDGE_OPACITY_HIGHLIGHTED × preset-opacity` is nearly invisible.
+// Rendered hot alpha ≈ EDGE_OPACITY_HIGHLIGHTED × this (≈0.4). Only raises the
+// multiplier (max with the user's slider), never lowers it.
+export const HIGHLIGHT_EDGE_OPACITY_FLOOR = 0.8;
 
 // ─── Hot-edge glow ribbon ───────────────────────────────────────────────
 // Highlighted / chat-traversal edges render as soft, curved, additively-blended

--- a/ui/src/components/pipeline/__tests__/helpers.ts
+++ b/ui/src/components/pipeline/__tests__/helpers.ts
@@ -52,6 +52,29 @@ export async function parsePython(source: string): Promise<SyntaxNode> {
   return tree.rootNode;
 }
 
+let tsParser: Parser | null = null;
+let tsxParser: Parser | null = null;
+
+export async function getTypeScriptParser(): Promise<Parser> {
+  await initTreeSitter();
+  if (!tsParser) {
+    tsParser = new Parser();
+    const buf = await readFile(getWasmPath('typescript'));
+    tsParser.setLanguage(await Language.load(buf));
+  }
+  return tsParser;
+}
+
+export async function getTsxParser(): Promise<Parser> {
+  await initTreeSitter();
+  if (!tsxParser) {
+    tsxParser = new Parser();
+    const buf = await readFile(getWasmPath('tsx'));
+    tsxParser.setLanguage(await Language.load(buf));
+  }
+  return tsxParser;
+}
+
 let phpParser: Parser | null = null;
 
 export async function getPhpParser(): Promise<Parser> {

--- a/ui/src/components/pipeline/__tests__/typescriptCalls.test.ts
+++ b/ui/src/components/pipeline/__tests__/typescriptCalls.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 OpenTrace Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { runPipeline, initParsers } from '../pipeline';
+import { MemoryStore } from '../store/memory';
+import type { GraphRelationship, PipelineEvent } from '../types';
+import { getTypeScriptParser, getTsxParser, makeRepoTree } from './helpers';
+
+beforeAll(async () => {
+  initParsers(
+    new Map([
+      ['typescript', await getTypeScriptParser()],
+      ['tsx', await getTsxParser()],
+    ]),
+  );
+});
+
+/** Collect all CALLS relationships emitted while indexing `files`. */
+function callEdges(files: Array<{ path: string; content: string }>) {
+  const store = new MemoryStore();
+  const rels: GraphRelationship[] = [];
+  const events: PipelineEvent[] = [];
+  for (const event of runPipeline(
+    { repo: makeRepoTree(files, { owner: 'o', repo: 'r' }) },
+    { cancelled: false },
+    store,
+  )) {
+    events.push(event);
+    if (event.relationships) rels.push(...event.relationships);
+  }
+  expect(events.some((e) => e.kind === 'done')).toBe(true);
+  return rels.filter((r) => r.type === 'CALLS');
+}
+
+const FOO = `export class Foo {
+  bar(): number { return 1; }
+  baz(): void { this.bar(); }
+}
+`;
+
+describe('TypeScript type-hint call resolution (Strategy 2.5)', () => {
+  it('resolves this.method(), new-instance, param-typed, and ref.current calls to the class method', () => {
+    const calls = callEdges([
+      { path: 'foo.ts', content: FOO },
+      {
+        path: 'consumer.ts',
+        content: `import { Foo } from './foo';
+export function useLocal(): void {
+  const f = new Foo();
+  f.bar();
+}
+export function useParam(f: Foo): void {
+  f.bar();
+}
+`,
+      },
+      {
+        path: 'canvas.tsx',
+        content: `import { forwardRef, useRef } from 'react';
+import { Foo } from './foo';
+export const Canvas = forwardRef<HTMLDivElement, object>((props, ref) => {
+  const fooRef = useRef<Foo | null>(null);
+  fooRef.current?.bar();
+  return null;
+});
+`,
+      },
+    ]);
+
+    // Every call above should land on Foo.bar.
+    const toBar = calls.filter((c) => c.target_id.includes('::Foo::bar'));
+    const from = (needle: string) =>
+      toBar.some((c) => c.source_id.includes(needle));
+
+    expect(from('::Foo::baz')).toBe(true); // Strategy 1 (this.) — control
+    expect(from('::useLocal')).toBe(true); // new Foo() local
+    expect(from('::useParam')).toBe(true); // param typed Foo
+    expect(from('::Canvas')).toBe(true); // useRef<Foo>().current
+  });
+
+  it('does not invent edges when the receiver type is not a known class', () => {
+    const calls = callEdges([
+      {
+        path: 'a.ts',
+        content: `export function f(x: SomeInterface): void {
+  x.doThing();
+}
+`,
+      },
+    ]);
+    expect(calls.some((c) => c.target_id.includes('doThing'))).toBe(false);
+  });
+});

--- a/ui/src/components/pipeline/__tests__/typescriptCalls.test.ts
+++ b/ui/src/components/pipeline/__tests__/typescriptCalls.test.ts
@@ -104,4 +104,45 @@ export const Canvas = forwardRef<HTMLDivElement, object>((props, ref) => {
     ]);
     expect(calls.some((c) => c.target_id.includes('doThing'))).toBe(false);
   });
+
+  it('resolves an object-field receiver via a unique class-method name (Strategy 8)', () => {
+    // `v.canvasRef.current.zoomToFit()` — the receiver type needs cross-function
+    // inference we don't do, but `zoomToFit` is a UNIQUE class method, so the
+    // fallback resolves it. `get()` is shared by two classes → stays unresolved.
+    const calls = callEdges([
+      {
+        path: 'renderer.ts',
+        content: `export class Renderer {
+  zoomToFit(): void {}
+  get(): number { return 1; }
+}
+`,
+      },
+      {
+        path: 'other.ts',
+        content: `export class Other {
+  get(): number { return 2; }
+}
+`,
+      },
+      {
+        path: 'viewer.ts',
+        content: `export function useViewer(): void {
+  const v = makeThing();
+  v.canvasRef.current.zoomToFit(); // unique method → resolves
+  v.canvasRef.current.get();       // ambiguous (2 classes) → unresolved
+}
+`,
+      },
+    ]);
+    expect(
+      calls.some(
+        (c) =>
+          c.source_id.includes('::useViewer') &&
+          c.target_id.includes('::Renderer::zoomToFit'),
+      ),
+    ).toBe(true);
+    // `get` is defined by both Renderer and Other → not unique → no edge.
+    expect(calls.some((c) => c.target_id.endsWith('::get'))).toBe(false);
+  });
 });

--- a/ui/src/components/pipeline/parser/callResolver.ts
+++ b/ui/src/components/pipeline/parser/callResolver.ts
@@ -26,6 +26,7 @@
  *   5. Constructor call → bare name matches class
  *   6. Intra-file bare call
  *   7. Cross-file bare call with unique match
+ *   8. Unresolved attribute call → unique class-method-name fallback
  */
 
 import type { CallRef, GraphRelationship } from '../types';
@@ -291,6 +292,31 @@ function resolveSingleCall(
     );
     if (crossFile.length === 1) {
       return { targetId: crossFile[0].id, confidence: 0.8 };
+    }
+  }
+
+  // Strategy 8: Unresolved attribute call → unique class-method-name fallback.
+  // The receiver couldn't be tied to a class by strategies 1–4 (e.g. it's an
+  // object field like `v.canvasRef.current` whose type would need cross-function
+  // inference we don't do). Last resort: if EXACTLY ONE class method with this
+  // exact name exists in the same language, resolve to it — unique ⇒
+  // unambiguous (mirrors Strategy 7 for bare calls). Distinctive names
+  // (zoomToFit, setAmbientMotion) resolve; common ones (get, update, render)
+  // stay unresolved because >1 class defines them. Low confidence.
+  //
+  // A class method's parentId is its class node id (`fileId::ClassName`, so it
+  // contains '::'); a top-level function/class's parentId is the bare fileId
+  // (no '::') — that check keeps this from resolving `obj.foo()` to a top-level
+  // function foo.
+  if (ref.kind === 'attribute') {
+    const methods = (nameRegistry.get(ref.name) ?? []).filter(
+      (c) =>
+        c.kind === 'function' &&
+        c.parentId.includes('::') &&
+        c.language === callerNode.language,
+    );
+    if (methods.length === 1) {
+      return { targetId: methods[0].id, confidence: 0.5 };
     }
   }
 

--- a/ui/src/components/pipeline/parser/extractors/typescript.ts
+++ b/ui/src/components/pipeline/parser/extractors/typescript.ts
@@ -32,6 +32,34 @@ const FUNCTION_TYPES = new Set([
 ]);
 const METHOD_TYPES = new Set(['method_definition', 'public_field_definition']);
 
+/** Higher-order component / wrapper calls whose function argument IS the real
+ *  component body. Without unwrapping these, `const C = forwardRef((p) => {…})`
+ *  extracts NO symbol — so every call the component makes (e.g. a React ref's
+ *  `rendererRef.current.foo()`) has no caller and never becomes a CALLS edge.
+ *  Handles nesting like `memo(forwardRef(fn))`. */
+const HOC_WRAPPERS = new Set([
+  'forwardRef',
+  'memo',
+  'React.forwardRef',
+  'React.memo',
+  'observer',
+]);
+
+/** React ref-wrapper type names: `useRef<T>()` / a var typed `RefObject<T>`
+ *  holds T on its `.current`, so calls read as `<var>.current.method()`. */
+const REF_WRAPPER_TYPES = new Set([
+  'RefObject',
+  'MutableRefObject',
+  'Ref',
+  'LegacyRef',
+]);
+const REF_FACTORY_CALLS = new Set([
+  'useRef',
+  'createRef',
+  'React.useRef',
+  'React.createRef',
+]);
+
 /** Extract a JSDoc/TSDoc comment from the preceding sibling of an AST node.
  *  Checks both the node itself and its parent (for `export_statement` wrapping). */
 function extractJSDoc(node: SyntaxNode): string | undefined {
@@ -176,7 +204,7 @@ function extractFunction(node: SyntaxNode): CodeSymbol | null {
     calls,
     receiverVar: null,
     receiverType: null,
-    paramTypes: null,
+    paramTypes: collectVarTypes(paramsNode, bodyNode),
     docs,
     typeSignature,
     returnType,
@@ -203,7 +231,7 @@ function extractMethod(node: SyntaxNode): CodeSymbol | null {
     calls,
     receiverVar: null,
     receiverType: null,
-    paramTypes: null,
+    paramTypes: collectVarTypes(paramsNode, bodyNode),
     docs,
     typeSignature,
     returnType,
@@ -227,6 +255,15 @@ function extractLexicalDeclaration(node: SyntaxNode): CodeSymbol[] {
       } else if (valueNode.type === 'class') {
         const sym = extractClassExpression(name, node, valueNode);
         if (sym) symbols.push(sym);
+      } else {
+        // HOC-wrapped component: `const C = forwardRef((p, r) => {…})` /
+        // `memo(forwardRef(fn))`. Unwrap to the inner function so the
+        // component's body (and every call it makes) is extracted.
+        const hocFn = unwrapHocFunction(valueNode);
+        if (hocFn) {
+          const sym = extractArrowFunction(name, node, hocFn);
+          if (sym) symbols.push(sym);
+        }
       }
     }
   }
@@ -255,7 +292,7 @@ function extractArrowFunction(
     calls,
     receiverVar: null,
     receiverType: null,
-    paramTypes: null,
+    paramTypes: collectVarTypes(paramsNode, bodyNode),
     docs,
     typeSignature,
     returnType,
@@ -361,4 +398,138 @@ function collectCalls(node: SyntaxNode): CallRef[] {
     calls.push(...collectCalls(child));
   }
   return calls;
+}
+
+/** Extract a bare class name from a type expression, or null if it isn't a
+ *  usable class-like name. Handles `: T` annotations, `A | null` unions,
+ *  `Foo<Bar>` generics, and qualified `a.b.C` names. PascalCase-gated to skip
+ *  primitives (`string`, `number`); the resolver additionally requires the name
+ *  to be a known class, so an interface/type-alias name here resolves to
+ *  nothing rather than a wrong edge. */
+function classNameFromType(raw: string): string | null {
+  const s = raw.replace(/^\s*:\s*/, '').trim();
+  const member = s
+    .split('|')
+    .map((p) => p.trim())
+    .find((p) => p && p !== 'null' && p !== 'undefined');
+  if (!member) return null;
+  // Strip generic args, then take the leaf of a qualified name.
+  const base = member.replace(/<.*$/, '').trim().split('.').pop();
+  if (!base) return null;
+  return /^[A-Z]/.test(base) ? base : null;
+}
+
+/** If a type expression is a React ref wrapper (`RefObject<Foo>`), return the
+ *  inner class name — the type held on `.current`. */
+function refWrapperInner(raw: string): string | null {
+  const s = raw.replace(/^\s*:\s*/, '').trim();
+  const m = s.match(/^([A-Za-z_$][\w$]*)\s*<(.+)>$/);
+  if (!m || !REF_WRAPPER_TYPES.has(m[1])) return null;
+  return classNameFromType(m[2]);
+}
+
+/** If a value is a ref factory call (`useRef<Foo>(…)`), return the inner class
+ *  name so the caller keys the type on `<var>.current`. */
+function refFactoryInner(valueNode: SyntaxNode | null): string | null {
+  if (!valueNode || valueNode.type !== 'call_expression') return null;
+  const fn = valueNode.childForFieldName('function');
+  if (!fn || !REF_FACTORY_CALLS.has(fn.text)) return null;
+  const typeArgs = valueNode.childForFieldName('type_arguments');
+  if (!typeArgs) return null;
+  for (const t of typeArgs.namedChildren) {
+    const inner = classNameFromType(t.text);
+    if (inner) return inner;
+  }
+  return null;
+}
+
+/** Recursively map local `const`/`let` declarations to class types within a
+ *  function body. Keys are the exact receiver text a call site produces, so a
+ *  ref keys on `${name}.current` and a plain instance on `${name}`. */
+function collectLocalVarTypes(
+  node: SyntaxNode,
+  map: Record<string, string>,
+): void {
+  if (node.type === 'variable_declarator') {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode && nameNode.type === 'identifier') {
+      const name = nameNode.text;
+      const typeNode = node.childForFieldName('type');
+      const valueNode = node.childForFieldName('value');
+      // 1. Ref: `useRef<Foo>(…)` or a var typed `RefObject<Foo>` → foo on .current
+      const refInner =
+        refFactoryInner(valueNode) ??
+        (typeNode ? refWrapperInner(typeNode.text) : null);
+      if (refInner) {
+        map[`${name}.current`] = refInner;
+      } else if (typeNode) {
+        // 2. Annotated instance: `const r: Foo = …`
+        const t = classNameFromType(typeNode.text);
+        if (t) map[name] = t;
+      } else if (valueNode && valueNode.type === 'new_expression') {
+        // 3. Constructor: `const r = new Foo()`
+        const ctor = valueNode.childForFieldName('constructor');
+        if (ctor) {
+          const t = classNameFromType(ctor.text);
+          if (t) map[name] = t;
+        }
+      }
+    }
+  }
+  for (const child of node.children) collectLocalVarTypes(child, map);
+}
+
+/** Build a variable → class-type map for a function scope, powering the
+ *  resolver's type-hint strategy (Strategy 2.5) so `r.method()` and
+ *  `ref.current.method()` resolve to the class's methods. Captures typed
+ *  params, `new Foo()`/annotated locals, and React refs. Returns null when
+ *  empty so the symbol keeps `paramTypes: null` unless something was found. */
+function collectVarTypes(
+  paramsNode: SyntaxNode | null,
+  bodyNode: SyntaxNode | null,
+): Record<string, string> | null {
+  const map: Record<string, string> = {};
+
+  if (paramsNode) {
+    for (const child of paramsNode.namedChildren) {
+      if (
+        child.type === 'required_parameter' ||
+        child.type === 'optional_parameter'
+      ) {
+        const nameNode = child.childForFieldName('pattern');
+        const typeNode = child.childForFieldName('type');
+        if (nameNode && nameNode.type === 'identifier' && typeNode) {
+          const refInner = refWrapperInner(typeNode.text);
+          if (refInner) map[`${nameNode.text}.current`] = refInner;
+          else {
+            const t = classNameFromType(typeNode.text);
+            if (t) map[nameNode.text] = t;
+          }
+        }
+      }
+    }
+  }
+
+  if (bodyNode) collectLocalVarTypes(bodyNode, map);
+
+  return Object.keys(map).length > 0 ? map : null;
+}
+
+/** Unwrap HOC wrapper calls (`forwardRef`, `memo`, incl. nesting) to the inner
+ *  arrow/function that is the real component body, or null if `node` isn't such
+ *  a wrapper. */
+function unwrapHocFunction(node: SyntaxNode): SyntaxNode | null {
+  if (node.type === 'arrow_function' || node.type === 'function_expression') {
+    return node;
+  }
+  if (node.type !== 'call_expression') return null;
+  const fn = node.childForFieldName('function');
+  if (!fn || !HOC_WRAPPERS.has(fn.text)) return null;
+  const args = node.childForFieldName('arguments');
+  if (!args) return null;
+  for (const arg of args.namedChildren) {
+    const inner = unwrapHocFunction(arg);
+    if (inner) return inner;
+  }
+  return null;
 }

--- a/ui/src/components/three/ThreeRenderer.ts
+++ b/ui/src/components/three/ThreeRenderer.ts
@@ -81,6 +81,7 @@ import {
   EDGE_OPACITY_DEFAULT,
   EDGE_OPACITY_HIGHLIGHTED,
   EDGE_OPACITY_DIMMED,
+  HIGHLIGHT_EDGE_OPACITY_FLOOR,
   HOT_EDGE_CURVE_SEGMENTS,
   HOT_EDGE_SAG_FACTOR,
   HOT_EDGE_HALF_WIDTH,
@@ -3146,7 +3147,20 @@ export class ThreeRenderer {
    *  controls the selected node's edges too. 1.0 = default behavior. */
   setEdgeOpacity(multiplier: number): void {
     this.edgeOpacityMultiplier = Math.max(0, Math.min(2, multiplier));
-    const hot = this.edgeOpacityMultiplier;
+    this.applyHotEdgeOpacity();
+    this.requestRender();
+  }
+  private edgeOpacityMultiplier = 1;
+
+  /** Push the hot-edge multiplier (uHotOpacity) to every edge material. While a
+   *  selection/highlight is active it's floored to HIGHLIGHT_EDGE_OPACITY_FLOOR
+   *  so the lit neighborhood stands out even on faint-edge presets (Planet 15%,
+   *  Onion 0%); otherwise it tracks the user's slider. Call whenever the slider
+   *  OR hasHighlight changes. */
+  private applyHotEdgeOpacity(): void {
+    const hot = this.hasHighlight
+      ? Math.max(this.edgeOpacityMultiplier, HIGHLIGHT_EDGE_OPACITY_FLOOR)
+      : this.edgeOpacityMultiplier;
     if (this.edgeMaterial) this.edgeMaterial.uniforms.uHotOpacity.value = hot;
     if (this.superEdgeMaterial)
       this.superEdgeMaterial.uniforms.uHotOpacity.value = hot;
@@ -3155,9 +3169,7 @@ export class ThreeRenderer {
         this.curvedEdgeMaterial
           .uniforms as unknown as CurvedEdgeMaterialUniforms
       ).uHotOpacity.value = hot;
-    this.requestRender();
   }
-  private edgeOpacityMultiplier = 1;
 
   zoomToFit(duration = 300): void {
     if (this.mode3d) {
@@ -3929,6 +3941,7 @@ export class ThreeRenderer {
     this.highlightNodes = highlightNodes;
     this.highlightLinks = highlightLinks;
     this.hasHighlight = this.computeHasHighlight();
+    this.applyHotEdgeOpacity();
     this.applyNodeStates();
     this.updateEdgeAlpha();
     this.runNodeLabelCull();
@@ -6875,6 +6888,7 @@ export class ThreeRenderer {
    *  clears. */
   private refreshHotState(): void {
     this.hasHighlight = this.computeHasHighlight();
+    this.applyHotEdgeOpacity();
     this.applyNodeStates();
     this.updateEdgeAlpha();
     this.fillEdgeColors();

--- a/ui/src/components/three/ThreeRenderer.ts
+++ b/ui/src/components/three/ThreeRenderer.ts
@@ -225,6 +225,18 @@ interface InteractionCallbacks {
 
 const CLICK_THRESHOLD = 5; // px — distinguish click from drag
 
+// A 3D reframe sets the orbit distance from the visible-node bounds. If those
+// bounds are momentarily DEGENERATE — many nodes reported visible yet crammed
+// into ~zero extent (a fresh zero-initialised posArray, or a reseed before the
+// layout has spread) — the distance floors out and the camera lands INSIDE the
+// real graph: the whole graph appears to teleport/blow up. These thresholds
+// detect that collapsed state so reframes can skip/defer until the layout has
+// real extent. A radius at/near computeBounds3D's 0.5 floor means every node is
+// within ~`COLLAPSED_BOUNDS_RADIUS` units — implausible for this many real nodes
+// in a layout that spreads them hundreds of units apart, i.e. transient.
+const COLLAPSED_BOUNDS_RADIUS = 1; // world units — radius at/near the floor
+const COLLAPSED_BOUNDS_MIN_NODES = 4; // this many coincident visibles ⇒ collapsed
+
 // The label gate is PROXIMITY-ONLY: a full-graph overview shows NO labels and
 // names appear only as the camera closes in on nodes, regardless of how big
 // the "Zoom scaling" slider renders them (cranking node size must not flood
@@ -3149,7 +3161,11 @@ export class ThreeRenderer {
 
   zoomToFit(duration = 300): void {
     if (this.mode3d) {
-      this.reframe3D(this.computeBounds3D());
+      const b = this.computeBounds3D();
+      // Don't reframe off collapsed bounds (mid data-swap / reseed) — it would
+      // plant the camera inside the graph. Skip; a later call reframes cleanly.
+      if (this.bounds3DCollapsed(b.radius)) return;
+      this.reframe3D(b);
       return;
     }
     const target = this.computeFitTarget();
@@ -5073,6 +5089,29 @@ export class ThreeRenderer {
     return { center, radius };
   }
 
+  /** True when the 3D bounds are transiently DEGENERATE — several nodes report
+   *  visible yet occupy essentially no extent (radius at/near computeBounds3D's
+   *  floor). This happens for a beat after a data swap (zero-initialised
+   *  posArray) or a layout reseed, before real positions stream in. Reframing
+   *  from such bounds floors the orbit distance and drops the camera INSIDE the
+   *  real graph — the "whole graph teleports" bug. Callers skip/defer instead.
+   *  A genuinely tiny graph (1–3 nodes) is NOT flagged: it needs
+   *  COLLAPSED_BOUNDS_MIN_NODES coincident visibles, which only occurs when
+   *  positions haven't spread yet. */
+  private bounds3DCollapsed(radius: number): boolean {
+    if (radius > COLLAPSED_BOUNDS_RADIUS) return false;
+    let visible = 0;
+    for (let i = 0; i < this.nodeArray.length; i++) {
+      if (
+        this.nodeArray[i].visible &&
+        ++visible >= COLLAPSED_BOUNDS_MIN_NODES
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** Smooth 3D camera follow for live-build: eases the orbit distance + target
    *  toward the LAYOUT-TARGET bounds (stable — not the animating render
    *  positions, which oscillate from the fly-out pop and would make the camera
@@ -5195,6 +5234,16 @@ export class ThreeRenderer {
       return false;
     }
     const b = this.computeBounds3D();
+    // Bounds collapsed for a beat (reseed / data swap before positions stream
+    // in): easing toward them would floor the distance and drop the camera
+    // inside the graph. Hold the current camera and keep the fit alive — the
+    // next frame with real extent resumes the ease. Reset the smoother so it
+    // re-seeds from the real radius rather than the collapsed one.
+    if (this.bounds3DCollapsed(b.radius)) {
+      f.init = false;
+      f.stableFrames = 0;
+      return true;
+    }
     // Low-pass BOTH the radius and the center: during the settle the positions
     // jitter frame to frame (a single flung node spikes the extent, and the
     // min/max midpoint swings as different nodes become the extremes), so

--- a/ui/src/config/graphSettingDefaults.ts
+++ b/ui/src/config/graphSettingDefaults.ts
@@ -69,9 +69,9 @@ export const GRAPH_SETTING_DEFAULTS = {
   labelScale: 100,
   edgeOpacity: 100,
   communitiesEnabled: true,
-  // Gentle perpetual node drift after the layout settles. On by default; users
-  // can disable it (and it auto-eases on very large graphs).
-  ambientMotion: true,
+  // Gentle perpetual node drift after the layout settles. Off by default; users
+  // can enable it (and it auto-eases on very large graphs).
+  ambientMotion: false,
 };
 
 /** Shape of {@link GRAPH_SETTING_DEFAULTS}. */

--- a/ui/src/hooks/useGraphData.ts
+++ b/ui/src/hooks/useGraphData.ts
@@ -193,6 +193,13 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
   // Edges whose endpoints haven't both arrived — held back (a dangling edge
   // crashes d3-force-3d), promoted once both ends exist.
   const liveDeferredLinks = useRef<GraphLink[]>([]);
+  // Node ids actually REVEALED into graphData so far. Nodes are metered (a chunk
+  // per flush) but links must not outrun them: the renderer's appendLiveEdges
+  // DROPS (no retry) any edge whose endpoint node isn't in yet, so a link is
+  // only flushed once BOTH endpoints have been revealed — otherwise most
+  // symbol-DEFINES (which stream interleaved with their nodes) are lost while
+  // CALLS (emitted after every node is revealed) survive.
+  const liveRevealedNodes = useRef<Set<string>>(new Set());
   const liveFlushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const flushLive = useCallback(() => {
@@ -210,7 +217,20 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
       Math.floor(liveSeenNodes.current.size * 0.05),
     );
     const ns = pn.splice(0, chunk);
-    const ls = pl.splice(0, pl.length);
+    const revealed = liveRevealedNodes.current;
+    for (const n of ns) revealed.add(n.id);
+    // Only flush links whose BOTH endpoints are already revealed. Nodes are
+    // metered, but the renderer's appendLiveEdges drops (without retry) any edge
+    // whose endpoint node isn't in yet — so links pointing at still-queued nodes
+    // must wait for a later flush (or the unmetered endLiveStream drain) rather
+    // than being flushed now and silently lost.
+    const ls: GraphLink[] = [];
+    const stillWaiting: GraphLink[] = [];
+    for (const l of pl) {
+      if (revealed.has(l.source) && revealed.has(l.target)) ls.push(l);
+      else stillWaiting.push(l);
+    }
+    livePendLinks.current = stillWaiting;
     setGraphData((prev) => ({
       nodes: ns.length ? prev.nodes.concat(ns) : prev.nodes,
       links: ls.length ? prev.links.concat(ls) : prev.links,
@@ -223,7 +243,10 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
     // small graphs stay a fine 70ms wave; huge ones (Grafana) flush ~3×/s so
     // the main thread stays free for parsing. (The chunk grows too, so the
     // graph still keeps up — just in fewer, larger, cheaper-per-node batches.)
-    if (pn.length && !liveFlushTimer.current) {
+    if (
+      (pn.length || livePendLinks.current.length) &&
+      !liveFlushTimer.current
+    ) {
       const interval = Math.min(
         350,
         LIVE_FLUSH_MS + liveSeenNodes.current.size * 0.005,
@@ -244,6 +267,7 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
     livePendNodes.current = [];
     livePendLinks.current = [];
     liveDeferredLinks.current = [];
+    liveRevealedNodes.current = new Set();
     setError(null);
     setRefreshError(null);
     setGraphData({ nodes: [], links: [] });
@@ -386,6 +410,7 @@ export function useGraphData(onGraphLoaded?: () => void): GraphDataState {
       liveDeferredLinks.current = [];
       liveSeenNodes.current = new Set();
       liveSeenLinks.current = new Set();
+      liveRevealedNodes.current = new Set();
       setIsStreaming(false);
     },
     [store],


### PR DESCRIPTION
## Summary

Fixes a cluster of graph-viewer bugs and — more substantially — makes the graph actually render edges for class / file / method nodes, which previously appeared unconnected. Two root causes for the missing edges: the browser TS extractor didn't resolve calls made through variables/refs (and skipped HOC-wrapped components entirely), and the live-build stream dropped edges whose endpoint nodes hadn't been revealed yet.

Verified by re-indexing opentrace: rendered edges went from 3,347 → 9,225, and the ThreeRenderer class node from 0 → 376 edges.

## Changes

**Edge coverage**
- TS extractor: resolve `x.method()` / `ref.current.method()` via a variable→type map (typed params, `new X()`, `useRef<X>()`), and unwrap `forwardRef`/`memo` (incl. nesting) so HOC-wrapped components — and every call they make — are extracted. Resolution stays safe: the target must be a known class, same-language-guarded. New cross-validation test.
- Call resolver Strategy 8: when an attribute call's receiver can't be typed (e.g. an object field like `v.canvasRef.current.zoomToFit()`, which would need cross-function inference), fall back to a class method with that exact name **only when exactly one class defines it** — unique ⇒ unambiguous (mirrors the bare-call Strategy 7). Distinctive names resolve; common ones (`get`, `update`) stay unresolved.
- Live-build: only flush an edge once **both** endpoints have been revealed into the graph (nodes are metered, but links were flushed all at once and the renderer drops edges with not-yet-present endpoints without retry). This silently discarded most `DEFINES` and all `IMPORTS`/`DEPENDS_ON` edges.

**Viewer interaction / rendering**
- Ambient motion off by default.
- Clicking empty canvas clears chat-driven highlights (no longer need to close/restart the chat to deselect).
- With the Display (physics) panel open, a click on the graph only dismisses it — no node select/deselect.
- Fix 3D "graph teleports while rotating": guard reframes (`zoomToFit`/`stepFit3D`) against transiently-degenerate bounds that floored the orbit distance and dropped the camera inside the graph.
- Keep the view-preset chips clear of an open right-hand panel (they were rendering over the chat header on a full-width graph).
- Boost highlighted-edge opacity while a selection is active so the lit neighborhood is visible on faint-edge presets (Planet/Onion).

> Note: extractor changes are the TS/browser pipeline only; the Python agent mirror is a follow-up.