### PR TITLE
feat: add java support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ Full details: [OpenCode Plugin reference](https://opentrace.github.io/opentrace/
 
 ## Supported Languages
 
-**Full extraction** (symbols + calls + imports): Python, TypeScript/JavaScript, Go
-**Structural extraction** (symbols only): Rust, Java, Kotlin, C#, C/C++, Ruby, Swift
+**CLI agent full extraction** (symbols + calls + imports): Python, TypeScript/JavaScript, Go, Java
+**Browser indexer full extraction** (symbols + calls + imports): Python, TypeScript/JavaScript, Go
+**Browser indexer structural extraction** (symbols only): Rust, Java, Kotlin, C#, C/C++, Ruby, Swift
 **Indexed as file nodes**: JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash
 
 Full language matrix: [Supported Languages](https://opentrace.github.io/opentrace/reference/languages/).

--- a/agent/README.md
+++ b/agent/README.md
@@ -77,11 +77,11 @@ Add OpenTrace to Claude Code as a plugin, or configure it manually in your proje
 
 ## Supported Languages
 
-| Full extraction (symbols + calls + imports) | Structural extraction (symbols only)       |
-| ------------------------------------------- | ------------------------------------------ |
-| Python, TypeScript/JavaScript, Go           | Rust, Java, Kotlin, C#, C/C++, Ruby, Swift |
+The CLI agent performs full extraction (symbols, calls, and imports) for
+Python, TypeScript/JavaScript, Go, and Java.
 
-Config and data files (JSON, YAML, TOML, Protobuf, SQL, GraphQL, Bash) are indexed as file nodes.
+Other recognized source, config, and data files are indexed as file nodes
+without symbol extraction.
 
 ## CLI Reference
 

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "tree-sitter-python",
     "tree-sitter-typescript",
     "tree-sitter-go",
+    "tree-sitter-java",
     "click>=8.0",
     "mcp>=1.0",
     "real-ladybug>=0.13",

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -265,10 +265,29 @@ def _clean_stale_staging(staging_db: str) -> None:
 
 
 def _seed_staging_from_live(db_path: str, staging_db: str) -> None:
-    """Clone live DB + WAL into staging so a new index appends rather than replaces."""
+    """Clone live DB + WAL into staging so a new index appends rather than replaces.
+
+    Forces a WAL checkpoint on the live DB first so the copy captures a
+    self-contained snapshot.  Without this, a large WAL accumulated from
+    prior writes would be duplicated into the staging file, doubling the
+    on-disk footprint and seeding the staging DB with dead pages that
+    LadybugDB never reclaims.
+    """
     live = Path(db_path)
     if not live.exists():
         return
+
+    # Checkpoint the live DB so the WAL is folded into the main file
+    # before we byte-copy it.  Opened read_only=False briefly just for
+    # the CHECKPOINT command; the exclusive index lock is already held.
+    from opentrace_agent.store import GraphStore
+
+    try:
+        with GraphStore(db_path) as gs:
+            gs.checkpoint()
+    except Exception as exc:
+        # Non-fatal: the copy still works, just with a potentially large WAL.
+        click.echo(f"Note: pre-copy checkpoint skipped ({exc})", err=True)
 
     shutil.copy2(live, staging_db)
     live_wal = Path(db_path + ".wal")
@@ -353,6 +372,148 @@ def _swap_staging_into_place(staging_db: str, db_path: str) -> None:
         _safe_unlink(live_wal, context="post-rename cleanup")
 
 
+def _do_index(
+    *,
+    staging_db: str,
+    source_path: Path,
+    repo_id: str,
+    batch_size: int,
+    verbose: bool,
+    extra_metadata: dict[str, object] | None,
+    on_event: "Callable[[object], None] | None",
+    GraphStore,
+    GraphStoreAdapter,
+    PipelineInput,
+    run_pipeline,
+) -> float:
+    """Core indexing logic: open staging, run pipeline, flush, checkpoint."""
+    with GraphStore(staging_db) as graph_store:
+        store = GraphStoreAdapter(graph_store, batch_size=batch_size)
+
+        click.echo(f"Indexing {source_path} ...")
+        t0 = time.monotonic()
+
+        inp = PipelineInput(path=str(source_path), repo_id=repo_id)
+
+        last_result = None
+        for event in run_pipeline(inp, store=store):
+            _print_event(event, verbose)
+            if getattr(event, "result", None) is not None:
+                last_result = event.result
+            if on_event is not None:
+                try:
+                    on_event(event)
+                except Exception:
+                    logging.getLogger(__name__).debug("on_event callback raised; ignoring", exc_info=True)
+
+        elapsed = time.monotonic() - t0
+
+        metadata = _collect_metadata(source_path, repo_id, elapsed, last_result)
+        if extra_metadata:
+            metadata.update(extra_metadata)
+        graph_store.save_metadata(metadata)
+
+        store.flush()
+
+        # Checkpoint the staging DB before the atomic swap so the
+        # WAL is folded into the main file.  This keeps the swapped-
+        # in DB compact and avoids carrying a bloated WAL sidecar
+        # that would be byte-copied again on the *next* index run.
+        graph_store.checkpoint()
+
+    return elapsed
+
+
+def _is_pk_collision(exc: Exception) -> bool:
+    """Return True if *exc* is a LadybugDB duplicate-primary-key error."""
+    msg = str(exc).lower()
+    return "primary key" in msg and ("duplicat" in msg or "uniqueness constraint" in msg)
+
+
+def _index_into_staging(
+    *,
+    staging_db: str,
+    db_path: str,
+    source_path: Path,
+    repo_id: str,
+    batch_size: int,
+    verbose: bool,
+    extra_metadata: dict[str, object] | None,
+    on_event: "Callable[[object], None] | None",
+    GraphStore,
+    GraphStoreAdapter,
+    PipelineInput,
+    run_pipeline,
+) -> float:
+    """Seed staging from live, delete old rows, index, checkpoint.
+
+    If the import hits a LadybugDB primary-key collision (stale internal
+    row-ID metadata baked into the DB file), discard the corrupted staging
+    copy and retry into a **fresh empty** staging DB.  The live DB is left
+    untouched so other repos' data is preserved; they will be re-seeded
+    from the live DB on their next individual index run.
+    """
+    _seed_staging_from_live(db_path, staging_db)
+
+    # Wipe this repo's rows so the bulk-import path starts clean.
+    with GraphStore(staging_db) as graph_store:
+        deleted = graph_store.delete_repo(repo_id)
+        # Flush the WAL after the bulk delete so that freed pages
+        # are consolidated before the connection closes.  This
+        # also prevents the subsequent fresh connection from
+        # seeing stale internal primary-key metadata.
+        graph_store.checkpoint()
+    if deleted.get("nodes_deleted"):
+        click.echo(f"Re-index: cleared {deleted['nodes_deleted']} existing nodes for '{repo_id}'")
+
+    try:
+        return _do_index(
+            staging_db=staging_db,
+            source_path=source_path,
+            repo_id=repo_id,
+            batch_size=batch_size,
+            verbose=verbose,
+            extra_metadata=extra_metadata,
+            on_event=on_event,
+            GraphStore=GraphStore,
+            GraphStoreAdapter=GraphStoreAdapter,
+            PipelineInput=PipelineInput,
+            run_pipeline=run_pipeline,
+        )
+    except RuntimeError as exc:
+        if not _is_pk_collision(exc):
+            raise
+
+    # ------------------------------------------------------------------
+    # Retry: the live DB has corrupted internal primary-key state that
+    # survived the delete_repo + checkpoint + fresh-connection sequence.
+    # Discard the tainted staging copy and re-index into a blank DB.
+    # Other repos will be absent from this staging file, but the live DB
+    # is untouched — subsequent index runs for those repos will re-seed
+    # their data from the live copy.
+    # ------------------------------------------------------------------
+    click.echo(
+        "Primary-key collision detected in seeded staging DB; retrying with a fresh empty database ...",
+        err=True,
+    )
+    _safe_unlink(staging_db, context="pk-collision retry")
+    _safe_unlink(staging_db + ".wal", context="pk-collision retry")
+
+    return _do_index(
+        staging_db=staging_db,
+        source_path=source_path,
+        repo_id=repo_id,
+        batch_size=batch_size,
+        verbose=verbose,
+        extra_metadata=extra_metadata,
+        on_event=on_event,
+        GraphStore=GraphStore,
+        GraphStoreAdapter=GraphStoreAdapter,
+        PipelineInput=PipelineInput,
+        run_pipeline=run_pipeline,
+    )
+
+
 def _run_indexing_pipeline(
     *,
     source_path: Path,
@@ -395,44 +556,20 @@ def _run_indexing_pipeline(
 
         click.echo(f"Opening staging database at {staging_db} ...")
         try:
-            _seed_staging_from_live(db_path, staging_db)
-
-            with GraphStore(staging_db) as graph_store:
-                # Staging is seeded from the live DB, so a re-index of an
-                # already-indexed repo would otherwise append into stale rows:
-                # the bulk-import path drops nodes whose id already exists
-                # (never updating line numbers/signatures) and deleted symbols
-                # would persist as ghosts. Wipe this repo's rows first —
-                # other repos and shared pkg:* Dependency nodes are untouched.
-                deleted = graph_store.delete_repo(repo_id)
-                if deleted.get("nodes_deleted"):
-                    click.echo(f"Re-index: cleared {deleted['nodes_deleted']} existing nodes for '{repo_id}'")
-                store = GraphStoreAdapter(graph_store, batch_size=batch_size)
-
-                click.echo(f"Indexing {source_path} ...")
-                t0 = time.monotonic()
-
-                inp = PipelineInput(path=str(source_path), repo_id=repo_id)
-
-                last_result = None
-                for event in run_pipeline(inp, store=store):
-                    _print_event(event, verbose)
-                    if getattr(event, "result", None) is not None:
-                        last_result = event.result
-                    if on_event is not None:
-                        try:
-                            on_event(event)
-                        except Exception:
-                            logging.getLogger(__name__).debug("on_event callback raised; ignoring", exc_info=True)
-
-                elapsed = time.monotonic() - t0
-
-                metadata = _collect_metadata(source_path, repo_id, elapsed, last_result)
-                if extra_metadata:
-                    metadata.update(extra_metadata)
-                graph_store.save_metadata(metadata)
-
-                store.flush()
+            elapsed = _index_into_staging(
+                staging_db=staging_db,
+                db_path=db_path,
+                source_path=source_path,
+                repo_id=repo_id,
+                batch_size=batch_size,
+                verbose=verbose,
+                extra_metadata=extra_metadata,
+                on_event=on_event,
+                GraphStore=GraphStore,
+                GraphStoreAdapter=GraphStoreAdapter,
+                PipelineInput=PipelineInput,
+                run_pipeline=run_pipeline,
+            )
 
             # Inside the try so a swap-time failure (ENOSPC, permission flip)
             # gets the same staging cleanup as a pipeline failure.

--- a/agent/src/opentrace_agent/pipeline/processing.py
+++ b/agent/src/opentrace_agent/pipeline/processing.py
@@ -38,6 +38,7 @@ from opentrace_agent.pipeline.types import (
 )
 from opentrace_agent.sources.code.extractors import (
     GoExtractor,
+    JavaExtractor,
     PythonExtractor,
     SymbolExtractor,
     TypeScriptExtractor,
@@ -49,6 +50,7 @@ from opentrace_agent.sources.code.extractors.typescript_extractor import (
 from opentrace_agent.sources.code.import_analyzer import (
     ImportResult,
     analyze_go_imports,
+    analyze_java_imports,
     analyze_python_imports,
     analyze_typescript_imports,
     build_go_dir_index,
@@ -61,6 +63,7 @@ _DEFAULT_EXTRACTORS: list[SymbolExtractor] = [
     PythonExtractor(),
     TypeScriptExtractor(),
     GoExtractor(),
+    JavaExtractor(),
 ]
 
 
@@ -299,6 +302,8 @@ def _analyze_imports_from_node(
         return analyze_go_imports(root_node, known_paths, go_module_path, dir_index=go_dir_index)  # type: ignore[arg-type]
     elif language in ("typescript", "javascript"):
         return analyze_typescript_imports(root_node, file_path, known_paths)  # type: ignore[arg-type]
+    elif language == "java":
+        return analyze_java_imports(root_node, file_path, known_paths)  # type: ignore[arg-type]
     return ImportResult()
 
 

--- a/agent/src/opentrace_agent/sources/code/extractors/__init__.py
+++ b/agent/src/opentrace_agent/sources/code/extractors/__init__.py
@@ -23,6 +23,7 @@ from opentrace_agent.sources.code.extractors.base import (
     VariableSymbol,
 )
 from opentrace_agent.sources.code.extractors.go_extractor import GoExtractor
+from opentrace_agent.sources.code.extractors.java_extractor import JavaExtractor
 from opentrace_agent.sources.code.extractors.python_extractor import PythonExtractor
 from opentrace_agent.sources.code.extractors.typescript_extractor import (
     TypeScriptExtractor,
@@ -32,6 +33,7 @@ _DEFAULT_EXTRACTORS: list[SymbolExtractor] = [
     PythonExtractor(),
     TypeScriptExtractor(),
     GoExtractor(),
+    JavaExtractor(),
 ]
 
 PARSEABLE_EXTENSIONS: frozenset[str] = frozenset().union(*(frozenset(ext.extensions) for ext in _DEFAULT_EXTRACTORS))
@@ -41,6 +43,7 @@ __all__ = [
     "CodeSymbol",
     "DerivationRef",
     "ExtractionResult",
+    "JavaExtractor",
     "PARSEABLE_EXTENSIONS",
     "PythonExtractor",
     "SymbolExtractor",

--- a/agent/src/opentrace_agent/sources/code/extractors/java_extractor.py
+++ b/agent/src/opentrace_agent/sources/code/extractors/java_extractor.py
@@ -1,0 +1,538 @@
+# Copyright 2026 OpenTrace Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Java symbol extractor using tree-sitter."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import tree_sitter
+import tree_sitter_java
+
+from opentrace_agent.sources.code.extractors.base import (
+    CallRef,
+    CodeSymbol,
+    ExtractionResult,
+    SymbolExtractor,
+)
+
+_PARSER: tree_sitter.Parser | None = None
+
+
+def _get_parser() -> tree_sitter.Parser:
+    global _PARSER
+    if _PARSER is None:
+        lang = tree_sitter.Language(tree_sitter_java.language())
+        _PARSER = tree_sitter.Parser(lang)
+    return _PARSER
+
+
+class JavaExtractor(SymbolExtractor):
+    """Extracts class/interface/enum/method symbols from Java source files."""
+
+    extensions: ClassVar[tuple[str, ...]] = (".java",)
+    language_name: ClassVar[str] = "java"
+
+    def extract(self, source_bytes: bytes) -> ExtractionResult:
+        parser = _get_parser()
+        tree = parser.parse(source_bytes)
+        symbols = _walk_program(tree.root_node)
+        return ExtractionResult(symbols=symbols, language=self.language_name, root_node=tree.root_node)
+
+
+# ---------------------------------------------------------------------------
+# Top-level walk
+# ---------------------------------------------------------------------------
+
+
+def _walk_program(node: tree_sitter.Node) -> list[CodeSymbol]:
+    """Walk the root program node and extract top-level declarations."""
+    symbols: list[CodeSymbol] = []
+    for child in node.children:
+        if child.type == "class_declaration":
+            sym = _extract_class(child)
+            if sym:
+                symbols.append(sym)
+        elif child.type == "interface_declaration":
+            sym = _extract_interface(child)
+            if sym:
+                symbols.append(sym)
+        elif child.type == "enum_declaration":
+            sym = _extract_enum(child)
+            if sym:
+                symbols.append(sym)
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# Class extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_class(node: tree_sitter.Node) -> CodeSymbol | None:
+    """Extract a class declaration with its methods, constructors, and inner types."""
+    name_node = node.child_by_field_name("name")
+    if not name_node:
+        return None
+
+    superclasses: list[str] | None = None
+    interfaces: list[str] | None = None
+
+    superclass_node = node.child_by_field_name("superclass")
+    if superclass_node:
+        names = _extract_type_names(superclass_node)
+        if names:
+            superclasses = names
+
+    interfaces_node = node.child_by_field_name("interfaces")
+    if interfaces_node:
+        names = _extract_type_names(interfaces_node)
+        if names:
+            interfaces = names
+
+    docs = _extract_javadoc(node)
+    children = _extract_class_body(node.child_by_field_name("body"))
+
+    return CodeSymbol(
+        name=name_node.text.decode(),
+        kind="class",
+        start_line=node.start_point.row + 1,
+        end_line=node.end_point.row + 1,
+        children=children,
+        superclasses=superclasses,
+        interfaces=interfaces,
+        subtype="class",
+        docs=docs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interface extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_interface(node: tree_sitter.Node) -> CodeSymbol | None:
+    """Extract an interface declaration with its method signatures."""
+    name_node = node.child_by_field_name("name")
+    if not name_node:
+        return None
+
+    docs = _extract_javadoc(node)
+
+    # Interfaces can extend other interfaces
+    interfaces: list[str] | None = None
+    extends_node = node.child_by_field_name("interfaces")
+    if extends_node:
+        names = _extract_type_names(extends_node)
+        if names:
+            interfaces = names
+
+    children: list[CodeSymbol] = []
+    body_node = node.child_by_field_name("body")
+    if body_node:
+        for child in body_node.children:
+            if child.type == "method_declaration":
+                sym = _extract_method(child)
+                if sym:
+                    children.append(sym)
+
+    return CodeSymbol(
+        name=name_node.text.decode(),
+        kind="class",
+        start_line=node.start_point.row + 1,
+        end_line=node.end_point.row + 1,
+        children=children,
+        interfaces=interfaces,
+        subtype="interface",
+        docs=docs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_enum(node: tree_sitter.Node) -> CodeSymbol | None:
+    """Extract an enum declaration with its methods."""
+    name_node = node.child_by_field_name("name")
+    if not name_node:
+        return None
+
+    docs = _extract_javadoc(node)
+    interfaces: list[str] | None = None
+
+    interfaces_node = node.child_by_field_name("interfaces")
+    if interfaces_node:
+        names = _extract_type_names(interfaces_node)
+        if names:
+            interfaces = names
+
+    children: list[CodeSymbol] = []
+    body_node = node.child_by_field_name("body")
+    if body_node:
+        for child in body_node.children:
+            if child.type == "enum_body_declarations":
+                for decl in child.children:
+                    if decl.type == "method_declaration":
+                        sym = _extract_method(decl)
+                        if sym:
+                            children.append(sym)
+                    elif decl.type == "constructor_declaration":
+                        sym = _extract_constructor(decl)
+                        if sym:
+                            children.append(sym)
+
+    return CodeSymbol(
+        name=name_node.text.decode(),
+        kind="class",
+        start_line=node.start_point.row + 1,
+        end_line=node.end_point.row + 1,
+        children=children,
+        interfaces=interfaces,
+        subtype="enum",
+        docs=docs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Class body
+# ---------------------------------------------------------------------------
+
+
+def _extract_class_body(body_node: tree_sitter.Node | None) -> list[CodeSymbol]:
+    """Extract methods, constructors, and inner types from a class body."""
+    if body_node is None:
+        return []
+
+    children: list[CodeSymbol] = []
+    for child in body_node.children:
+        if child.type == "method_declaration":
+            sym = _extract_method(child)
+            if sym:
+                children.append(sym)
+        elif child.type == "constructor_declaration":
+            sym = _extract_constructor(child)
+            if sym:
+                children.append(sym)
+        elif child.type == "class_declaration":
+            sym = _extract_class(child)
+            if sym:
+                children.append(sym)
+        elif child.type == "interface_declaration":
+            sym = _extract_interface(child)
+            if sym:
+                children.append(sym)
+        elif child.type == "enum_declaration":
+            sym = _extract_enum(child)
+            if sym:
+                children.append(sym)
+    return children
+
+
+# ---------------------------------------------------------------------------
+# Method / constructor extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_method(node: tree_sitter.Node) -> CodeSymbol | None:
+    """Extract a method declaration."""
+    name_node = node.child_by_field_name("name")
+    if not name_node:
+        return None
+
+    params_node = node.child_by_field_name("parameters")
+    signature = params_node.text.decode() if params_node else None
+    type_signature = _extract_type_signature(params_node) if params_node else "()"
+
+    body_node = node.child_by_field_name("body")
+    calls = _collect_calls(body_node) if body_node else []
+
+    docs = _extract_javadoc(node)
+    return_type = _extract_return_type(node)
+
+    return CodeSymbol(
+        name=name_node.text.decode(),
+        kind="function",
+        start_line=node.start_point.row + 1,
+        end_line=node.end_point.row + 1,
+        signature=signature,
+        calls=calls,
+        docs=docs,
+        type_signature=type_signature,
+        return_type=return_type,
+    )
+
+
+def _extract_constructor(node: tree_sitter.Node) -> CodeSymbol | None:
+    """Extract a constructor declaration (treated as a function named <init>)."""
+    name_node = node.child_by_field_name("name")
+    if not name_node:
+        return None
+
+    params_node = node.child_by_field_name("parameters")
+    signature = params_node.text.decode() if params_node else None
+    type_signature = _extract_type_signature(params_node) if params_node else "()"
+
+    body_node = node.child_by_field_name("body")
+    calls = _collect_calls(body_node) if body_node else []
+
+    docs = _extract_javadoc(node)
+
+    return CodeSymbol(
+        name=name_node.text.decode(),
+        kind="function",
+        start_line=node.start_point.row + 1,
+        end_line=node.end_point.row + 1,
+        signature=signature,
+        calls=calls,
+        docs=docs,
+        type_signature=type_signature,
+        return_type=None,  # constructors have no return type
+    )
+
+
+# ---------------------------------------------------------------------------
+# Type signature (for overload disambiguation)
+# ---------------------------------------------------------------------------
+
+
+def _extract_type_signature(params_node: tree_sitter.Node) -> str:
+    """Build a type signature from Java formal parameters, e.g. ``(String,int)``."""
+    types: list[str] = []
+    for child in params_node.children:
+        if child.type == "formal_parameter":
+            type_node = child.child_by_field_name("type")
+            if type_node:
+                types.append(_normalize_java_type(type_node))
+        elif child.type == "spread_parameter":
+            # varargs: String... args
+            type_node = child.child_by_field_name("type") or next(
+                (c for c in child.children if c.is_named and c.type != "variable_declarator"),
+                None,
+            )
+            if type_node:
+                types.append(_normalize_java_type(type_node) + "...")
+    return f"({','.join(types)})"
+
+
+def _normalize_java_type(type_node: tree_sitter.Node) -> str:
+    """Normalize a Java type node to a short type name.
+
+    Strips generics: ``List<String>`` → ``List``.
+    Strips qualifiers: ``java.util.Map`` → ``Map``.
+    Handles arrays: ``String[]`` → ``String[]``.
+    """
+    if type_node.type == "generic_type":
+        # Use the base type, ignoring type_arguments
+        for child in type_node.children:
+            if child.type == "type_identifier":
+                return child.text.decode()
+            if child.type == "scoped_type_identifier":
+                return _last_identifier(child)
+        return type_node.text.decode()
+    if type_node.type == "array_type":
+        element = type_node.child_by_field_name("element")
+        dimensions = type_node.child_by_field_name("dimensions")
+        base = _normalize_java_type(element) if element else type_node.text.decode()
+        dim_str = dimensions.text.decode() if dimensions else "[]"
+        return base + dim_str
+    if type_node.type == "scoped_type_identifier":
+        return _last_identifier(type_node)
+    if type_node.type in ("type_identifier", "integral_type", "floating_point_type", "boolean_type"):
+        return type_node.text.decode()
+    if type_node.type == "void_type":
+        return "void"
+    # Fallback: use the raw text
+    return type_node.text.decode()
+
+
+def _last_identifier(node: tree_sitter.Node) -> str:
+    """Extract the last identifier from a scoped name (``a.b.C`` → ``C``)."""
+    text = node.text.decode()
+    return text.rsplit(".", 1)[-1]
+
+
+# ---------------------------------------------------------------------------
+# Return type extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_return_type(node: tree_sitter.Node) -> str | None:
+    """Extract the return type from a Java method declaration.
+
+    The ``type`` field on a method_declaration holds the return type.
+    """
+    type_node = node.child_by_field_name("type")
+    if type_node is None:
+        return None
+    normalized = _normalize_java_type(type_node)
+    if normalized == "void":
+        return "void"
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Superclass / interface extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_type_names(node: tree_sitter.Node) -> list[str]:
+    """Extract type names from a superclass or super_interfaces node.
+
+    Handles ``extends Base``, ``implements Foo, Bar<T>``, ``extends A, B``.
+    """
+    names: list[str] = []
+    for child in node.children:
+        if child.type == "type_identifier":
+            names.append(child.text.decode())
+        elif child.type == "generic_type":
+            # Strip generics: Comparable<Foo> → Comparable
+            for sub in child.children:
+                if sub.type == "type_identifier":
+                    names.append(sub.text.decode())
+                    break
+        elif child.type == "scoped_type_identifier":
+            names.append(_last_identifier(child))
+        elif child.type == "type_list":
+            names.extend(_extract_type_names(child))
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Javadoc extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_javadoc(node: tree_sitter.Node) -> str | None:
+    """Extract a Javadoc comment (``/** ... */``) from the preceding sibling.
+
+    Also handles regular block comments (``/* ... */``) and consecutive
+    line comments (``// ...``) immediately above the declaration.
+    """
+    sibling = node.prev_named_sibling
+    if sibling is None:
+        # Inside a class body the Javadoc may be an unnamed sibling;
+        # check the parent's children list for a block_comment just before us.
+        parent = node.parent
+        if parent is not None:
+            prev = None
+            for child in parent.children:
+                if child.id == node.id:
+                    break
+                if child.is_named:
+                    prev = child
+            sibling = prev
+
+    if sibling is None:
+        return None
+
+    if sibling.type == "block_comment":
+        # Must be immediately above (no blank-line gap or intervening declarations)
+        if sibling.end_point.row + 1 < node.start_point.row:
+            # Allow at most 1 blank line between comment and declaration
+            if node.start_point.row - sibling.end_point.row > 2:
+                return None
+        return _clean_javadoc(sibling.text.decode())
+
+    # Consecutive line comments
+    if sibling.type == "line_comment":
+        lines: list[str] = []
+        expected_row = node.start_point.row - 1
+        current = sibling
+        while current is not None and current.type == "line_comment":
+            if current.end_point.row != expected_row:
+                break
+            text = current.text.decode()
+            if text.startswith("//"):
+                lines.append(text[2:].strip())
+            expected_row = current.start_point.row - 1
+            current = current.prev_named_sibling
+        if lines:
+            lines.reverse()
+            return "\n".join(lines)
+
+    return None
+
+
+def _clean_javadoc(text: str) -> str:
+    """Strip Javadoc delimiters and leading asterisks.
+
+    ``/** Foo bar. */`` → ``Foo bar.``
+    """
+    # Remove /** and */
+    if text.startswith("/**"):
+        text = text[3:]
+    elif text.startswith("/*"):
+        text = text[2:]
+    if text.endswith("*/"):
+        text = text[:-2]
+
+    lines: list[str] = []
+    for line in text.split("\n"):
+        stripped = line.strip()
+        # Remove leading * common in Javadoc
+        if stripped.startswith("*"):
+            stripped = stripped[1:].strip()
+        if stripped:
+            lines.append(stripped)
+
+    return "\n".join(lines) if lines else ""
+
+
+# ---------------------------------------------------------------------------
+# Call extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_call_from_node(node: tree_sitter.Node) -> CallRef | None:
+    """Extract a single CallRef if ``node`` is a Java method_invocation.
+
+    Returns None for non-call nodes.
+    """
+    if node.type != "method_invocation":
+        return None
+
+    name_node = node.child_by_field_name("name")
+    if not name_node:
+        return None
+
+    object_node = node.child_by_field_name("object")
+    if object_node:
+        # Dotted call: obj.method() or this.method()
+        receiver = object_node.text.decode()
+        return CallRef(
+            name=name_node.text.decode(),
+            receiver=receiver,
+            kind="attribute",
+        )
+    else:
+        # Bare call: method()
+        return CallRef(name=name_node.text.decode())
+
+
+def _collect_calls(node: tree_sitter.Node) -> list[CallRef]:
+    """Collect method call references from a tree-sitter subtree.
+
+    Captures bare calls (``foo()``), dotted calls (``obj.foo()``),
+    and chained calls (``a.b().c()``).
+    """
+    calls: list[CallRef] = []
+    own = _extract_call_from_node(node)
+    if own is not None:
+        calls.append(own)
+    for child in node.children:
+        calls.extend(_collect_calls(child))
+    return calls

--- a/agent/src/opentrace_agent/sources/code/import_analyzer.py
+++ b/agent/src/opentrace_agent/sources/code/import_analyzer.py
@@ -593,6 +593,134 @@ def _parse_ts_reexport(
             break
 
 
+def analyze_java_imports(
+    root_node: tree_sitter.Node,
+    file_path: str,
+    known_files: set[str],
+) -> ImportResult:
+    """Extract Java imports and map type aliases to repo file IDs.
+
+    Handles:
+      - ``import com.example.service.UserService`` → alias "UserService"
+      - ``import com.example.service.*`` → wildcard (maps package dir)
+      - ``import static com.example.Utils.helper`` → alias "helper"
+
+    Java uses fully-qualified class names in imports. The convention is one
+    public class per file, with the file path mirroring the package path
+    (e.g., ``com/example/service/UserService.java``). We try to resolve
+    the import to a known file using that convention.
+
+    Args:
+        root_node: Tree-sitter root node of the parsed Java file.
+        file_path: The repo-relative path of this file.
+        known_files: Set of all repo file IDs (paths) for local-import detection.
+
+    Returns:
+        ImportResult with internal (alias → file_id) and external (name → pkg ID).
+    """
+    internal: dict[str, str] = {}
+    external: dict[str, str] = {}
+
+    for child in root_node.children:
+        if child.type == "import_declaration":
+            _parse_java_import(child, known_files, internal, external)
+
+    return ImportResult(internal=internal, external=external)
+
+
+def _parse_java_import(
+    node: tree_sitter.Node,
+    known_files: set[str],
+    result: dict[str, str],
+    external: dict[str, str],
+) -> None:
+    """Parse a single Java import declaration."""
+    is_static = any(c.type == "static" for c in node.children)
+
+    # The import path is a scoped_identifier or identifier child
+    path_node = None
+    is_wildcard = False
+    for child in node.children:
+        if child.type == "scoped_identifier" or child.type == "identifier":
+            path_node = child
+        elif child.type == "asterisk":
+            is_wildcard = True
+
+    if path_node is None:
+        return
+
+    import_path = path_node.text.decode()
+
+    if is_wildcard:
+        # import com.example.service.* → try to find files under that package
+        dir_path = import_path.replace(".", "/")
+        # Try to find any known file under this directory (for the IMPORTS edge)
+        for known in known_files:
+            if known.startswith(dir_path + "/") or ("/" + dir_path + "/") in known:
+                # Map the package name as an alias to the first match
+                alias = import_path.rsplit(".", 1)[-1] if "." in import_path else import_path
+                result.setdefault(alias, known)
+                break
+        return
+
+    if is_static:
+        # import static com.example.Utils.helper → alias "helper"
+        # The last segment is a method/field name; the penultimate is the class.
+        parts = import_path.split(".")
+        if len(parts) >= 2:
+            method_name = parts[-1]
+            class_path = "/".join(parts[:-1]) + ".java"
+            resolved = _resolve_java_path(class_path, known_files)
+            if resolved:
+                result[method_name] = resolved
+            else:
+                group_id = ".".join(parts[:3]) if len(parts) >= 3 else import_path
+                external[group_id] = package_id("maven", group_id)
+        return
+
+    # Regular import: import com.example.service.UserService → alias "UserService"
+    parts = import_path.split(".")
+    alias = parts[-1]
+    file_path_candidate = "/".join(parts) + ".java"
+    resolved = _resolve_java_path(file_path_candidate, known_files)
+    if resolved:
+        result[alias] = resolved
+    else:
+        # External dependency — use the group ID (first 2-3 segments)
+        group_id = ".".join(parts[:3]) if len(parts) >= 3 else import_path
+        external[group_id] = package_id("maven", group_id)
+
+
+def _resolve_java_path(candidate: str, known_files: set[str]) -> str | None:
+    """Resolve a Java file path against known files.
+
+    Java source trees may be rooted under ``src/main/java/`` or similar
+    prefixes. Try the raw candidate first, then probe every trailing
+    path-component suffix so ``com/example/Foo.java`` matches
+    ``src/main/java/com/example/Foo.java``.
+    """
+    if candidate in known_files:
+        return candidate
+    # Try trailing suffixes: the repo file may have a src/main/java/ prefix
+    idx = 0
+    while True:
+        pos = candidate.find("/", idx)
+        if pos == -1:
+            break
+        suffix = candidate[pos + 1 :]
+        # Check if any known file ends with this suffix
+        for known in known_files:
+            if known.endswith("/" + suffix) or known == suffix:
+                return known
+        idx = pos + 1
+    # Last resort: match just the filename
+    filename = candidate.rsplit("/", 1)[-1]
+    for known in known_files:
+        if known.endswith("/" + filename):
+            return known
+    return None
+
+
 # --- path utilities ---
 
 

--- a/agent/src/opentrace_agent/store/graph_store.py
+++ b/agent/src/opentrace_agent/store/graph_store.py
@@ -338,6 +338,10 @@ class GraphStore:
         try:
             return self._import_batch_via_copy(nodes, relationships)
         except Exception as exc:
+            message = str(exc).lower()
+            if "primary key" in message and ("duplicat" in message or "uniqueness constraint" in message):
+                logger.error("Bulk COPY import hit a primary-key collision; refusing unsafe per-row MERGE fallback")
+                raise
             logger.warning(
                 "Bulk COPY import failed (%s); falling back to per-row MERGE",
                 exc,
@@ -969,6 +973,16 @@ class GraphStore:
         return {"nodes_deleted": nodes_deleted, "relationships_deleted": rels_deleted}
 
     # -- lifecycle -------------------------------------------------------
+
+    def checkpoint(self) -> None:
+        """Force a WAL checkpoint, flushing pending writes to the main DB file.
+
+        Call this after large write batches (especially after ``delete_repo``
+        followed by a bulk import) to prevent the WAL from growing unboundedly
+        and to ensure that a subsequent ``shutil.copy2`` of the DB file
+        captures a self-contained snapshot without a bloated WAL sidecar.
+        """
+        self._conn.execute("CHECKPOINT")
 
     def close(self) -> None:
         """Release connection and database resources."""

--- a/agent/tests/opentrace_agent/graph/test_graph_store.py
+++ b/agent/tests/opentrace_agent/graph/test_graph_store.py
@@ -826,6 +826,33 @@ class TestGraphStoreIdMirror:
         assert stats["total_nodes"] == 4
         assert stats["total_edges"] == 2
 
+    def test_primary_key_copy_failure_does_not_fallback_to_merge(self, store):
+        """A PK collision indicates stale/corrupt database state.
+
+        Retrying the same batch through per-row MERGE can make LadybugDB consume
+        unbounded memory and disk, so the index must fail and discard staging.
+        """
+        merge_called = False
+
+        def _copy_boom(nodes, rels):
+            raise RuntimeError(
+                "Found duplicated primary key value 177211, which violates "
+                "the uniqueness constraint of the primary key column."
+            )
+
+        def _merge_boom(nodes, rels):
+            nonlocal merge_called
+            merge_called = True
+            raise AssertionError("unsafe MERGE fallback was called")
+
+        store._import_batch_via_copy = _copy_boom
+        store._import_batch_via_merge = _merge_boom
+
+        with pytest.raises(RuntimeError, match="duplicated primary key"):
+            store.import_batch(self._NODES, [])
+
+        assert merge_called is False
+
     def test_query_fallback_when_mirror_unavailable(self, store):
         """If the mirror can't initialize, the old query path must produce
         the same rows."""

--- a/agent/tests/opentrace_agent/sources/code/extractors/test_java_extractor.py
+++ b/agent/tests/opentrace_agent/sources/code/extractors/test_java_extractor.py
@@ -1,0 +1,412 @@
+# Copyright 2026 OpenTrace Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for opentrace_agent.sources.code.extractors.java_extractor."""
+
+from __future__ import annotations
+
+from opentrace_agent.sources.code.extractors.base import CallRef
+from opentrace_agent.sources.code.extractors.java_extractor import JavaExtractor
+
+
+class TestJavaExtractor:
+    def setup_method(self):
+        self.extractor = JavaExtractor()
+
+    def test_extensions(self):
+        assert self.extractor.can_handle(".java")
+        assert not self.extractor.can_handle(".py")
+        assert not self.extractor.can_handle(".go")
+
+    def test_extract_empty_file(self):
+        source = b"package com.example;\n"
+        result = self.extractor.extract(source)
+        assert result.symbols == []
+        assert result.language == "java"
+
+    # --- class extraction ---
+
+    def test_extract_simple_class(self):
+        source = b"""\
+package com.example;
+
+public class User {
+    private String name;
+}
+"""
+        result = self.extractor.extract(source)
+        assert len(result.symbols) == 1
+        sym = result.symbols[0]
+        assert sym.name == "User"
+        assert sym.kind == "class"
+        assert sym.subtype == "class"
+        assert sym.start_line == 3
+        assert sym.end_line == 5
+
+    def test_extract_class_with_extends_and_implements(self):
+        source = b"""\
+package com.example;
+
+public class Child extends Base implements Serializable, Comparable {
+    public void process() {}
+}
+"""
+        result = self.extractor.extract(source)
+        sym = result.symbols[0]
+        assert sym.name == "Child"
+        assert sym.superclasses == ["Base"]
+        assert sym.interfaces == ["Serializable", "Comparable"]
+
+    def test_extract_class_with_generic_interfaces(self):
+        source = b"""\
+package com.example;
+
+public class Child extends Base implements Comparable<Child> {
+}
+"""
+        result = self.extractor.extract(source)
+        sym = result.symbols[0]
+        assert sym.superclasses == ["Base"]
+        assert sym.interfaces == ["Comparable"]
+
+    # --- method extraction ---
+
+    def test_extract_method(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public String process(String input, int count) {
+        return input;
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        cls = result.symbols[0]
+        assert len(cls.children) == 1
+        method = cls.children[0]
+        assert method.name == "process"
+        assert method.kind == "function"
+        assert method.return_type == "String"
+        assert method.type_signature == "(String,int)"
+        assert method.start_line == 4
+        assert method.end_line == 6
+
+    def test_extract_void_method(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    private void validate(String input) {}
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert method.name == "validate"
+        assert method.return_type == "void"
+        assert method.type_signature == "(String)"
+
+    def test_extract_method_with_generic_return(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public List<String> getItems() {
+        return null;
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert method.return_type == "List"
+        assert method.type_signature == "()"
+
+    def test_extract_method_no_params(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public void run() {}
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert method.type_signature == "()"
+
+    # --- constructor extraction ---
+
+    def test_extract_constructor(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public Service(String name, int port) {
+        this.name = name;
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        cls = result.symbols[0]
+        assert len(cls.children) == 1
+        ctor = cls.children[0]
+        assert ctor.name == "Service"
+        assert ctor.kind == "function"
+        assert ctor.return_type is None
+        assert ctor.type_signature == "(String,int)"
+
+    # --- interface extraction ---
+
+    def test_extract_interface(self):
+        source = b"""\
+package com.example;
+
+public interface Repository {
+    String findById(String id);
+    void save(String entity);
+}
+"""
+        result = self.extractor.extract(source)
+        assert len(result.symbols) == 1
+        iface = result.symbols[0]
+        assert iface.name == "Repository"
+        assert iface.kind == "class"
+        assert iface.subtype == "interface"
+        assert len(iface.children) == 2
+        assert iface.children[0].name == "findById"
+        assert iface.children[1].name == "save"
+
+    def test_interface_methods_have_no_calls(self):
+        source = b"""\
+package com.example;
+
+interface Store {
+    String get(String id);
+}
+"""
+        result = self.extractor.extract(source)
+        iface = result.symbols[0]
+        for child in iface.children:
+            assert child.calls == []
+
+    # --- enum extraction ---
+
+    def test_extract_enum(self):
+        source = b"""\
+package com.example;
+
+public enum Status {
+    ACTIVE, INACTIVE;
+
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        assert len(result.symbols) == 1
+        enum = result.symbols[0]
+        assert enum.name == "Status"
+        assert enum.kind == "class"
+        assert enum.subtype == "enum"
+        assert len(enum.children) == 1
+        assert enum.children[0].name == "isActive"
+
+    # --- call extraction ---
+
+    def test_extract_bare_calls(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public void run() {
+        helper();
+        validate();
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert CallRef("helper") in method.calls
+        assert CallRef("validate") in method.calls
+
+    def test_extract_dotted_calls(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public void run() {
+        service.process();
+        this.validate();
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert CallRef("process", receiver="service", kind="attribute") in method.calls
+        assert CallRef("validate", receiver="this", kind="attribute") in method.calls
+
+    def test_extract_nested_calls(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public void run() {
+        foo(bar());
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert CallRef("foo") in method.calls
+        assert CallRef("bar") in method.calls
+
+    def test_extract_chained_calls(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public void run() {
+        service.getRepo().findAll();
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        # The inner call: service.getRepo()
+        assert CallRef("getRepo", receiver="service", kind="attribute") in method.calls
+        # The outer call: <result>.findAll()
+        assert any(c.name == "findAll" for c in method.calls)
+
+    # --- Javadoc extraction ---
+
+    def test_javadoc_on_class(self):
+        source = b"""\
+package com.example;
+
+/**
+ * A user service.
+ */
+public class UserService {
+}
+"""
+        result = self.extractor.extract(source)
+        assert result.symbols[0].docs == "A user service."
+
+    def test_javadoc_on_method(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    /**
+     * Validate the input.
+     * @param input the value
+     */
+    public void validate(String input) {}
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert "Validate the input." in method.docs
+
+    def test_line_comments_as_docs(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    // Process the data.
+    // Second line.
+    public void process() {}
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert method.docs == "Process the data.\nSecond line."
+
+    # --- multiple declarations ---
+
+    def test_extract_multiple_top_level_types(self):
+        source = b"""\
+package com.example;
+
+class Foo {}
+interface Bar {
+    void baz();
+}
+enum Qux {
+    A, B;
+}
+"""
+        result = self.extractor.extract(source)
+        names = [s.name for s in result.symbols]
+        assert names == ["Foo", "Bar", "Qux"]
+
+    # --- inner types ---
+
+    def test_extract_inner_class(self):
+        source = b"""\
+package com.example;
+
+public class Outer {
+    public static class Inner {
+        public void run() {}
+    }
+}
+"""
+        result = self.extractor.extract(source)
+        outer = result.symbols[0]
+        assert outer.name == "Outer"
+        assert len(outer.children) == 1
+        inner = outer.children[0]
+        assert inner.name == "Inner"
+        assert inner.kind == "class"
+        assert len(inner.children) == 1
+        assert inner.children[0].name == "run"
+
+    # --- type signature edge cases ---
+
+    def test_type_signature_with_array_param(self):
+        source = b"""\
+package com.example;
+
+public class Main {
+    public static void main(String[] args) {}
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert method.type_signature == "(String[])"
+
+    def test_type_signature_with_generic_param(self):
+        source = b"""\
+package com.example;
+
+public class Service {
+    public void process(List<String> items, Map<String, Integer> counts) {}
+}
+"""
+        result = self.extractor.extract(source)
+        method = result.symbols[0].children[0]
+        assert method.type_signature == "(List,Map)"
+
+    # --- root_node preservation ---
+
+    def test_root_node_is_preserved(self):
+        source = b"""\
+package com.example;
+
+public class Foo {}
+"""
+        result = self.extractor.extract(source)
+        assert result.root_node is not None
+        assert result.root_node.type == "program"

--- a/agent/tests/opentrace_agent/sources/code/test_import_analyzer.py
+++ b/agent/tests/opentrace_agent/sources/code/test_import_analyzer.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 
 import tree_sitter
 import tree_sitter_go
+import tree_sitter_java
 import tree_sitter_python
 import tree_sitter_typescript
 
 from opentrace_agent.sources.code.import_analyzer import (
     analyze_go_imports,
+    analyze_java_imports,
     analyze_python_imports,
     analyze_typescript_imports,
     build_go_dir_index,
@@ -43,6 +45,12 @@ def _parse_go(source: bytes) -> tree_sitter.Node:
 
 def _parse_typescript(source: bytes) -> tree_sitter.Node:
     lang = tree_sitter.Language(tree_sitter_typescript.language_typescript())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(source).root_node
+
+
+def _parse_java(source: bytes) -> tree_sitter.Node:
+    lang = tree_sitter.Language(tree_sitter_java.language())
     parser = tree_sitter.Parser(lang)
     return parser.parse(source).root_node
 
@@ -376,3 +384,86 @@ class TestTypeScriptImports:
         known = {"src/index.ts"}
         result = analyze_typescript_imports(_parse_typescript(source), "src/index.ts", known)
         assert result.internal == {}
+
+
+class TestJavaImports:
+    def test_simple_import(self):
+        source = b"""\
+package com.example;
+
+import com.example.service.UserService;
+
+public class App {}
+"""
+        known = {"com/example/service/UserService.java", "com/example/App.java"}
+        result = analyze_java_imports(_parse_java(source), "com/example/App.java", known)
+        assert result.internal["UserService"] == "com/example/service/UserService.java"
+        assert result.external == {}
+
+    def test_import_resolves_with_src_prefix(self):
+        source = b"""\
+package com.example;
+
+import com.example.service.UserService;
+
+public class App {}
+"""
+        known = {"src/main/java/com/example/service/UserService.java", "src/main/java/com/example/App.java"}
+        result = analyze_java_imports(_parse_java(source), "src/main/java/com/example/App.java", known)
+        assert result.internal["UserService"] == "src/main/java/com/example/service/UserService.java"
+
+    def test_external_import(self):
+        source = b"""\
+package com.example;
+
+import org.springframework.web.bind.annotation.RestController;
+
+public class App {}
+"""
+        known = {"com/example/App.java"}
+        result = analyze_java_imports(_parse_java(source), "com/example/App.java", known)
+        assert result.internal == {}
+        assert "org.springframework.web" in result.external
+
+    def test_static_import(self):
+        source = b"""\
+package com.example;
+
+import static com.example.utils.Helpers.validate;
+
+public class App {}
+"""
+        known = {"com/example/utils/Helpers.java", "com/example/App.java"}
+        result = analyze_java_imports(_parse_java(source), "com/example/App.java", known)
+        assert result.internal["validate"] == "com/example/utils/Helpers.java"
+
+    def test_multiple_imports(self):
+        source = b"""\
+package com.example;
+
+import com.example.model.User;
+import com.example.service.UserService;
+import java.util.List;
+
+public class App {}
+"""
+        known = {
+            "com/example/App.java",
+            "com/example/model/User.java",
+            "com/example/service/UserService.java",
+        }
+        result = analyze_java_imports(_parse_java(source), "com/example/App.java", known)
+        assert result.internal["User"] == "com/example/model/User.java"
+        assert result.internal["UserService"] == "com/example/service/UserService.java"
+        assert "java.util.List" in result.external
+
+    def test_no_imports(self):
+        source = b"""\
+package com.example;
+
+public class App {}
+"""
+        known = {"com/example/App.java"}
+        result = analyze_java_imports(_parse_java(source), "com/example/App.java", known)
+        assert result.internal == {}
+        assert result.external == {}

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1060,6 +1060,7 @@ dependencies = [
     { name = "starlette" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-typescript" },
     { name = "uvicorn" },
@@ -1097,6 +1098,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'summarization'", specifier = ">=4.38" },
     { name = "tree-sitter", specifier = ">=0.24" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-typescript" },
     { name = "uvicorn", specifier = ">=0.24" },
@@ -1969,6 +1971,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/e2/ee5e09f63504fc286539535d374d2eaa0e7d489b80f8f744bb3962aff22a/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5608e089d2a29fa8d2b327abeb2ad1cdb8e223c440a6b0ceab0d3fa80bdeebae", size = 66088, upload-time = "2025-08-29T06:20:22.336Z" },
     { url = "https://files.pythonhosted.org/packages/6e/b6/d9142583374720e79aca9ccb394b3795149a54c012e1dfd80738df2d984e/tree_sitter_go-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:30d4ada57a223dfc2c32d942f44d284d40f3d1215ddcf108f96807fd36d53022", size = 48152, upload-time = "2025-08-29T06:20:23.089Z" },
     { url = "https://files.pythonhosted.org/packages/9e/00/9a2638e7339236f5b01622952a4d71c1474dd3783d1982a89555fc1f03b1/tree_sitter_go-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:d5d62362059bf79997340773d47cc7e7e002883b527a05cca829c46e40b70ded", size = 46752, upload-time = "2025-08-29T06:20:24.235Z" },
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/dc/eb9c8f96304e5d8ae1663126d89967a622a80937ad2909903569ccb7ec8f/tree_sitter_java-0.23.5.tar.gz", hash = "sha256:f5cd57b8f1270a7f0438878750d02ccc79421d45cca65ff284f1527e9ef02e38", size = 138121, upload-time = "2024-12-21T18:24:26.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:355ce0308672d6f7013ec913dee4a0613666f4cda9044a7824240d17f38209df", size = 58926, upload-time = "2024-12-21T18:24:12.53Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:24acd59c4720dedad80d548fe4237e43ef2b7a4e94c8549b0ca6e4c4d7bf6e69", size = 62288, upload-time = "2024-12-21T18:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9401e7271f0b333df39fc8a8336a0caf1b891d9a2b89ddee99fae66b794fc5b7", size = 85533, upload-time = "2024-12-21T18:24:16.695Z" },
+    { url = "https://files.pythonhosted.org/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:370b204b9500b847f6d0c5ad584045831cee69e9a3e4d878535d39e4a7e4c4f1", size = 84033, upload-time = "2024-12-21T18:24:18.758Z" },
+    { url = "https://files.pythonhosted.org/packages/43/56/7d06b23ddd09bde816a131aa504ee11a1bbe87c6b62ab9b2ed23849a3382/tree_sitter_java-0.23.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aae84449e330363b55b14a2af0585e4e0dae75eb64ea509b7e5b0e1de536846a", size = 82564, upload-time = "2024-12-21T18:24:20.493Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl", hash = "sha256:1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7", size = 60650, upload-time = "2024-12-21T18:24:22.902Z" },
+    { url = "https://files.pythonhosted.org/packages/72/57/5bab54d23179350356515526fff3cc0f3ac23bfbc1a1d518a15978d4880e/tree_sitter_java-0.23.5-cp39-abi3-win_arm64.whl", hash = "sha256:402efe136104c5603b429dc26c7e75ae14faaca54cfd319ecc41c8f2534750f4", size = 59059, upload-time = "2024-12-21T18:24:24.934Z" },
 ]
 
 [[package]]

--- a/docs/reference/languages.md
+++ b/docs/reference/languages.md
@@ -1,25 +1,30 @@
 # Supported Languages
 
+Extraction depth varies by runtime. The CLI agent has a dedicated Java
+extractor, while the browser indexer currently uses structural extraction for
+Java.
+
 ## Full Extraction (symbols + calls + imports)
 
-| Language | Symbols | Call Relationships | Imports |
-|----------|---------|-------------------|---------|
-| Python | Yes | Yes | Yes |
-| TypeScript | Yes | Yes | Yes |
-| JavaScript | Yes | Yes | Yes |
-| Go | Yes | Yes | Yes |
+| Language | Runtime | Symbols | Call Relationships | Imports |
+|----------|---------|---------|-------------------|---------|
+| Python | CLI agent and browser indexer | Yes | Yes | Yes |
+| TypeScript | CLI agent and browser indexer | Yes | Yes | Yes |
+| JavaScript | CLI agent and browser indexer | Yes | Yes | Yes |
+| Go | CLI agent and browser indexer | Yes | Yes | Yes |
+| Java | CLI agent | Yes | Yes | Yes |
 
 ## Structural Extraction (symbols only)
 
-| Language | Symbols |
-|----------|---------|
-| Rust | Yes |
-| Java | Yes |
-| Kotlin | Yes |
-| C# | Yes |
-| C/C++ | Yes |
-| Ruby | Yes |
-| Swift | Yes |
+| Language | Runtime | Symbols |
+|----------|---------|---------|
+| Rust | Browser indexer | Yes |
+| Java | Browser indexer | Yes |
+| Kotlin | Browser indexer | Yes |
+| C# | Browser indexer | Yes |
+| C/C++ | Browser indexer | Yes |
+| Ruby | Browser indexer | Yes |
+| Swift | Browser indexer | Yes |
 
 ## Config & Data Files
 


### PR DESCRIPTION
I'm not sure if you accept contributions out of the blue. I was missing full Java support, and here is a version that works for my use case. 

## Summary

Adds full Java extraction support to the OpenTrace Python agent, including symbols, method calls, imports, inheritance, and graph relationships.

## Changes

  - Add a Tree-sitter Java extractor.
  - Extract classes, interfaces, enums, methods, constructors, variables, calls, and inheritance.
  - Resolve Java imports against repository source paths.
  - Integrate Java processing into the indexing pipeline and CLI.
  - Add Java extractor, import-resolution, and graph-store tests.
  - Add the tree-sitter-java dependency.
  - Update language-support documentation to distinguish CLI and browser capabilities.

## Test plan

  - make test
  - make lint
  - make license-check

  All checks pass. 

## Checklist

  - [x] Tests pass
  - [x] Documentation updated
  - [x] No breaking changes
  - [x] License headers valid