### PR TITLE
refactor(agent): rename communities to clusters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ npm run dev
 
 Authoritative set is `VALID_NODE_TYPES` in `agent/src/opentrace_agent/store/constants.py`:
 
-Class, Cluster, Community, Database, DBTable, Dependency, Deployment, Directory,
+Class, Cluster, Database, DBTable, Dependency, Deployment, Directory,
 Endpoint, File, Function, InstrumentedService, KnowledgeDoc,
 KnowledgeVault, Log, Metric, Module, Namespace, Package, PullRequest, Repo,
 Repository, Service, Span, Variable

--- a/agent/CLAUDE.md
+++ b/agent/CLAUDE.md
@@ -11,7 +11,7 @@ src/opentrace_agent/
                  plus markdown/ doc plumbing (fetch, markitdown, corpus store)
   pipeline/    — Four-stage pipeline (scan → process → resolve → save) as LangGraph
   retrieval/   — Read-only agent-facing query primitives (search, overview,
-                 paths, counts, provenance, grep, communities)
+                 paths, counts, provenance, grep, clusters)
   wiki/        — Doc-ingestion pipeline + vault metadata (`index --wiki`,
                  `vault ingest`)
   store/       — LadybugDB persistence (Cypher queries, schema)

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "openai>=1.0",
     # Doc ingestion + graph analysis. markitdown[all] converts PDF/DOCX/PPTX/
     # XLSX/HTML/EPUB to markdown and bundles youtube-transcript-api for URL
-    # ingestion. networkx powers community detection (`cluster`) and the
+    # ingestion. networkx powers clustering (`cluster`) and the
     # graph exporters.
     #
     # Audio/video transcription is NOT supported: no audio extension is in

--- a/agent/src/opentrace_agent/cli/CLAUDE.md
+++ b/agent/src/opentrace_agent/cli/CLAUDE.md
@@ -35,9 +35,9 @@ vault_cmd.py     — vault ingest / list / show / attach / detach / promote /
                    both use). Files skipped by type are REPORTED in the
                    summary, never silent ("14 docs" over a 15-file folder must
                    not read as full coverage)
-analyze_cmd.py   — god nodes, bridges, cross-domain bridges, cross-cutting communities
-                   (all Community-based; needs `opentraceai cluster` first)
-cluster_cmd.py   — community detection (Leiden → Louvain fallback)
+analyze_cmd.py   — god nodes, bridges, cross-domain bridges, cross-cutting clusters
+                   (all cluster-based; needs `opentraceai cluster` first)
+cluster_cmd.py   — graph clustering (Leiden → Louvain fallback)
 export_graph.py  — graphml / obsidian / report exporters (deterministic, no LLM)
 serve.py         — Starlette HTTP server; REST API consumed by the UI
 mcp_server.py    — MCP (Model Context Protocol) server for agent clients
@@ -80,7 +80,7 @@ REST endpoints (full list in `docs/reference/graph-tools.md`):
 `/api/retrieval/{search,overview,find_path,find_orphans,find_via_relationship_to_type,count_by,provenance,grep}`,
 plus `/api/source/*` and the vault routes:
 
-Community analysis (god nodes, bridges, cross-cutting communities, suggested
+Cluster analysis (god nodes, bridges, cross-cutting clusters, suggested
 questions) is deliberately NOT on REST — it is reachable via `opentraceai
 analyze`, the MCP tools, and the report exporter. Routes for it existed briefly
 to back a `KnowledgeHighlightsPanel` that was never built, and were removed
@@ -92,7 +92,7 @@ rather than shipped unconsumed.
 - `POST /api/vaults/{vault}/promote` / `POST /api/vaults/{vault}/demote` — move a vault between scopes on disk and re-mirror its graph `KnowledgeVault` row with the new scope. Promote (local → `~/.opentrace/vaults/`) also seeds the global corpus so the vault is attachable elsewhere; demote (global → `<project>/.opentrace/vaults/`) copies the corpus into the project. REST-only counterparts of `vault promote` / `vault demote`; 400 if already in the target scope, 409 if a vault of that name already exists in the target scope. Optional `?scope=` disambiguates a local/global name collision.
 - `DELETE /api/vaults/{vault}?scope=...` — delete from disk (and graph) for the given scope.
 
-MCP tools mirror the same primitives plus `find_cross_cutting_communities`. Tool list lives in `plugins/claude-code/CLAUDE.md`.
+MCP tools mirror the same primitives plus `find_cross_cutting_clusters`. Tool list lives in `plugins/claude-code/CLAUDE.md`.
 
 "Which documents discuss X" is answered by `grep` (exhaustive, verbatim, pre-labelled). There is no doc→topic edge to traverse.
 

--- a/agent/src/opentrace_agent/cli/analyze_cmd.py
+++ b/agent/src/opentrace_agent/cli/analyze_cmd.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""``opentraceai analyze`` — report the graph's hotspots: god nodes, cross-community bridges, starter questions.
+"""``opentraceai analyze`` — report the graph's hotspots: god nodes, cross-cluster bridges, starter questions.
 
 Reads from the store via :meth:`GraphStore.list_god_nodes` and
-:meth:`GraphStore.list_cross_community_bridges`. The "questions" tab is a
+:meth:`GraphStore.list_cross_cluster_bridges`. The "questions" tab is a
 placeholder until the LLM extraction stage is wired up — it returns
 template starter questions seeded by the top god nodes.
 """
@@ -31,7 +31,7 @@ import click
 def _suggested_questions(gods: list[dict[str, Any]], bridges: list[dict[str, Any]]) -> list[str]:
     """Deterministic placeholder until LLM extraction is wired up.
 
-    Seeds prompts off the top god nodes and the most prominent cross-community
+    Seeds prompts off the top god nodes and the most prominent cross-cluster
     bridges. Stable across runs of the same graph, so the CLI is reproducible
     in tests and snapshots.
     """
@@ -40,8 +40,8 @@ def _suggested_questions(gods: list[dict[str, Any]], bridges: list[dict[str, Any
         out.append(f"What depends on {g['name']}?")
     for b in bridges[:3]:
         out.append(
-            f"What links {b['source_name']} (in {b['source_community_name']}) "
-            f"with {b['target_name']} (in {b['target_community_name']})?"
+            f"What links {b['source_name']} (in {b['source_cluster_name']}) "
+            f"with {b['target_name']} (in {b['target_cluster_name']})?"
         )
     return out
 
@@ -54,19 +54,19 @@ def run_analyze_cli(
     output_json: bool = False,
 ) -> None:
     from opentrace_agent.retrieval import (
-        cross_community_bridges,
+        cross_cluster_bridges,
         cross_domain_bridges,
-        find_communities_spanning_domains,
+        find_clusters_spanning_domains,
         god_nodes,
     )
     from opentrace_agent.store import GraphStore
 
     with GraphStore(db_path) as store:
         gods = god_nodes(store, limit=god_limit)
-        bridges = cross_community_bridges(store, limit=bridge_limit)
+        bridges = cross_cluster_bridges(store, limit=bridge_limit)
         # Phase 7: cross-domain (code/doc) connectivity.
         domain_bridges = cross_domain_bridges(store, limit=bridge_limit)
-        cross_cutting = find_communities_spanning_domains(store, min_domains=2, limit=bridge_limit)
+        cross_cutting = find_clusters_spanning_domains(store, min_domains=2, limit=bridge_limit)
 
     questions = _suggested_questions(gods, bridges)
 
@@ -77,7 +77,7 @@ def run_analyze_cli(
                     "gods": gods,
                     "bridges": bridges,
                     "cross_domain_bridges": domain_bridges,
-                    "cross_cutting_communities": cross_cutting,
+                    "cross_cutting_clusters": cross_cutting,
                     "questions": questions,
                 },
                 indent=2,
@@ -92,14 +92,14 @@ def run_analyze_cli(
         click.echo(f"  {g['degree']:>4}  {g['type']:<14}  {g['name']}")
 
     click.echo("")
-    click.echo(f"Cross-community bridges ({len(bridges)}):")
+    click.echo(f"Cross-cluster bridges ({len(bridges)}):")
     if not bridges:
-        click.echo("  (none — run `opentraceai cluster` to assign communities)")
+        click.echo("  (none — run `opentraceai cluster` to assign clusters)")
     for b in bridges:
         click.echo(
-            f"  {b['source_name']} [{b['source_community_name']}] "
+            f"  {b['source_name']} [{b['source_cluster_name']}] "
             f"--{b['relation']}--> "
-            f"{b['target_name']} [{b['target_community_name']}]"
+            f"{b['target_name']} [{b['target_cluster_name']}]"
         )
 
     click.echo("")
@@ -115,7 +115,7 @@ def run_analyze_cli(
 
     if cross_cutting:
         click.echo("")
-        click.echo(f"Cross-cutting communities (span ≥2 domains) ({len(cross_cutting)}):")
+        click.echo(f"Cross-cutting clusters (span ≥2 domains) ({len(cross_cutting)}):")
         for c in cross_cutting:
             domain_str = "+".join(c["domains"])
             click.echo(f"  {c['name']} — {domain_str} ({c['total_members']} members: {c['member_counts']})")

--- a/agent/src/opentrace_agent/cli/cluster_cmd.py
+++ b/agent/src/opentrace_agent/cli/cluster_cmd.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""``opentraceai cluster`` — run community detection over the stored graph.
+"""``opentraceai cluster`` — partition the stored graph into clusters.
 
-Wraps :func:`opentrace_agent.pipeline.cluster.run_clustering`. Idempotent: clears
-existing Community nodes + memberships before writing fresh ones, so re-running
+Wraps :func:`opentrace_agent.pipeline.cluster.run_clustering`. Idempotent:
+clears existing cluster assignments before stamping fresh ones, so re-running
 on the same DB produces the same shape (deterministic seed).
 """
 
@@ -50,8 +50,8 @@ def run_cluster_cli(db_path: str, output_json: bool = False) -> None:
 
     click.echo(
         f"Clustered {report.nodes} nodes / {report.edges} edges "
-        f"into {report.communities} communities "
-        f"({report.god_communities} flagged as god, "
-        f"largest = {report.largest_community} nodes, "
+        f"into {report.clusters} clusters "
+        f"({report.god_clusters} flagged as god, "
+        f"largest = {report.largest_cluster} nodes, "
         f"mean cohesion = {report.mean_cohesion:.2f})."
     )

--- a/agent/src/opentrace_agent/cli/export_graph.py
+++ b/agent/src/opentrace_agent/cli/export_graph.py
@@ -19,8 +19,8 @@ Three formats:
 * ``graphml``  — universal escape hatch (Gephi, yEd, Cytoscape).
 * ``obsidian`` — markdown vault (one note per node, wikilinks for edges).
 * ``report``   — a folder of linked markdown pages: an ``index.md`` dashboard
-                 (provenance, Mermaid community map), per-community and
-                 per-god-node pages, and a ``bridges.md`` of community- and
+                 (provenance, Mermaid cluster map), per-cluster and
+                 per-god-node pages, and a ``bridges.md`` of cluster- and
                  domain-crossing edges.
 
 Each subcommand reads from the store and writes to an output path. No LLM
@@ -51,9 +51,9 @@ def export_graph_app() -> None:
 def _build_export_graph(store):  # type: ignore[no-untyped-def]
     """Build a networkx DiGraph for export. Excludes IndexMetadata.
 
-    Community ids ride as a node attribute so Gephi/yEd can colour by
-    community — the partition is metadata about nodes, so there is no
-    community node to render and no membership edge to draw.
+    Cluster ids ride as a node attribute so Gephi/yEd can colour by
+    cluster — the partition is metadata about nodes, so there is no
+    cluster node to render and no membership edge to draw.
     """
     try:
         import networkx as nx
@@ -71,12 +71,12 @@ def _build_export_graph(store):  # type: ignore[no-untyped-def]
         # GraphML only accepts primitive attributes — strip None and collapse
         # missing fields to empty strings. An unassigned node gets -1 rather
         # than a missing key: GraphML keys are declared per-attribute, so an
-        # absent value reads as community 0 in some importers.
+        # absent value reads as cluster 0 in some importers.
         g.add_node(
             n["id"],
             type=n["type"] or "",
             name=n["name"] or "",
-            community=int(n.get(_Store.COMMUNITY_PROPERTY, -1)),
+            cluster=int(n.get(_Store.CLUSTER_PROPERTY, -1)),
         )
     for src, tgt in edges:
         if g.has_node(src) and g.has_node(tgt):
@@ -102,7 +102,7 @@ def _build_export_graph(store):  # type: ignore[no-untyped-def]
 def graphml_cmd(db_path: str | None, output: str) -> None:
     """Export the stored graph as GraphML (Gephi, yEd, Cytoscape).
 
-    Each node carries a ``community`` attribute (-1 when unassigned) so those
+    Each node carries a ``cluster`` attribute (-1 when unassigned) so those
     tools can colour by cluster without the partition existing as nodes of its
     own. IndexMetadata is excluded (it's a per-repo provenance record, not part
     of the graph).
@@ -124,7 +124,7 @@ def graphml_cmd(db_path: str | None, output: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Obsidian + wiki exporters share a community → members projection
+# Obsidian + wiki exporters share a cluster → members projection
 # ---------------------------------------------------------------------------
 
 
@@ -189,29 +189,29 @@ def _display_name(node: dict) -> str:
 
 
 def _project_graph(store):  # type: ignore[no-untyped-def]
-    """Return ``(nodes_by_id, edges, communities, memberships)`` for exporters.
+    """Return ``(nodes_by_id, edges, clusters, memberships)`` for exporters.
 
     - ``nodes_by_id``: id → ``{id, type, name}`` for non-internal source nodes.
     - ``edges``: list of ``(source_id, target_id, relation)`` between source nodes.
-    - ``communities``: list of derived community summary dicts.
-    - ``memberships``: community_id → list of node_ids.
+    - ``clusters``: list of derived cluster summary dicts.
+    - ``memberships``: cluster_id → list of node_ids.
 
     Membership rides along on the nodes ``iter_analysis_graph`` already
     returned, so grouping is a pass over them rather than a lookup per node.
     """
-    from opentrace_agent.retrieval.communities import list_communities
+    from opentrace_agent.retrieval.clusters import list_clusters
     from opentrace_agent.store.graph_store import GraphStore as _Store
 
     nodes, edges = store.iter_analysis_graph()
     nodes_by_id = {n["id"]: n for n in nodes}
 
-    communities = list_communities(store)
-    memberships: dict[int, list[str]] = {c["id"]: [] for c in communities}
+    clusters = list_clusters(store)
+    memberships: dict[int, list[str]] = {c["id"]: [] for c in clusters}
     for node_id, node in nodes_by_id.items():
-        community = node.get(_Store.COMMUNITY_PROPERTY)
-        if community is None:
+        cluster = node.get(_Store.CLUSTER_PROPERTY)
+        if cluster is None:
             continue
-        memberships.setdefault(int(community), []).append(node_id)
+        memberships.setdefault(int(cluster), []).append(node_id)
 
     # We want (s, t, relation) but iter_analysis_graph only returns (s, t).
     # Pull the relation type by re-querying — cheap because we only iterate
@@ -223,7 +223,7 @@ def _project_graph(store):  # type: ignore[no-untyped-def]
         if r["source_id"] in nodes_by_id and r["target_id"] in nodes_by_id:
             rel_edges.append((r["source_id"], r["target_id"], r["type"]))
 
-    return nodes_by_id, rel_edges, communities, memberships
+    return nodes_by_id, rel_edges, clusters, memberships
 
 
 def _node_filename(node: dict, used: set[str]) -> str:
@@ -271,10 +271,10 @@ def obsidian_cmd(
     db_path: str | None,
     output: str,
 ) -> None:
-    """Export an Obsidian-compatible vault: one .md per node, folder per community.
+    """Export an Obsidian-compatible vault: one .md per node, folder per cluster.
 
     Synthesises a vault from the graph. One ``.md`` per node, folder per
-    community, wikilinks for edges. Nodes without a community land in
+    cluster, wikilinks for edges. Nodes without a cluster land in
     ``_uncategorised/``.
     """
     from pathlib import Path
@@ -289,7 +289,7 @@ def obsidian_cmd(
     resolved = _resolve_db(db_path, must_exist=True)
 
     with GraphStore(resolved) as store:
-        nodes_by_id, edges, communities, memberships = _project_graph(store)
+        nodes_by_id, edges, clusters, memberships = _project_graph(store)
 
     # Build per-node edge lists for fast rendering.
     out_edges: dict[str, list[tuple[str, str]]] = {nid: [] for nid in nodes_by_id}
@@ -299,15 +299,15 @@ def obsidian_cmd(
         if tgt in out_edges and src in nodes_by_id:
             out_edges[tgt].append((f"<-{rel}", src))
 
-    # Resolve community names (and the catch-all bucket for unassigned nodes).
-    folder_for_community: dict[str, str] = {}
+    # Resolve cluster names (and the catch-all bucket for unassigned nodes).
+    folder_for_cluster: dict[str, str] = {}
     used_folders: set[str] = set()
-    for c in communities:
+    for c in clusters:
         slug = _slugify(c["name"])
         if slug in used_folders:
-            slug = f"{slug}--{c.get('community_id', '?')}"
+            slug = f"{slug}--{c.get('cluster_id', '?')}"
         used_folders.add(slug)
-        folder_for_community[c["id"]] = slug
+        folder_for_cluster[c["id"]] = slug
         (out_root / slug).mkdir(parents=True, exist_ok=True)
     uncategorised = "_uncategorised"
     (out_root / uncategorised).mkdir(parents=True, exist_ok=True)
@@ -316,11 +316,11 @@ def obsidian_cmd(
     node_path: dict[str, str] = {}
     node_link_target: dict[str, str] = {}
     for nid, node in nodes_by_id.items():
-        # Find the community this node belongs to (if any).
+        # Find the cluster this node belongs to (if any).
         folder = uncategorised
         for cid, members in memberships.items():
-            if nid in members and cid in folder_for_community:
-                folder = folder_for_community[cid]
+            if nid in members and cid in folder_for_cluster:
+                folder = folder_for_cluster[cid]
                 break
         fname = _node_filename(node, used_filenames)
         node_path[nid] = f"{folder}/{fname}"
@@ -360,7 +360,7 @@ def obsidian_cmd(
             lines.append("")
         path.write_text("\n".join(lines))
 
-    click.echo(f"Wrote {len(nodes_by_id)} notes across {len(folder_for_community)} community folders to {out_root}")
+    click.echo(f"Wrote {len(nodes_by_id)} notes across {len(folder_for_cluster)} cluster folders to {out_root}")
 
 
 @export_graph_app.command("report")
@@ -382,9 +382,9 @@ def report_cmd(db_path: str | None, output: str) -> None:
     """Write the graph out as a folder of linked markdown pages.
 
     ``index.md`` is the entry point — provenance header, a Mermaid map of the
-    community structure, and links into the rest. Every community gets a page
-    under ``communities/``, every god node a page under ``gods/``, and
-    ``bridges.md`` collects the edges that cross community or domain
+    cluster structure, and links into the rest. Every cluster gets a page
+    under ``clusters/``, every god node a page under ``gods/``, and
+    ``bridges.md`` collects the edges that cross cluster or domain
     boundaries. Deterministic projection of stored data — no LLM calls at
     export time.
     """
@@ -393,28 +393,28 @@ def report_cmd(db_path: str | None, output: str) -> None:
 
     from opentrace_agent.cli.main import _resolve_db
     from opentrace_agent.retrieval import (
-        cross_community_bridges,
+        cross_cluster_bridges,
         cross_domain_bridges,
-        find_communities_spanning_domains,
+        find_clusters_spanning_domains,
     )
     from opentrace_agent.store import GraphStore
 
     list_cap = 25  # longest member/edge list any single page renders
-    map_cap = 30  # most communities the Mermaid map will draw
+    map_cap = 30  # most clusters the Mermaid map will draw
 
     resolved = _resolve_db(db_path, must_exist=True)
     out_root = Path(output)
     out_root.mkdir(parents=True, exist_ok=True)
 
     with GraphStore(resolved) as store:
-        nodes_by_id, edges, communities, memberships = _project_graph(store)
+        nodes_by_id, edges, clusters, memberships = _project_graph(store)
         god_nodes = store.list_god_nodes(limit=20)
         metadata = store.get_metadata()
-        # Retrieval-layer helper, not the raw store call: community labels are
+        # Retrieval-layer helper, not the raw store call: cluster labels are
         # derived, so only this wrapper joins them onto the bridge rows.
-        community_bridges = cross_community_bridges(store, limit=list_cap)
+        cluster_bridges = cross_cluster_bridges(store, limit=list_cap)
         domain_bridges = cross_domain_bridges(store, limit=list_cap)
-        cross_cutting = find_communities_spanning_domains(store, min_domains=2, limit=list_cap)
+        cross_cutting = find_clusters_spanning_domains(store, min_domains=2, limit=list_cap)
 
     # Per-node outgoing adjacency, used for degree ranking and page rendering.
     out_edges: dict[str, list[tuple[str, str]]] = {nid: [] for nid in nodes_by_id}
@@ -422,21 +422,21 @@ def report_cmd(db_path: str | None, output: str) -> None:
         if src in out_edges and tgt in nodes_by_id:
             out_edges[src].append((rel, tgt))
 
-    # Reverse membership map: node id → its community record.
-    community_of: dict[str, dict] = {}
-    for c in communities:
+    # Reverse membership map: node id → its cluster record.
+    cluster_of: dict[str, dict] = {}
+    for c in clusters:
         for member_id in memberships.get(c["id"], []):
-            community_of[member_id] = c
+            cluster_of[member_id] = c
 
     # Assign collision-free slugs for both page sets up front.
-    community_slug: dict[str, str] = {}
+    cluster_slug: dict[str, str] = {}
     taken: set[str] = set()
-    for c in communities:
+    for c in clusters:
         slug = _slugify(c["name"])
         if slug in taken:
-            slug = f"{slug}--{c.get('community_id', '?')}"
+            slug = f"{slug}--{c.get('cluster_id', '?')}"
         taken.add(slug)
-        community_slug[c["id"]] = slug
+        cluster_slug[c["id"]] = slug
 
     god_slug: dict[str, str] = {}
     taken.clear()
@@ -447,14 +447,14 @@ def report_cmd(db_path: str | None, output: str) -> None:
         taken.add(slug)
         god_slug[g["id"]] = slug
 
-    community_by_id = {c["id"]: c for c in communities}
+    cluster_by_id = {c["id"]: c for c in clusters}
 
     # ---- index.md ------------------------------------------------------
     index = [
         "# Knowledge Graph",
         "",
         f"This graph holds {len(nodes_by_id)} nodes connected by {len(edges)} edges. "
-        f"Community detection grouped them into {len(communities)} communities, and "
+        f"Clustering grouped them into {len(clusters)} clusters, and "
         f"{len(god_nodes)} highly connected nodes are broken out below.",
     ]
     for meta in sorted(metadata, key=lambda m: str(m.get("indexedAt") or "")):
@@ -470,12 +470,12 @@ def report_cmd(db_path: str | None, output: str) -> None:
             f"— opentraceai {meta.get('opentraceaiVersion', '?')}.",
         ]
 
-    if communities:
-        mapped = sorted(communities, key=lambda c: len(memberships.get(c["id"], [])), reverse=True)[:map_cap]
+    if clusters:
+        mapped = sorted(clusters, key=lambda c: len(memberships.get(c["id"], [])), reverse=True)[:map_cap]
         mapped_ids = {c["id"] for c in mapped}
         pair_counts: dict[tuple[str, str], int] = {}
         for src, tgt, _rel in edges:
-            sc, tc = community_of.get(src), community_of.get(tgt)
+            sc, tc = cluster_of.get(src), cluster_of.get(tgt)
             if not sc or not tc or sc["id"] == tc["id"]:
                 continue
             if sc["id"] in mapped_ids and tc["id"] in mapped_ids:
@@ -484,45 +484,43 @@ def report_cmd(db_path: str | None, output: str) -> None:
         index += ["", "## Map", "", "```mermaid", "graph LR"]
         for c in mapped:
             safe_name = str(c["name"]).replace('"', "'")
-            index.append(f'  c{c["community_id"]}["{safe_name} ({len(memberships.get(c["id"], []))})"]')
+            index.append(f'  c{c["cluster_id"]}["{safe_name} ({len(memberships.get(c["id"], []))})"]')
         for (id_a, id_b), count in sorted(pair_counts.items()):
-            index.append(
-                f"  c{community_by_id[id_a]['community_id']} ---|{count}| c{community_by_id[id_b]['community_id']}"
-            )
+            index.append(f"  c{cluster_by_id[id_a]['cluster_id']} ---|{count}| c{cluster_by_id[id_b]['cluster_id']}")
         index.append("```")
-        if len(communities) > map_cap:
-            index.append(f"_Showing the {map_cap} largest of {len(communities)} communities._")
+        if len(clusters) > map_cap:
+            index.append(f"_Showing the {map_cap} largest of {len(clusters)} clusters._")
 
     index += ["", "## God Nodes"]
     index.extend(
         f"- [{g['name']}](gods/{god_slug[g['id']]}.md): a {g['type']} touching {g['degree']} edges" for g in god_nodes
     )
-    index += ["", "## Communities"]
+    index += ["", "## Clusters"]
     index.extend(
-        f"- [{c['name']}](communities/{community_slug[c['id']]}.md): "
+        f"- [{c['name']}](clusters/{cluster_slug[c['id']]}.md): "
         f"{len(memberships.get(c['id'], []))} members, {c.get('cohesion', 0.0):.2f} cohesion"
-        for c in communities
+        for c in clusters
     )
-    index += ["", "See also: [Bridges](bridges.md) — edges that cross community and domain boundaries."]
+    index += ["", "See also: [Bridges](bridges.md) — edges that cross cluster and domain boundaries."]
     (out_root / "index.md").write_text("\n".join(index))
 
     # ---- bridges.md ------------------------------------------------------
     bridge_page = [
         "# Bridges",
         "",
-        "Edges whose endpoints live in different communities or different domains — "
+        "Edges whose endpoints live in different clusters or different domains — "
         "the seams where one area of the system touches another.",
         "",
-        "## Cross-community",
+        "## Cross-cluster",
     ]
-    if community_bridges:
+    if cluster_bridges:
         bridge_page.extend(
-            f"- {b['source_name']} [{b['source_community_name']}] "
-            f"--{b['relation']}--> {b['target_name']} [{b['target_community_name']}]"
-            for b in community_bridges
+            f"- {b['source_name']} [{b['source_cluster_name']}] "
+            f"--{b['relation']}--> {b['target_name']} [{b['target_cluster_name']}]"
+            for b in cluster_bridges
         )
     else:
-        bridge_page.append("(none — run `opentraceai cluster` to assign communities)")
+        bridge_page.append("(none — run `opentraceai cluster` to assign clusters)")
     bridge_page += ["", "## Cross-domain (code ↔ doc)"]
     if domain_bridges:
         bridge_page.extend(
@@ -532,7 +530,7 @@ def report_cmd(db_path: str | None, output: str) -> None:
         )
     else:
         bridge_page.append("(none — every edge stays inside a single domain)")
-    bridge_page += ["", "## Communities spanning multiple domains"]
+    bridge_page += ["", "## Clusters spanning multiple domains"]
     if cross_cutting:
         bridge_page.extend(
             f"- {c['name']} — {'+'.join(c['domains'])}, {c['total_members']} members" for c in cross_cutting
@@ -541,10 +539,10 @@ def report_cmd(db_path: str | None, output: str) -> None:
         bridge_page.append("(none)")
     (out_root / "bridges.md").write_text("\n".join(bridge_page))
 
-    # ---- communities/*.md ---------------------------------------------
-    communities_dir = out_root / "communities"
-    communities_dir.mkdir(exist_ok=True)
-    for c in communities:
+    # ---- clusters/*.md --------------------------------------------------
+    clusters_dir = out_root / "clusters"
+    clusters_dir.mkdir(exist_ok=True)
+    for c in clusters:
         members = memberships.get(c["id"], [])
         member_set = set(members)
         ranked = sorted(
@@ -552,46 +550,46 @@ def report_cmd(db_path: str | None, output: str) -> None:
             key=lambda n: len(out_edges.get(n["id"], [])),
             reverse=True,
         )
-        god_note = " Flagged as a god community." if c.get("is_god") else ""
+        god_note = " Flagged as a god cluster." if c.get("is_god") else ""
         page = [
             f"# {c['name']}",
             "",
-            f"{len(ranked)}-member community with cohesion {c.get('cohesion', 0.0):.2f}.{god_note}",
+            f"{len(ranked)}-member cluster with cohesion {c.get('cohesion', 0.0):.2f}.{god_note}",
             "",
             f"## Members (highest degree first, top {list_cap})",
         ]
         page.extend(f"- {_display_name(n)} ({n['type']})" for n in ranked[:list_cap])
 
-        # Leaving edges, grouped by the community they land in — the reader
+        # Leaving edges, grouped by the cluster they land in — the reader
         # wants "who do we talk to and how much", not a flat edge sample.
         leaving: defaultdict[str | None, list[tuple[str, str, str]]] = defaultdict(list)
         for s, t, r in edges:
             if s in member_set and t not in member_set:
-                target = community_of.get(t)
+                target = cluster_of.get(t)
                 leaving[target["id"] if target else None].append((s, t, r))
         if leaving:
-            page += ["", "## Connections to other communities"]
+            page += ["", "## Connections to other clusters"]
             for target_id, group in sorted(leaving.items(), key=lambda kv: -len(kv[1]))[:list_cap]:
                 samples = "; ".join(
                     f"{_display_name(nodes_by_id[s])} → {_display_name(nodes_by_id[t])} ({r})" for s, t, r in group[:3]
                 )
                 count = f"{len(group)} edge" + ("s" if len(group) != 1 else "")
                 if target_id is None:
-                    page.append(f"- (no community): {count} — {samples}")
+                    page.append(f"- (no cluster): {count} — {samples}")
                 else:
-                    target_c = community_by_id[target_id]
-                    page.append(f"- [{target_c['name']}]({community_slug[target_id]}.md): {count} — {samples}")
+                    target_c = cluster_by_id[target_id]
+                    page.append(f"- [{target_c['name']}]({cluster_slug[target_id]}.md): {count} — {samples}")
 
-        (communities_dir / f"{community_slug[c['id']]}.md").write_text("\n".join(page))
+        (clusters_dir / f"{cluster_slug[c['id']]}.md").write_text("\n".join(page))
 
     # ---- gods/*.md -----------------------------------------------------
     gods_dir = out_root / "gods"
     gods_dir.mkdir(exist_ok=True)
     for g in god_nodes:
         page = [f"# {g['name']}", "", f"**Type**: {g['type']}", f"**Degree**: {g['degree']}"]
-        home = community_of.get(g["id"])
+        home = cluster_of.get(g["id"])
         if home:
-            page.append(f"Belongs to the [{home['name']}](../communities/{community_slug[home['id']]}.md) community.")
+            page.append(f"Belongs to the [{home['name']}](../clusters/{cluster_slug[home['id']]}.md) cluster.")
         neighbours_by_rel: defaultdict[str, list[str]] = defaultdict(list)
         for rel, other in out_edges.get(g["id"], []):
             neighbours_by_rel[rel].append(nodes_by_id[other]["name"])
@@ -601,6 +599,5 @@ def report_cmd(db_path: str | None, output: str) -> None:
         (gods_dir / f"{god_slug[g['id']]}.md").write_text("\n".join(page))
 
     click.echo(
-        f"Report written to {out_root}: {len(communities)} community pages, "
-        f"{len(god_nodes)} god-node pages, bridges.md."
+        f"Report written to {out_root}: {len(clusters)} cluster pages, {len(god_nodes)} god-node pages, bridges.md."
     )

--- a/agent/src/opentrace_agent/cli/main.py
+++ b/agent/src/opentrace_agent/cli/main.py
@@ -3024,11 +3024,11 @@ def _configure_logging(verbose: bool) -> None:
 )
 @click.option("--json", "output_json", is_flag=True, help="Output structured JSON.")
 def cluster(db_path: str | None, output_json: bool) -> None:
-    """Run community detection over the stored graph.
+    """Partition the stored graph into clusters.
 
     Reads non-internal nodes + edges, runs Leiden (falls back to Louvain),
-    re-splits oversized or low-cohesion communities, and stamps each member's
-    ``community`` property. The partition is metadata about nodes, not nodes of
+    re-splits oversized or low-cohesion clusters, and stamps each member's
+    ``cluster`` property. The partition is metadata about nodes, not nodes of
     its own, so it adds nothing to the node or edge count. Idempotent —
     re-running rewrites every assignment.
     """
@@ -3052,14 +3052,14 @@ def cluster(db_path: str | None, output_json: bool) -> None:
     "bridge_limit",
     default=10,
     show_default=True,
-    help="Top-N cap for cross-community bridges, cross-domain bridges, and cross-cutting communities.",
+    help="Top-N cap for cross-cluster bridges, cross-domain bridges, and cross-cutting clusters.",
 )
 @click.option("--json", "output_json", is_flag=True, help="Output structured JSON.")
 def analyze(db_path: str | None, god_limit: int, bridge_limit: int, output_json: bool) -> None:
-    """Surface god nodes, cross-community bridges, and suggested questions.
+    """Surface god nodes, cross-cluster bridges, and suggested questions.
 
-    Run ``opentraceai cluster`` first — bridges depend on community
-    membership. Without communities, only god nodes are reported.
+    Run ``opentraceai cluster`` first — bridges depend on cluster
+    membership. Without clusters, only god nodes are reported.
     """
     from opentrace_agent.cli.analyze_cmd import run_analyze_cli
 

--- a/agent/src/opentrace_agent/cli/mcp_server.py
+++ b/agent/src/opentrace_agent/cli/mcp_server.py
@@ -28,7 +28,7 @@ from opentrace_agent.retrieval import (
     count_by as _count_by,
 )
 from opentrace_agent.retrieval import (
-    find_communities_spanning_domains as _find_communities_spanning_domains,
+    find_clusters_spanning_domains as _find_clusters_spanning_domains,
 )
 from opentrace_agent.retrieval import (
     find_orphans as _find_orphans,
@@ -51,14 +51,14 @@ from opentrace_agent.retrieval import (
 from opentrace_agent.retrieval import (
     search as _search,
 )
-from opentrace_agent.retrieval.communities import (
-    cross_community_bridges as _cross_community_bridges,
+from opentrace_agent.retrieval.clusters import (
+    cross_cluster_bridges as _cross_cluster_bridges,
 )
-from opentrace_agent.retrieval.communities import (
+from opentrace_agent.retrieval.clusters import (
     god_nodes as _god_nodes,
 )
-from opentrace_agent.retrieval.communities import (
-    list_communities as _list_communities,
+from opentrace_agent.retrieval.clusters import (
+    list_clusters as _list_clusters,
 )
 from opentrace_agent.store import GraphStore
 
@@ -1170,18 +1170,18 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
             return _error_response("overview", e)
 
     @server.tool()
-    def get_communities(limit: int = 100) -> str:
-        """List detected communities (Leiden/Louvain clusters) with cohesion and member counts.
+    def get_clusters(limit: int = 100) -> str:
+        """List detected clusters (Leiden/Louvain partition) with cohesion and member counts.
 
-        Run ``opentraceai cluster`` first to populate community membership.
+        Run ``opentraceai cluster`` first to populate cluster membership.
         """
         if not store:
             return NO_INDEX_MSG
         try:
-            rows = _list_communities(store)[: min(limit, 1000)]
+            rows = _list_clusters(store)[: min(limit, 1000)]
             return _json_response(rows)
         except Exception as e:
-            return _error_response("get_communities", e)
+            return _error_response("get_clusters", e)
 
     @server.tool()
     def get_god_nodes(limit: int = 20) -> str:
@@ -1198,17 +1198,17 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
 
     @server.tool()
     def get_bridges(limit: int = 50) -> str:
-        """List edges whose endpoints belong to different communities.
+        """List edges whose endpoints belong to different clusters.
 
-        Cross-community edges are the bridges that hold otherwise distinct
+        Cross-cluster edges are the bridges that hold otherwise distinct
         regions of the graph together — useful for orienting on which
         components are coupling concerns that look unrelated by name.
-        Run ``opentraceai cluster`` first; empty until communities exist.
+        Run ``opentraceai cluster`` first; empty until clusters exist.
         """
         if not store:
             return NO_INDEX_MSG
         try:
-            return _json_response(_cross_community_bridges(store, limit=min(limit, 500)))
+            return _json_response(_cross_cluster_bridges(store, limit=min(limit, 500)))
         except Exception as e:
             return _error_response("get_bridges", e)
 
@@ -1302,22 +1302,22 @@ def create_mcp_server(store: GraphStore | None) -> FastMCP:
             return _error_response("load_source", e)
 
     @server.tool()
-    def find_cross_cutting_communities(min_domains: int = 2, limit: int = 50) -> str:
-        """List Communities whose members span ≥``min_domains`` domains
+    def find_cross_cutting_clusters(min_domains: int = 2, limit: int = 50) -> str:
+        """List clusters whose members span ≥``min_domains`` domains
         (code / doc — the legacy runtime-node domain is only populated on
         graphs built by other producers).
 
         Requires ``opentraceai cluster`` to have been run first; returns an
-        empty list when no Community nodes exist.
+        empty list when no cluster assignments exist.
         """
         if not store:
             return NO_INDEX_MSG
         try:
             cap = min(limit, 500)
-            result = _find_communities_spanning_domains(store, min_domains=min_domains, limit=cap)
+            result = _find_clusters_spanning_domains(store, min_domains=min_domains, limit=cap)
             return _json_response(result)
         except Exception as e:
-            return _error_response("find_cross_cutting_communities", e)
+            return _error_response("find_cross_cutting_clusters", e)
 
     # Only advertise the documentation types when this index has them: on a
     # code-only graph the doc copy makes an agent chase a layer that isn't there.

--- a/agent/src/opentrace_agent/pipeline/cluster.py
+++ b/agent/src/opentrace_agent/pipeline/cluster.py
@@ -12,22 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Community detection over the OpenTrace graph.
+"""Clustering over the OpenTrace graph.
 
 Leiden via graspologic is preferred; falls back to Louvain via networkx when
 graspologic isn't available (e.g. Python ≥3.13 where graspologic doesn't
-build). Both produce a partition of node IDs into communities.
+build). Both are community-detection algorithms in the graph-theory sense;
+their output — a partition of node IDs — is what OpenTrace calls *clusters*.
+(The UI's unrelated viewer-local "communities" feature is a different thing;
+see ``ui/CLAUDE.md``.)
 
-``detect_communities(graph)`` is pure — networkx in, ``Community`` list out,
-no store access. Community size is bounded at ``OVERSIZE_SHARE`` of the
+``detect_clusters(graph)`` is pure — networkx in, ``Cluster`` list out,
+no store access. Cluster size is bounded at ``OVERSIZE_SHARE`` of the
 graph (a well-connected document can otherwise drag everything into one
 blob): on the Leiden path the bound is enforced natively by
 ``hierarchical_leiden(max_cluster_size=...)``, which recursively
-re-partitions any community over the cap; the Louvain fallback has no such
+re-partitions any cluster over the cap; the Louvain fallback has no such
 parameter, so it gets one explicit subdivision sweep instead. A second sweep
-subdivides large-but-sparse communities below ``SPARSE_COHESION_CEILING``
-(usually several real groups bridged by hub nodes). Each surviving community
-gets a cohesion score (intra-community edge density) and the biggest few are
+subdivides large-but-sparse clusters below ``SPARSE_COHESION_CEILING``
+(usually several real groups bridged by hub nodes). Each surviving cluster
+gets a cohesion score (intra-cluster edge density) and the biggest few are
 flagged ``is_god``. ``run_clustering`` wraps the store round-trip.
 """
 
@@ -40,12 +43,12 @@ from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
-# Sizing thresholds. The community-size cap is OVERSIZE_SHARE of the graph,
-# but never below MEMBER_CAP_FLOOR — splitting tiny communities produces
-# noise, not structure. A community is also re-partitioned when it has at
+# Sizing thresholds. The cluster-size cap is OVERSIZE_SHARE of the graph,
+# but never below MEMBER_CAP_FLOOR — splitting tiny clusters produces
+# noise, not structure. A cluster is also re-partitioned when it has at
 # least SPARSE_MIN_MEMBERS members but its edge density sits under
-# SPARSE_COHESION_CEILING. The top GOD_RANK_SHARE of communities by member
-# count are flagged as god communities.
+# SPARSE_COHESION_CEILING. The top GOD_RANK_SHARE of clusters by member
+# count are flagged as god clusters.
 OVERSIZE_SHARE = 0.25
 MEMBER_CAP_FLOOR = 10
 SPARSE_COHESION_CEILING = 0.05
@@ -54,8 +57,8 @@ GOD_RANK_SHARE = 0.10
 
 
 @dataclass(frozen=True)
-class Community:
-    """A detected community: integer id + the node ids that belong to it."""
+class Cluster:
+    """A detected cluster: integer id + the node ids that belong to it."""
 
     id: int
     members: tuple[str, ...]
@@ -79,10 +82,10 @@ def _try_leiden(graph, member_cap: int) -> dict[Any, int] | None:
     """Run Leiden via graspologic. Returns None if unavailable.
 
     ``member_cap`` is handed to graspologic as ``max_cluster_size``: any
-    community whose membership exceeds it gets its own induced subnetwork,
+    cluster whose membership exceeds it gets its own induced subnetwork,
     is re-partitioned, and the result is folded back into the overall map —
     recursively, until nothing exceeds the cap. ``final_level_hierarchical_clustering``
-    is the per-node assignment after all of that (communities that never
+    is the per-node assignment after all of that (clusters that never
     needed splitting only appear at level 0, so reading any single level
     would drop nodes).
     """
@@ -101,16 +104,16 @@ def _try_leiden(graph, member_cap: int) -> dict[Any, int] | None:
 def _louvain(graph) -> dict[Any, int]:
     """Louvain via networkx (always available). Deterministic via seed."""
     nx = _import_networkx()
-    communities = nx.community.louvain_communities(graph, seed=42)
+    groups = nx.community.louvain_communities(graph, seed=42)
     partition: dict[Any, int] = {}
-    for cid, members in enumerate(communities):
+    for cid, members in enumerate(groups):
         for node in members:
             partition[node] = cid
     return partition
 
 
 def _group_partition(partition: dict[Any, int]) -> list[list[Any]]:
-    """Turn a node→community-id mapping into member lists."""
+    """Turn a node→cluster-id mapping into member lists."""
     grouped: defaultdict[int, list[Any]] = defaultdict(list)
     for node, cid in partition.items():
         grouped[cid].append(node)
@@ -128,17 +131,17 @@ def _cohesion(graph, members: list[Any]) -> float:
 
 
 def _subdivide(graph, members: list[Any], member_cap: int) -> list[list[Any]]:
-    """Partition one community's induced subgraph into smaller ones.
+    """Partition one cluster's induced subgraph into smaller ones.
 
     Tries Leiden on the subgraph first and only falls back to Louvain, exactly
     as the top-level pass does. So the "Louvain fallback" is a hybrid whenever
     graspologic is installed but the top-level Leiden call returned nothing:
     Louvain partitions the whole graph, then Leiden re-partitions the oversized
-    and sparse communities. Both paths therefore converge on the same
+    and sparse clusters. Both paths therefore converge on the same
     subdivision behaviour, which is why only the top-level algorithm is
     reported.
 
-    A community the algorithm can't break apart comes back unchanged as a
+    A cluster the algorithm can't break apart comes back unchanged as a
     single-element list, so callers can splice the result in unconditionally.
     """
     if len(members) < 2:
@@ -158,15 +161,15 @@ def _sweep(
     return refined
 
 
-def detect_communities(graph) -> list[Community]:
-    """Partition a networkx Graph into size-bounded communities.
+def detect_clusters(graph) -> list[Cluster]:
+    """Partition a networkx Graph into size-bounded clusters.
 
     Pure function — does not touch the store. Output is ordered by member
     count, largest first; ids are the position in that order.
     """
     nx = _import_networkx()
     if not isinstance(graph, nx.Graph):
-        raise TypeError("detect_communities requires a networkx.Graph")
+        raise TypeError("detect_clusters requires a networkx.Graph")
     if graph.number_of_nodes() == 0:
         return []
 
@@ -177,7 +180,7 @@ def detect_communities(graph) -> list[Community]:
         # The size cap was enforced inside hierarchical Leiden.
         groups = _group_partition(partition)
     else:
-        # Louvain can't bound community size itself — sweep once afterwards.
+        # Louvain can't bound cluster size itself — sweep once afterwards.
         groups = _sweep(graph, _group_partition(_louvain(graph)), lambda m: len(m) > member_cap, member_cap)
 
     groups = _sweep(
@@ -190,7 +193,7 @@ def detect_communities(graph) -> list[Community]:
     ranked = sorted(groups, key=len, reverse=True)
     god_cutoff = max(1, int(len(ranked) * GOD_RANK_SHARE))
     return [
-        Community(
+        Cluster(
             id=rank,
             members=tuple(str(m) for m in members),
             cohesion=_cohesion(graph, members),
@@ -211,9 +214,9 @@ class ClusterReport:
 
     nodes: int
     edges: int
-    communities: int
-    god_communities: int
-    largest_community: int
+    clusters: int
+    god_clusters: int
+    largest_cluster: int
     mean_cohesion: float
 
 
@@ -248,17 +251,17 @@ def _short_member_name(member: dict[str, Any]) -> str:
     return name[:40]
 
 
-def _community_label(members: list[dict[str, Any]]) -> str:
+def _cluster_label(members: list[dict[str, Any]]) -> str:
     """Cheap deterministic label until LLM labelling is wired in.
 
-    Named after the community's two most-connected members (callers pass
+    Named after the cluster's two most-connected members (callers pass
     ``members`` ordered by degree) so listings read as content —
     ``"auth_service, login_handler +60"`` — rather than bookkeeping. The
     :mod:`pipeline.labels` module (added later) will replace this with an
     LLM call.
     """
     if not members:
-        return "empty community"
+        return "empty cluster"
     hubs = [_short_member_name(m) for m in members[:2]]
     label = ", ".join(hubs)
     remainder = len(members) - len(hubs)
@@ -266,22 +269,22 @@ def _community_label(members: list[dict[str, Any]]) -> str:
 
 
 def run_clustering(store) -> ClusterReport:  # type: ignore[no-untyped-def]
-    """End-to-end: read graph → detect communities → stamp the partition back.
+    """End-to-end: read graph → detect clusters → stamp the partition back.
 
-    The partition is written as a ``community`` property on each member, not as
+    The partition is written as a ``cluster`` property on each member, not as
     Community nodes and membership edges: it is derived from the graph, so it is
     metadata about nodes rather than graph data in its own right. The label,
     cohesion and god flag summarised in the returned report are recomputed on
-    read by ``retrieval.communities`` from the same partition, so nothing has to
+    read by ``retrieval.clusters`` from the same partition, so nothing has to
     be kept in sync with the members.
 
-    Idempotent: ``assign_communities`` rewrites every node's assignment.
+    Idempotent: ``assign_clusters`` rewrites every node's assignment.
     """
     # Clear before reading, not just before writing. A database written by the
     # old node-based model still holds Community nodes, and those are ordinary
     # nodes to the reader — partitioning would take clustering's own previous
     # output as input and report an inflated node count for the run.
-    store.clear_communities()
+    store.clear_clusters()
 
     g = build_graph_from_store(store)
     n_nodes = g.number_of_nodes()
@@ -289,25 +292,25 @@ def run_clustering(store) -> ClusterReport:  # type: ignore[no-untyped-def]
     if n_nodes == 0:
         return ClusterReport(0, 0, 0, 0, 0, 0.0)
 
-    communities = detect_communities(g)
+    clusters = detect_clusters(g)
 
-    store.assign_communities({nid: c.id for c in communities for nid in c.members})
+    store.assign_clusters({nid: c.id for c in clusters for nid in c.members})
 
     god_count = 0
     largest = 0
     cohesion_sum = 0.0
-    for c in communities:
+    for c in clusters:
         if c.is_god:
             god_count += 1
         largest = max(largest, len(c.members))
         cohesion_sum += c.cohesion
 
-    mean_cohesion = cohesion_sum / len(communities) if communities else 0.0
+    mean_cohesion = cohesion_sum / len(clusters) if clusters else 0.0
     return ClusterReport(
         nodes=n_nodes,
         edges=n_edges,
-        communities=len(communities),
-        god_communities=god_count,
-        largest_community=largest,
+        clusters=len(clusters),
+        god_clusters=god_count,
+        largest_cluster=largest,
         mean_cohesion=mean_cohesion,
     )

--- a/agent/src/opentrace_agent/retrieval/CLAUDE.md
+++ b/agent/src/opentrace_agent/retrieval/CLAUDE.md
@@ -15,8 +15,8 @@ existence.py   — find_orphans (two-query set difference)
 counts.py      — count_by (global or descendants-of-parent)
 provenance.py  — Trust chain for code (commit_sha + line range) and wiki (the doc's own identity)
 grep.py        — Regex match via ripgrep over a Repository or Vault scope
-communities.py — list_communities, god_nodes, cross_community_bridges
-cross_domain.py — cross_domain_bridges, find_communities_spanning_domains
+clusters.py    — list_clusters, god_nodes, cross_cluster_bridges
+cross_domain.py — cross_domain_bridges, find_clusters_spanning_domains
 ```
 
 ## Convention

--- a/agent/src/opentrace_agent/retrieval/__init__.py
+++ b/agent/src/opentrace_agent/retrieval/__init__.py
@@ -20,15 +20,15 @@ read-only by construction and follow the store/CLAUDE.md convention of
 parameterised values + hardcoded labels.
 """
 
-from opentrace_agent.retrieval.communities import (
-    cross_community_bridges,
+from opentrace_agent.retrieval.clusters import (
+    cross_cluster_bridges,
     god_nodes,
-    list_communities,
+    list_clusters,
 )
 from opentrace_agent.retrieval.counts import count_by
 from opentrace_agent.retrieval.cross_domain import (
     cross_domain_bridges,
-    find_communities_spanning_domains,
+    find_clusters_spanning_domains,
 )
 from opentrace_agent.retrieval.existence import find_orphans
 from opentrace_agent.retrieval.grep import grep
@@ -39,15 +39,15 @@ from opentrace_agent.retrieval.search import search
 
 __all__ = [
     "count_by",
-    "cross_community_bridges",
+    "cross_cluster_bridges",
     "cross_domain_bridges",
-    "find_communities_spanning_domains",
+    "find_clusters_spanning_domains",
     "find_orphans",
     "find_path",
     "find_via_relationship_to_type",
     "god_nodes",
     "grep",
-    "list_communities",
+    "list_clusters",
     "overview",
     "provenance",
     "search",

--- a/agent/src/opentrace_agent/retrieval/clusters.py
+++ b/agent/src/opentrace_agent/retrieval/clusters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Knowledge-graph highlights — communities, god nodes, bridges.
+"""Knowledge-graph highlights — clusters, god nodes, bridges.
 
 Thin typed helpers on top of the equivalent ``GraphStore`` methods. Lives
 here so the retrieval/ surface owns the API for MCP / REST / UI clients,
@@ -20,7 +20,7 @@ matching the convention already established by ``search``, ``overview``,
 ``paths``, etc. The underlying Cypher still lives in ``graph_store.py``
 because these queries depend on internal label / rel-type constants.
 
-A community is stored as the ``community`` id on each member, so the summary
+A cluster is stored as the ``cluster`` id on each member, so the summary
 a caller wants — label, member count, cohesion, god flag — is *derived* here
 from the partition rather than read back from a persisted row. Deriving is
 what keeps the summary honest: there is no second copy of the member count to
@@ -37,27 +37,27 @@ from opentrace_agent.store import GraphStore
 
 
 def _summarize(store: GraphStore) -> tuple[list[dict[str, Any]], dict[int, str]]:
-    """Derive every community's summary from the stored partition.
+    """Derive every cluster's summary from the stored partition.
 
     Returns ``(rows, labels_by_id)``. Cohesion and the god flag are recomputed
     with the same definitions ``pipeline.cluster`` used when it partitioned the
     graph, so a summary read back matches the run that produced it.
     """
-    from opentrace_agent.pipeline.cluster import GOD_RANK_SHARE, _community_label
+    from opentrace_agent.pipeline.cluster import GOD_RANK_SHARE, _cluster_label
     from opentrace_agent.store.graph_store import GraphStore as _Store
 
     nodes, edges = store.iter_analysis_graph()
-    key = _Store.COMMUNITY_PROPERTY
+    key = _Store.CLUSTER_PROPERTY
 
-    members_by_community: dict[int, list[dict[str, Any]]] = defaultdict(list)
-    community_of: dict[str, int] = {}
+    members_by_cluster: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    cluster_of: dict[str, int] = {}
     for node in nodes:
-        community = node.get(key)
-        if community is None:
+        cluster = node.get(key)
+        if cluster is None:
             continue
-        community_of[node["id"]] = int(community)
-        members_by_community[int(community)].append(node)
-    if not members_by_community:
+        cluster_of[node["id"]] = int(cluster)
+        members_by_cluster[int(cluster)].append(node)
+    if not members_by_cluster:
         return [], {}
 
     degree: dict[str, int] = defaultdict(int)
@@ -65,39 +65,39 @@ def _summarize(store: GraphStore) -> tuple[list[dict[str, Any]], dict[int, str]]
     for source, target in edges:
         degree[source] += 1
         degree[target] += 1
-        source_community = community_of.get(source)
-        if source_community is not None and source_community == community_of.get(target):
-            intra_edges[source_community] += 1
+        source_cluster = cluster_of.get(source)
+        if source_cluster is not None and source_cluster == cluster_of.get(target):
+            intra_edges[source_cluster] += 1
 
-    # God communities are the top GOD_RANK_SHARE by member count, matching
-    # detect_communities' ranking.
-    ranked = sorted(members_by_community, key=lambda cid: len(members_by_community[cid]), reverse=True)
+    # God clusters are the top GOD_RANK_SHARE by member count, matching
+    # detect_clusters' ranking.
+    ranked = sorted(members_by_cluster, key=lambda cid: len(members_by_cluster[cid]), reverse=True)
     god_cutoff = max(1, int(len(ranked) * GOD_RANK_SHARE))
     gods = set(ranked[:god_cutoff])
 
     rows: list[dict[str, Any]] = []
     labels: dict[int, str] = {}
-    for community_id, members in sorted(members_by_community.items()):
+    for cluster_id, members in sorted(members_by_cluster.items()):
         members.sort(key=lambda m: degree[m["id"]], reverse=True)
-        label = _community_label(members)
-        labels[community_id] = label
+        label = _cluster_label(members)
+        labels[cluster_id] = label
         size = len(members)
         possible = size * (size - 1) / 2
         rows.append(
             {
-                "id": community_id,
-                "community_id": community_id,
+                "id": cluster_id,
+                "cluster_id": cluster_id,
                 "name": label,
                 "members": size,
-                "cohesion": (intra_edges[community_id] / possible) if possible else 0.0,
-                "is_god": community_id in gods,
+                "cohesion": (intra_edges[cluster_id] / possible) if possible else 0.0,
+                "is_god": cluster_id in gods,
             }
         )
     return rows, labels
 
 
-def list_communities(store: GraphStore) -> list[dict[str, Any]]:
-    """Return every detected community, ordered by community id."""
+def list_clusters(store: GraphStore) -> list[dict[str, Any]]:
+    """Return every detected cluster, ordered by cluster id."""
     rows, _ = _summarize(store)
     return rows
 
@@ -111,21 +111,21 @@ def god_nodes(
     return store.list_god_nodes(limit=limit, exclude_types=exclude_types)
 
 
-def cross_community_bridges(
+def cross_cluster_bridges(
     store: GraphStore,
     limit: int = 50,
 ) -> list[dict[str, Any]]:
-    """Return edges whose endpoints belong to different communities.
+    """Return edges whose endpoints belong to different clusters.
 
-    The store compares the two endpoints' community ids; the labels are joined
+    The store compares the two endpoints' cluster ids; the labels are joined
     on here, where the derived summary lives.
     """
-    bridges = store.list_cross_community_bridges(limit=limit)
+    bridges = store.list_cross_cluster_bridges(limit=limit)
     if not bridges:
         return []
     _, labels = _summarize(store)
     for bridge in bridges:
         for end in ("source", "target"):
-            community_id = bridge[f"{end}_community_id"]
-            bridge[f"{end}_community_name"] = labels.get(community_id, str(community_id))
+            cluster_id = bridge[f"{end}_cluster_id"]
+            bridge[f"{end}_cluster_name"] = labels.get(cluster_id, str(cluster_id))
     return bridges

--- a/agent/src/opentrace_agent/retrieval/cross_domain.py
+++ b/agent/src/opentrace_agent/retrieval/cross_domain.py
@@ -107,48 +107,48 @@ def cross_domain_bridges(
     return bridges[:limit]
 
 
-def find_communities_spanning_domains(
+def find_clusters_spanning_domains(
     store: GraphStore,
     min_domains: int = 2,
     limit: int = 50,
 ) -> list[dict[str, Any]]:
-    """Return communities whose members come from ≥ *min_domains* domains.
+    """Return clusters whose members come from ≥ *min_domains* domains.
 
     Useful for "topics that bridge code and docs" surfacing. Returns
-    ``{community_id, name, domains, member_counts, total_members}`` per row,
+    ``{cluster_id, name, domains, member_counts, total_members}`` per row,
     sorted by total domain count descending then by total_members.
 
     Membership is a property on each node, so this is one scan and a group-by
-    rather than a traversal per community.
+    rather than a traversal per cluster.
     """
-    from opentrace_agent.retrieval.communities import _summarize
+    from opentrace_agent.retrieval.clusters import _summarize
     from opentrace_agent.store.graph_store import GraphStore as _Store
 
     nodes, _edges = store.iter_analysis_graph()
-    key = _Store.COMMUNITY_PROPERTY
+    key = _Store.CLUSTER_PROPERTY
 
-    domains_by_community: dict[int, dict[str, int]] = {}
+    domains_by_cluster: dict[int, dict[str, int]] = {}
     for node in nodes:
-        community = node.get(key)
-        if community is None:
+        cluster = node.get(key)
+        if cluster is None:
             continue
         dom = _domain_of(node.get("type") or "")
         if not dom:
             continue
-        counts = domains_by_community.setdefault(int(community), {})
+        counts = domains_by_cluster.setdefault(int(cluster), {})
         counts[dom] = counts.get(dom, 0) + 1
-    if not domains_by_community:
+    if not domains_by_cluster:
         return []
 
     _, labels = _summarize(store)
 
     out: list[dict[str, Any]] = []
-    for community_id, domain_counts in sorted(domains_by_community.items()):
+    for cluster_id, domain_counts in sorted(domains_by_cluster.items()):
         if len(domain_counts) >= min_domains:
             out.append(
                 {
-                    "community_id": community_id,
-                    "name": labels.get(community_id, str(community_id)),
+                    "cluster_id": cluster_id,
+                    "name": labels.get(cluster_id, str(cluster_id)),
                     "domains": sorted(domain_counts.keys()),
                     "member_counts": domain_counts,
                     "total_members": sum(domain_counts.values()),

--- a/agent/src/opentrace_agent/store/CLAUDE.md
+++ b/agent/src/opentrace_agent/store/CLAUDE.md
@@ -41,34 +41,40 @@ The schema is **enumerated**, not free-form. Allowed node types live in
 - Rel types: `CONTAINS` (Vault → KnowledgeDoc), `LINKS_TO` (doc→doc author links, parsed mechanically from relative markdown links), `MIRRORS` (KnowledgeDoc → File twin), `DOCUMENTS` (Repository → repo-spawned Vault)
 - `Repository.local_path` — set on local-directory indexes; null on cloned-remote (lets `retrieval/grep.py` shell out to ripgrep)
 
-### Communities are a node property, not a node type
+### Clusters are a node property, not a node type
 
-`opentraceai cluster` writes its partition as the `community` integer on each
-member (`assign_communities` / `clear_communities` / `node_communities`). There
-is deliberately no `Community` node type and no `MEMBER_OF_COMMUNITY` edge.
+`opentraceai cluster` writes its partition as the `cluster` integer on each
+member (`assign_clusters` / `clear_clusters` / `node_clusters`). There is
+deliberately no cluster node type and no membership edge. (Unrelated: the
+`Cluster` entry in `VALID_NODE_TYPES` is a runtime/observability concept — a
+k8s cluster — with no producer today.)
 
-The pair existed briefly and was removed before any release. Because derived
-data sat in the same tables as indexed data, every consumer had to remember to
-exclude it, and the ones that forgot were silently wrong: `stats` counted
-communities as indexed content (a 34-node graph reported 39 nodes / 75 edges
-after clustering), the viewer rendered them as ordinary nodes, and
-`list_god_nodes` ranked a community as a top hub because it has one edge per
-member. Keeping the partition in a property makes the whole class unrepresentable
-— an attribute cannot be counted as a node or walked as an edge.
+A `Community` node type + `MEMBER_OF_COMMUNITY` edge pair existed briefly and
+was removed before any release. Because derived data sat in the same tables as
+indexed data, every consumer had to remember to exclude it, and the ones that
+forgot were silently wrong: `stats` counted the partition as indexed content
+(a 34-node graph reported 39 nodes / 75 edges after clustering), the viewer
+rendered its rows as ordinary nodes, and `list_god_nodes` ranked one as a top
+hub because it has one edge per member. Keeping the partition in a property
+makes the whole class unrepresentable — an attribute cannot be counted as a
+node or walked as an edge. The property was briefly named `community`;
+`clear_clusters` sweeps that spelling too, so a pre-rename DB carries no ghost
+key after a re-cluster.
 
-The per-community summary (label, member count, cohesion, god flag) is derived
-in `retrieval/communities.py::_summarize`, not stored, so no second copy can
+The per-cluster summary (label, member count, cohesion, god flag) is derived
+in `retrieval/clusters.py::_summarize`, not stored, so no second copy can
 drift from the members it describes. If you add a consumer, read it from there
 rather than persisting a summary alongside the nodes.
 
-**The UI has an unrelated thing with the same name.** `ui/src/components/graph/
-useCommunities.ts` runs its own Louvain in a Web Worker over whatever nodes the
-viewer currently has loaded, purely for colour and layout. It is ephemeral view
-state and does not read the property described here, so the viewer's grouping
-and what `analyze` reports can disagree about the same graph. Neither can
-substitute for the other: a Web Worker can't serve the CLI, exporters, or MCP,
-and browser-indexed graphs never run `cluster` so they have no stored partition.
-Don't "unify" them by deleting either one — see `ui/CLAUDE.md`.
+**The UI's "communities" are a different feature, not this partition renamed.**
+`ui/src/components/graph/useCommunities.ts` runs its own Louvain in a Web
+Worker over whatever nodes the viewer currently has loaded, purely for colour
+and layout. It is ephemeral view state and does not read the property described
+here, so the viewer's grouping and what `analyze` reports can disagree about
+the same graph. Neither can substitute for the other: a Web Worker can't serve
+the CLI, exporters, or MCP, and browser-indexed graphs never run `cluster` so
+they have no stored partition. Don't "unify" them by deleting either one — see
+`ui/CLAUDE.md`.
 
 ### `VALID_NODE_TYPES` is declarative only
 

--- a/agent/src/opentrace_agent/store/graph_store.py
+++ b/agent/src/opentrace_agent/store/graph_store.py
@@ -209,6 +209,9 @@ class GraphStore:
         # instead; it reloads on the next bulk import.
         self._node_ids: set[str] | None = None
         self._rel_ids: set[str] | None = None
+        # One-shot latch for the pre-rename cluster-property warning; see
+        # _warn_if_only_legacy_clusters.
+        self._warned_legacy_clusters = False
         self._load_extensions()
         if not read_only:
             self._ensure_schema()
@@ -1032,6 +1035,30 @@ class GraphStore:
     # pre-rename DB carries no ghost key after a re-cluster.
     _LEGACY_CLUSTER_PROPERTY = "community"
 
+    def _warn_if_only_legacy_clusters(self, *, saw_legacy: bool, saw_current: bool) -> None:
+        """Warn once when a graph is partitioned under the pre-rename key.
+
+        Nothing reads ``community`` any more, so such a graph does not error —
+        it reads as *un-partitioned*, and every cluster consumer (summaries,
+        bridges, cross-domain, all three exporters) quietly returns nothing.
+        An empty result is indistinguishable from "never clustered", so say
+        which one it is rather than letting the data appear to vanish.
+
+        Deliberately a warning and not a read fallback: honouring the old key
+        would keep it alive in every read path and leave two spellings of the
+        same property in circulation indefinitely. Re-clustering is cheap and
+        ``clear_clusters`` sweeps the old key, so one run ends the ambiguity.
+        """
+        if saw_current or not saw_legacy or self._warned_legacy_clusters:
+            return
+        self._warned_legacy_clusters = True
+        logger.warning(
+            "Graph carries the pre-rename `%s` property but no `%s` property, so it reads as "
+            "un-clustered and every cluster query will return empty. Re-run `opentraceai cluster`.",
+            self._LEGACY_CLUSTER_PROPERTY,
+            self.CLUSTER_PROPERTY,
+        )
+
     def iter_analysis_graph(
         self,
         *,
@@ -1047,6 +1074,8 @@ class GraphStore:
             parameters={"excl": list(exclude_types)},
         )
         nodes: list[dict[str, Any]] = []
+        saw_legacy = False
+        saw_current = False
         while node_result.has_next():
             r = node_result.get_next()
             props = _parse_props(r[3]) or {}
@@ -1054,7 +1083,11 @@ class GraphStore:
             cluster = props.get(self.CLUSTER_PROPERTY)
             if cluster is not None:
                 node[self.CLUSTER_PROPERTY] = cluster
+                saw_current = True
+            elif self._LEGACY_CLUSTER_PROPERTY in props:
+                saw_legacy = True
             nodes.append(node)
+        self._warn_if_only_legacy_clusters(saw_legacy=saw_legacy, saw_current=saw_current)
 
         edge_result = self._conn.execute(
             "MATCH (a:Node)-[r:RELATES]->(b:Node) WHERE NOT a.type IN $excl AND NOT b.type IN $excl RETURN a.id, b.id",
@@ -1185,12 +1218,16 @@ class GraphStore:
         """
         result = self._conn.execute("MATCH (n:Node) RETURN n.id, n.properties")
         out: dict[str, int] = {}
+        saw_legacy = False
         while result.has_next():
             r = result.get_next()
             props = _parse_props(r[1]) or {}
             cluster = props.get(self.CLUSTER_PROPERTY)
             if cluster is not None:
                 out[str(r[0])] = int(cluster)
+            elif self._LEGACY_CLUSTER_PROPERTY in props:
+                saw_legacy = True
+        self._warn_if_only_legacy_clusters(saw_legacy=saw_legacy, saw_current=bool(out))
         return out
 
     def get_node_cluster(self, node_id: str) -> int | None:
@@ -1198,7 +1235,15 @@ class GraphStore:
         node = self.get_node(node_id)
         if node is None:
             return None
-        cluster = (node.get("properties") or {}).get(self.CLUSTER_PROPERTY)
+        props = node.get("properties") or {}
+        cluster = props.get(self.CLUSTER_PROPERTY)
+        # Single node, so "unassigned" is the common case and can't imply a
+        # legacy graph — but this node carrying the old key and not the new
+        # one is conclusive on its own.
+        self._warn_if_only_legacy_clusters(
+            saw_legacy=self._LEGACY_CLUSTER_PROPERTY in props,
+            saw_current=cluster is not None,
+        )
         return None if cluster is None else int(cluster)
 
     def list_god_nodes(self, limit: int = 20, exclude_types: tuple[str, ...] = ()) -> list[dict[str, Any]]:

--- a/agent/src/opentrace_agent/store/graph_store.py
+++ b/agent/src/opentrace_agent/store/graph_store.py
@@ -1015,16 +1015,22 @@ class GraphStore:
             "nodes_by_type": nodes_by_type,
         }
 
-    # -- communities (node metadata, not graph data) ---------------------
+    # -- clusters (node metadata, not graph data) -------------------------
     #
-    # A community is derived from an already-indexed graph, so it is stored as
-    # the ``community`` property on each member rather than as a node with
+    # A cluster is derived from an already-indexed graph, so it is stored as
+    # the ``cluster`` property on each member rather than as a node with
     # membership edges. Nothing here needs to be excluded from a traversal, a
     # degree count, or a node census, because none of it is a node or an edge.
-    # The per-community summary (label, cohesion, god flag) is recomputed from
-    # the partition by ``retrieval.communities`` rather than persisted.
+    # The per-cluster summary (label, cohesion, god flag) is recomputed from
+    # the partition by ``retrieval.clusters`` rather than persisted.
+    #
+    # Distinct from the ``Cluster`` *node type* in constants.py, which is a
+    # runtime/observability concept (a k8s cluster) with no producer today.
 
-    COMMUNITY_PROPERTY = "community"
+    CLUSTER_PROPERTY = "cluster"
+    # The property was briefly named ``community``; swept on clear so a
+    # pre-rename DB carries no ghost key after a re-cluster.
+    _LEGACY_CLUSTER_PROPERTY = "community"
 
     def iter_analysis_graph(
         self,
@@ -1033,7 +1039,7 @@ class GraphStore:
     ) -> tuple[list[dict[str, Any]], list[tuple[str, str]]]:
         """Return (nodes, edges) for analytical workloads (clustering, exports).
 
-        Each node carries its ``community`` id when one has been assigned, so
+        Each node carries its ``cluster`` id when one has been assigned, so
         callers get the partition without a second query per node.
         """
         node_result = self._conn.execute(
@@ -1045,9 +1051,9 @@ class GraphStore:
             r = node_result.get_next()
             props = _parse_props(r[3]) or {}
             node: dict[str, Any] = {"id": str(r[0]), "type": str(r[1]), "name": str(r[2])}
-            community = props.get(self.COMMUNITY_PROPERTY)
-            if community is not None:
-                node[self.COMMUNITY_PROPERTY] = community
+            cluster = props.get(self.CLUSTER_PROPERTY)
+            if cluster is not None:
+                node[self.CLUSTER_PROPERTY] = cluster
             nodes.append(node)
 
         edge_result = self._conn.execute(
@@ -1060,34 +1066,37 @@ class GraphStore:
             edges.append((str(r[0]), str(r[1])))
         return nodes, edges
 
-    def assign_communities(self, assignments: dict[str, int]) -> int:
-        """Stamp ``community`` onto each node in *assignments*; clear the rest.
+    def assign_clusters(self, assignments: dict[str, int]) -> int:
+        """Stamp ``cluster`` onto each node in *assignments*; clear the rest.
 
-        Idempotent by construction: every node's community property is
+        Idempotent by construction: every node's cluster property is
         rewritten from the given partition, so a re-cluster cannot leave a
         stale assignment behind the way orphaned Community nodes could.
         Returns the number of nodes stamped.
         """
-        self.clear_communities()
+        self.clear_clusters()
         stamped = 0
-        for node_id, community_id in assignments.items():
-            if self._merge_node_property(node_id, self.COMMUNITY_PROPERTY, community_id):
+        for node_id, cluster_id in assignments.items():
+            if self._merge_node_property(node_id, self.CLUSTER_PROPERTY, cluster_id):
                 stamped += 1
         return stamped
 
-    def clear_communities(self) -> None:
-        """Drop the ``community`` property from every node that carries one."""
+    def clear_clusters(self) -> None:
+        """Drop the ``cluster`` property (and its legacy spelling) everywhere."""
+        keys = (self.CLUSTER_PROPERTY, self._LEGACY_CLUSTER_PROPERTY)
         result = self._conn.execute(
             "MATCH (n:Node) RETURN n.id, n.properties",
         )
-        stale: list[str] = []
+        stale: list[tuple[str, tuple[str, ...]]] = []
         while result.has_next():
             r = result.get_next()
             props = _parse_props(r[1]) or {}
-            if self.COMMUNITY_PROPERTY in props:
-                stale.append(str(r[0]))
-        for node_id in stale:
-            self._merge_node_property(node_id, self.COMMUNITY_PROPERTY, None)
+            present = tuple(k for k in keys if k in props)
+            if present:
+                stale.append((str(r[0]), present))
+        for node_id, present in stale:
+            for key in present:
+                self._merge_node_property(node_id, key, None)
         self._drop_legacy_community_nodes()
 
     # Communities were briefly stored as nodes + MEMBER_OF_COMMUNITY edges (see
@@ -1112,7 +1121,7 @@ class GraphStore:
         except Exception:
             # Best-effort: a graph with no legacy rows is the normal case, and
             # failing to sweep must not block a re-cluster.
-            logger.warning("clear_communities: legacy Community sweep failed", exc_info=True)
+            logger.warning("clear_clusters: legacy Community sweep failed", exc_info=True)
         else:
             # The in-memory id mirrors can't be filtered in place after a
             # delete; invalidate so the next bulk import reloads them.
@@ -1168,8 +1177,8 @@ class GraphStore:
             ids.add(str(rows.get_next()[0]))
         return ids
 
-    def node_communities(self) -> dict[str, int]:
-        """Return ``{node_id: community_id}`` for every assigned node.
+    def node_clusters(self) -> dict[str, int]:
+        """Return ``{node_id: cluster_id}`` for every assigned node.
 
         One scan, so callers building a partition-wide view don't issue a
         query per node.
@@ -1179,18 +1188,18 @@ class GraphStore:
         while result.has_next():
             r = result.get_next()
             props = _parse_props(r[1]) or {}
-            community = props.get(self.COMMUNITY_PROPERTY)
-            if community is not None:
-                out[str(r[0])] = int(community)
+            cluster = props.get(self.CLUSTER_PROPERTY)
+            if cluster is not None:
+                out[str(r[0])] = int(cluster)
         return out
 
-    def get_node_community(self, node_id: str) -> int | None:
-        """Return the community id a node belongs to, or None if unassigned."""
+    def get_node_cluster(self, node_id: str) -> int | None:
+        """Return the cluster id a node belongs to, or None if unassigned."""
         node = self.get_node(node_id)
         if node is None:
             return None
-        community = (node.get("properties") or {}).get(self.COMMUNITY_PROPERTY)
-        return None if community is None else int(community)
+        cluster = (node.get("properties") or {}).get(self.CLUSTER_PROPERTY)
+        return None if cluster is None else int(cluster)
 
     def list_god_nodes(self, limit: int = 20, exclude_types: tuple[str, ...] = ()) -> list[dict[str, Any]]:
         """Return top-degree non-synthetic nodes.
@@ -1198,7 +1207,7 @@ class GraphStore:
         Degree = inbound + outbound RELATES count. Excludes the index-metadata
         type by default; pass extra types in ``exclude_types`` to filter further.
 
-        Community membership needs no exclusion here: it is a node property, so
+        Cluster membership needs no exclusion here: it is a node property, so
         it contributes neither a node to rank nor an edge to count.
         """
         exclude = (NODE_TYPE_INDEX_METADATA, *exclude_types)
@@ -1223,17 +1232,17 @@ class GraphStore:
             )
         return rows
 
-    def list_cross_community_bridges(self, limit: int = 50) -> list[dict[str, Any]]:
-        """Return edges whose endpoints carry different ``community`` ids.
+    def list_cross_cluster_bridges(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return edges whose endpoints carry different ``cluster`` ids.
 
         Edges where either endpoint is unassigned are skipped — an unassigned
-        node is not evidence of a boundary. Community *labels* are not attached
-        here: they are derived from the partition, so ``retrieval.communities``
+        node is not evidence of a boundary. Cluster *labels* are not attached
+        here: they are derived from the partition, so ``retrieval.clusters``
         joins them on. Useful for surfacing cross-cluster couplings — places
         where two architecturally distinct regions touch.
         """
-        communities = self.node_communities()
-        if not communities:
+        clusters = self.node_clusters()
+        if not clusters:
             return []
 
         result = self._conn.execute(
@@ -1242,20 +1251,20 @@ class GraphStore:
         rows: list[dict[str, Any]] = []
         while result.has_next():
             r = result.get_next()
-            source_community = communities.get(str(r[0]))
-            target_community = communities.get(str(r[2]))
-            if source_community is None or target_community is None:
+            source_cluster = clusters.get(str(r[0]))
+            target_cluster = clusters.get(str(r[2]))
+            if source_cluster is None or target_cluster is None:
                 continue
-            if source_community == target_community:
+            if source_cluster == target_cluster:
                 continue
             rows.append(
                 {
                     "source_id": str(r[0]),
                     "source_name": str(r[1]),
-                    "source_community_id": source_community,
+                    "source_cluster_id": source_cluster,
                     "target_id": str(r[2]),
                     "target_name": str(r[3]),
-                    "target_community_id": target_community,
+                    "target_cluster_id": target_cluster,
                     "relation": str(r[4]),
                 }
             )

--- a/agent/tests/opentrace_agent/cli/test_cluster_analyze_cmd.py
+++ b/agent/tests/opentrace_agent/cli/test_cluster_analyze_cmd.py
@@ -49,7 +49,7 @@ class TestClusterCmd:
         run_cluster_cli(db, output_json=False)
         out = capsys.readouterr().out
         assert "Clustered 8 nodes" in out
-        assert "communities" in out
+        assert "clusters" in out
 
     def test_json_output(self, tmp_path, capsys):
         db = str(tmp_path / "db")
@@ -57,7 +57,7 @@ class TestClusterCmd:
         run_cluster_cli(db, output_json=True)
         payload = json.loads(capsys.readouterr().out)
         assert payload["nodes"] == 8
-        assert payload["communities"] >= 2
+        assert payload["clusters"] >= 2
 
     def test_empty_db_friendly_message(self, tmp_path, capsys):
         db = str(tmp_path / "db")
@@ -76,7 +76,7 @@ class TestAnalyzeCmd:
         run_analyze_cli(db, output_json=False)
         out = capsys.readouterr().out
         assert "God nodes" in out
-        assert "Cross-community bridges" in out
+        assert "Cross-cluster bridges" in out
         assert "Suggested questions" in out
 
     def test_json_includes_questions(self, tmp_path, capsys):
@@ -91,7 +91,7 @@ class TestAnalyzeCmd:
         assert "questions" in payload
         assert isinstance(payload["questions"], list)
 
-    def test_no_communities_means_no_bridges(self, tmp_path, capsys):
+    def test_no_clusters_means_no_bridges(self, tmp_path, capsys):
         # Pre-cluster state: god nodes are still reported, bridges are empty.
         db = str(tmp_path / "db")
         _seed(db)

--- a/agent/tests/opentrace_agent/cli/test_export_graph.py
+++ b/agent/tests/opentrace_agent/cli/test_export_graph.py
@@ -37,13 +37,13 @@ def _seed(db_path: str) -> None:
         s.add_node("f2", "Function", "beta")
         s.add_relationship("r1", "CALLS", "f1", "f2")
         # Cluster output: a partition stamped onto the members themselves.
-        s.assign_communities({"f1": 1, "f2": 1})
+        s.assign_clusters({"f1": 1, "f2": 1})
         # Metadata that should be excluded.
         s.save_metadata({"repoId": "test", "indexedAt": "2026-05-14"})
 
 
 class TestBuildExportGraph:
-    def test_carries_community_attr_and_excludes_metadata(self, tmp_path):
+    def test_carries_cluster_attr_and_excludes_metadata(self, tmp_path):
         db = str(tmp_path / "db")
         _seed(db)
         with GraphStore(db) as store:
@@ -52,18 +52,18 @@ class TestBuildExportGraph:
         # IndexMetadata id starts with `_meta:index:`
         assert not any(str(n).startswith("_meta:index:") for n in g.nodes)
         # The partition is an attribute, so Gephi can colour by it without
-        # a community node or a membership edge existing to render.
-        assert g.nodes["f1"]["community"] == 1
-        assert g.nodes["f2"]["community"] == 1
+        # a cluster node or a membership edge existing to render.
+        assert g.nodes["f1"]["cluster"] == 1
+        assert g.nodes["f2"]["cluster"] == 1
         assert g.number_of_nodes() == 2
 
-    def test_unassigned_node_gets_sentinel_community(self, tmp_path):
+    def test_unassigned_node_gets_sentinel_cluster(self, tmp_path):
         db = str(tmp_path / "db")
         with GraphStore(db) as s:
             s.add_node("lonely", "Function", "lonely")
         with GraphStore(db) as store:
             g = _build_export_graph(store)
-        assert g.nodes["lonely"]["community"] == -1
+        assert g.nodes["lonely"]["cluster"] == -1
 
     def test_node_attrs_are_primitive_strings(self, tmp_path):
         db = str(tmp_path / "db")
@@ -94,9 +94,9 @@ class TestGraphmlCmd:
         # Node IDs should appear in the export.
         assert "f1" in text
         assert "f2" in text
-        # The community rides as a node attribute — GraphML declares a key for
-        # it — so Gephi can colour by community with no community node present.
-        assert 'attr.name="community"' in text
+        # The cluster rides as a node attribute — GraphML declares a key for
+        # it — so Gephi can colour by cluster with no cluster node present.
+        assert 'attr.name="cluster"' in text
 
     def test_requires_existing_db(self, tmp_path):
         out = tmp_path / "out.graphml"

--- a/agent/tests/opentrace_agent/cli/test_export_obsidian_wiki.py
+++ b/agent/tests/opentrace_agent/cli/test_export_obsidian_wiki.py
@@ -27,21 +27,21 @@ from opentrace_agent.cli.export_graph import _slugify, export_graph_app  # noqa:
 from opentrace_agent.store import GraphStore  # noqa: E402
 
 
-def _community_names(db_path: str) -> dict[int, str]:
-    """Map community id → its derived label and exported slug.
+def _cluster_names(db_path: str) -> dict[int, str]:
+    """Map cluster id → its derived label and exported slug.
 
-    Labels are derived from each community's top members rather than stored, so
+    Labels are derived from each cluster's top members rather than stored, so
     the tests resolve them from the store instead of hardcoding a name the
     fixture no longer sets.
     """
-    from opentrace_agent.retrieval.communities import list_communities
+    from opentrace_agent.retrieval.clusters import list_clusters
 
     with GraphStore(db_path) as s:
-        return {c["id"]: c["name"] for c in list_communities(s)}
+        return {c["id"]: c["name"] for c in list_clusters(s)}
 
 
 def _seed(db_path: str) -> None:
-    """Two communities of two nodes each, with a bridge edge."""
+    """Two clusters of two nodes each, with a bridge edge."""
     with GraphStore(db_path) as s:
         for i in range(2):
             s.add_node(f"a{i}", "Function", f"alpha-{i}")
@@ -49,7 +49,7 @@ def _seed(db_path: str) -> None:
         s.add_relationship("ea", "CALLS", "a0", "a1")
         s.add_relationship("eb", "CALLS", "b0", "b1")
         s.add_relationship("ebridge", "CALLS", "a0", "b0")
-        s.assign_communities({"a0": 1, "a1": 1, "b0": 2, "b1": 2})
+        s.assign_clusters({"a0": 1, "a1": 1, "b0": 2, "b1": 2})
 
 
 class TestSlugify:
@@ -72,17 +72,17 @@ class TestObsidianExport:
         result = runner.invoke(export_graph_app, ["obsidian", "--db", db, "--output", str(out)])
         assert result.exit_code == 0, result.output
         md_files = list(out.rglob("*.md"))
-        # 4 source nodes → 4 .md files. Communities live in folder names, not separate files.
+        # 4 source nodes → 4 .md files. Clusters live in folder names, not separate files.
         assert len(md_files) == 4
 
-    def test_community_folder_structure(self, tmp_path):
+    def test_cluster_folder_structure(self, tmp_path):
         db = str(tmp_path / "db")
         _seed(db)
         out = tmp_path / "vault"
         runner = CliRunner()
         runner.invoke(export_graph_app, ["obsidian", "--db", db, "--output", str(out)])
-        # Each community's derived label slugifies into a folder.
-        names = _community_names(db)
+        # Each cluster's derived label slugifies into a folder.
+        names = _cluster_names(db)
         assert (out / _slugify(names[1])).is_dir()
         assert (out / _slugify(names[2])).is_dir()
 
@@ -92,7 +92,7 @@ class TestObsidianExport:
         out = tmp_path / "vault"
         runner = CliRunner()
         runner.invoke(export_graph_app, ["obsidian", "--db", db, "--output", str(out)])
-        a0 = out / _slugify(_community_names(db)[1]) / "alpha-0.md"
+        a0 = out / _slugify(_cluster_names(db)[1]) / "alpha-0.md"
         text = a0.read_text()
         # a0 has outgoing edges to a1 + bridge to b0 → wikilinks for both.
         assert "[[alpha-1]]" in text
@@ -104,14 +104,14 @@ class TestObsidianExport:
         out = tmp_path / "vault"
         runner = CliRunner()
         runner.invoke(export_graph_app, ["obsidian", "--db", db, "--output", str(out)])
-        a0 = out / _slugify(_community_names(db)[1]) / "alpha-0.md"
+        a0 = out / _slugify(_cluster_names(db)[1]) / "alpha-0.md"
         text = a0.read_text()
         assert text.startswith("---\n")
         assert 'id: "a0"' in text
         assert "type: Function" in text
 
     def test_uncategorised_nodes_get_their_own_folder(self, tmp_path):
-        """A node without a community membership lands in _uncategorised/."""
+        """A node without a cluster membership lands in _uncategorised/."""
         db = str(tmp_path / "db")
         with GraphStore(db) as s:
             s.add_node("orphan", "Function", "orphan")
@@ -123,7 +123,7 @@ class TestObsidianExport:
 
 
 class TestWikiExport:
-    def test_writes_index_and_community_files(self, tmp_path):
+    def test_writes_index_and_cluster_files(self, tmp_path):
         db = str(tmp_path / "db")
         _seed(db)
         out = tmp_path / "wiki"
@@ -131,33 +131,33 @@ class TestWikiExport:
         result = runner.invoke(export_graph_app, ["report", "--db", db, "--output", str(out)])
         assert result.exit_code == 0, result.output
         assert (out / "index.md").exists()
-        names = _community_names(db)
-        assert (out / "communities" / f"{_slugify(names[1])}.md").exists()
-        assert (out / "communities" / f"{_slugify(names[2])}.md").exists()
+        names = _cluster_names(db)
+        assert (out / "clusters" / f"{_slugify(names[1])}.md").exists()
+        assert (out / "clusters" / f"{_slugify(names[2])}.md").exists()
         assert (out / "gods").is_dir()
 
-    def test_index_links_to_communities(self, tmp_path):
+    def test_index_links_to_clusters(self, tmp_path):
         db = str(tmp_path / "db")
         _seed(db)
         out = tmp_path / "wiki"
         runner = CliRunner()
         runner.invoke(export_graph_app, ["report", "--db", db, "--output", str(out)])
         index = (out / "index.md").read_text()
-        names = _community_names(db)
-        assert f"communities/{_slugify(names[1])}.md" in index
-        assert f"communities/{_slugify(names[2])}.md" in index
+        names = _cluster_names(db)
+        assert f"clusters/{_slugify(names[1])}.md" in index
+        assert f"clusters/{_slugify(names[2])}.md" in index
         assert "## God Nodes" in index
 
-    def test_community_article_lists_members(self, tmp_path):
+    def test_cluster_article_lists_members(self, tmp_path):
         db = str(tmp_path / "db")
         _seed(db)
         out = tmp_path / "wiki"
         runner = CliRunner()
         runner.invoke(export_graph_app, ["report", "--db", db, "--output", str(out)])
-        alpha = (out / "communities" / f"{_slugify(_community_names(db)[1])}.md").read_text()
+        alpha = (out / "clusters" / f"{_slugify(_cluster_names(db)[1])}.md").read_text()
         assert "alpha-0" in alpha
         assert "alpha-1" in alpha
-        # Cross-community connections should surface the bridge edge.
+        # Cross-cluster connections should surface the bridge edge.
         assert "beta-0" in alpha
 
     def test_god_article_shows_degree(self, tmp_path):
@@ -185,7 +185,7 @@ class TestWikiExport:
 
 
 def _seed_rich(db_path: str) -> None:
-    """The base two-community seed plus index metadata."""
+    """The base two-cluster seed plus index metadata."""
     _seed(db_path)
     with GraphStore(db_path) as s:
         s.save_metadata(
@@ -209,33 +209,33 @@ class TestReportDashboard:
         assert "Indexed from `demo` @ abcdef12 (main)" in index
         assert "opentraceai 1.2.3" in index
 
-    def test_index_renders_mermaid_community_map(self, tmp_path):
+    def test_index_renders_mermaid_cluster_map(self, tmp_path):
         db = str(tmp_path / "db")
         _seed_rich(db)
         out = tmp_path / "wiki"
         CliRunner().invoke(export_graph_app, ["report", "--db", db, "--output", str(out)])
         index = (out / "index.md").read_text()
         assert "```mermaid" in index
-        assert f'c1["{_community_names(db)[1]} (2)"]' in index
-        # One bridge edge between the two communities.
+        assert f'c1["{_cluster_names(db)[1]} (2)"]' in index
+        # One bridge edge between the two clusters.
         assert "c1 ---|1| c2" in index
 
-    def test_bridges_page_lists_cross_community_edges(self, tmp_path):
+    def test_bridges_page_lists_cross_cluster_edges(self, tmp_path):
         db = str(tmp_path / "db")
         _seed_rich(db)
         out = tmp_path / "wiki"
         CliRunner().invoke(export_graph_app, ["report", "--db", db, "--output", str(out)])
         bridges = (out / "bridges.md").read_text()
-        assert "## Cross-community" in bridges
+        assert "## Cross-cluster" in bridges
         assert "alpha-0" in bridges and "beta-0" in bridges
 
-    def test_community_page_groups_connections_by_target(self, tmp_path):
+    def test_cluster_page_groups_connections_by_target(self, tmp_path):
         db = str(tmp_path / "db")
         _seed_rich(db)
         out = tmp_path / "wiki"
         CliRunner().invoke(export_graph_app, ["report", "--db", db, "--output", str(out)])
-        names = _community_names(db)
-        alpha = (out / "communities" / f"{_slugify(names[1])}.md").read_text()
-        assert "## Connections to other communities" in alpha
+        names = _cluster_names(db)
+        alpha = (out / "clusters" / f"{_slugify(names[1])}.md").read_text()
+        assert "## Connections to other clusters" in alpha
         assert f"[{names[2]}]({_slugify(names[2])}.md): 1 edge" in alpha
         assert "alpha-0 → beta-0 (CALLS)" in alpha

--- a/agent/tests/opentrace_agent/cli/test_mcp_knowledge_tools.py
+++ b/agent/tests/opentrace_agent/cli/test_mcp_knowledge_tools.py
@@ -14,7 +14,7 @@
 
 """Tests for the new MCP knowledge-graph tools.
 
-Exercises ``get_communities``, ``get_god_nodes``, ``get_bridges``, and
+Exercises ``get_clusters``, ``get_god_nodes``, ``get_bridges``, and
 ``find_path`` against a hand-built GraphStore. Mirrors the pattern in
 ``tests/opentrace_agent/graph/test_mcp_integration.py``.
 """
@@ -47,39 +47,39 @@ def _call_raw(store: GraphStore | None, tool_name: str, **kwargs) -> str:
 @pytest.fixture()
 def store(tmp_path):
     s = GraphStore(str(tmp_path / "db"))
-    # Two communities of two nodes each, with a bridge.
+    # Two clusters of two nodes each, with a bridge.
     for i in range(2):
         s.add_node(f"a{i}", "Function", f"a{i}")
         s.add_node(f"b{i}", "Function", f"b{i}")
     s.add_relationship("ea", "CALLS", "a0", "a1")
     s.add_relationship("eb", "CALLS", "b0", "b1")
     s.add_relationship("ebridge", "CALLS", "a0", "b0")
-    s.assign_communities({"a0": 1, "a1": 1, "b0": 2, "b1": 2})
+    s.assign_clusters({"a0": 1, "a1": 1, "b0": 2, "b1": 2})
     yield s
     s.close()
 
 
-class TestGetCommunities:
+class TestGetClusters:
     def test_returns_both(self, store):
-        rows = _call(store, "get_communities")
-        # Labels are derived from each community's members, not stored.
+        rows = _call(store, "get_clusters")
+        # Labels are derived from each cluster's members, not stored.
         assert sorted(r["id"] for r in rows) == [1, 2]
         assert sorted(r["name"] for r in rows) == ["a0, a1", "b0, b1"]
         assert all(r["members"] == 2 for r in rows)
 
     def test_no_index_message(self):
-        rows = _call(None, "get_communities")
+        rows = _call(None, "get_clusters")
         assert rows.get("status") == "ok"
         assert "No index" in rows["message"]
 
     def test_limit_applied(self, store):
-        rows = _call(store, "get_communities", limit=1)
+        rows = _call(store, "get_clusters", limit=1)
         assert len(rows) == 1
 
 
 class TestGetGodNodes:
     def test_top_by_degree(self, store):
-        # a0 and b0 both have degree 2 (each touches one intra-community
+        # a0 and b0 both have degree 2 (each touches one intra-cluster
         # edge and the bridge). The top result should be one of them.
         rows = _call(store, "get_god_nodes", limit=2)
         top_ids = {r["id"] for r in rows}
@@ -92,15 +92,15 @@ class TestGetGodNodes:
 
 
 class TestGetBridges:
-    def test_returns_cross_community_edges(self, store):
+    def test_returns_cross_cluster_edges(self, store):
         rows = _call(store, "get_bridges")
-        # The bridge edge connects a0 ↔ b0; should appear with distinct community IDs.
+        # The bridge edge connects a0 ↔ b0; should appear with distinct cluster IDs.
         bridge = next(
             (r for r in rows if {r["source_id"], r["target_id"]} == {"a0", "b0"}),
             None,
         )
         assert bridge is not None
-        assert bridge["source_community_id"] != bridge["target_community_id"]
+        assert bridge["source_cluster_id"] != bridge["target_cluster_id"]
 
     def test_no_index_message(self):
         rows = _call(None, "get_bridges")
@@ -148,7 +148,7 @@ class TestToolsRegistered:
     def test_tools_present(self, store):
         server = create_mcp_server(store)
         names = set(server._tool_manager._tools.keys())
-        for expected in ("get_communities", "get_god_nodes", "get_bridges", "find_path", "load_source"):
+        for expected in ("get_clusters", "get_god_nodes", "get_bridges", "find_path", "load_source"):
             assert expected in names
 
 

--- a/agent/tests/opentrace_agent/graph/test_graph_store.py
+++ b/agent/tests/opentrace_agent/graph/test_graph_store.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 
@@ -935,6 +936,41 @@ class TestKnowledgeGraph:
     def test_get_node_cluster_returns_none_for_unassigned(self, store):
         store.add_node("orphan", "Function", "orphan")
         assert store.get_node_cluster("orphan") is None
+
+    def test_legacy_only_partition_warns_instead_of_reading_as_empty(self, store, caplog):
+        """A pre-rename DB reads as un-clustered rather than erroring, so every
+        cluster consumer returns empty. That is indistinguishable from "never
+        clustered" — the warning is the only thing that tells them apart."""
+        store.add_node("fn1", "Function", "login", properties={"community": 3})
+        store.add_node("fn2", "Function", "logout", properties={"community": 3})
+
+        with caplog.at_level(logging.WARNING):
+            nodes, _ = store.iter_analysis_graph()
+
+        assert all("cluster" not in n for n in nodes), "the old key must not be read as a partition"
+        assert "Re-run `opentraceai cluster`" in caplog.text
+
+        # Latched: a single export calls into these paths repeatedly, and the
+        # advice does not get truer by repetition.
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            store.iter_analysis_graph()
+            store.node_clusters()
+            store.get_node_cluster("fn1")
+        assert caplog.text == ""
+
+    def test_no_legacy_warning_on_a_normal_graph(self, store, caplog):
+        """Unassigned nodes are the norm before a first cluster run — warning
+        on those would make the message noise and train people to ignore it."""
+        store.add_node("fn1", "Function", "login")
+        store.add_node("fn2", "Function", "logout")
+        with caplog.at_level(logging.WARNING):
+            store.iter_analysis_graph()
+            store.node_clusters()
+            store.get_node_cluster("fn1")
+            store.assign_clusters({"fn1": 1})
+            store.iter_analysis_graph()
+        assert "opentraceai cluster" not in caplog.text
 
     def test_clustering_adds_no_nodes(self, store):
         """Assignment is metadata: the node census must not move."""

--- a/agent/tests/opentrace_agent/graph/test_graph_store.py
+++ b/agent/tests/opentrace_agent/graph/test_graph_store.py
@@ -885,51 +885,62 @@ class TestGraphStoreContextManager:
 
 
 class TestKnowledgeGraph:
-    """Community, hyperedge, and semantic-edge round-trips."""
+    """Cluster, hyperedge, and semantic-edge round-trips."""
 
-    def test_assign_communities_roundtrip(self, store):
+    def test_assign_clusters_roundtrip(self, store):
         store.add_node("fn1", "Function", "login")
         store.add_node("fn2", "Function", "logout")
-        assert store.assign_communities({"fn1": 1, "fn2": 2}) == 2
-        assert store.get_node_community("fn1") == 1
-        assert store.get_node_community("fn2") == 2
+        assert store.assign_clusters({"fn1": 1, "fn2": 2}) == 2
+        assert store.get_node_cluster("fn1") == 1
+        assert store.get_node_cluster("fn2") == 2
 
     def test_assignment_preserves_existing_properties(self, store):
         """The partition is merged into properties, not written over them."""
         store.add_node("fn1", "Function", "login", properties={"path": "auth.py"})
-        store.assign_communities({"fn1": 7})
+        store.assign_clusters({"fn1": 7})
         props = store.get_node("fn1")["properties"]
-        assert props["community"] == 7
+        assert props["cluster"] == 7
         assert props["path"] == "auth.py"
 
-    def test_assign_communities_is_idempotent(self, store):
-        """Re-assigning rewrites, so a node cannot end up in two communities."""
+    def test_assign_clusters_is_idempotent(self, store):
+        """Re-assigning rewrites, so a node cannot end up in two clusters."""
         store.add_node("fn1", "Function", "login")
-        store.assign_communities({"fn1": 1})
-        store.assign_communities({"fn1": 2})
-        assert store.get_node_community("fn1") == 2
+        store.assign_clusters({"fn1": 1})
+        store.assign_clusters({"fn1": 2})
+        assert store.get_node_cluster("fn1") == 2
 
     def test_reassignment_clears_nodes_dropped_from_the_partition(self, store):
         """A node absent from the new partition must not keep its old id."""
         store.add_node("fn1", "Function", "login")
         store.add_node("fn2", "Function", "logout")
-        store.assign_communities({"fn1": 1, "fn2": 1})
-        store.assign_communities({"fn1": 1})
-        assert store.get_node_community("fn1") == 1
-        assert store.get_node_community("fn2") is None
+        store.assign_clusters({"fn1": 1, "fn2": 1})
+        store.assign_clusters({"fn1": 1})
+        assert store.get_node_cluster("fn1") == 1
+        assert store.get_node_cluster("fn2") is None
 
-    def test_assign_communities_ignores_unknown_nodes(self, store):
-        assert store.assign_communities({"nope": 1}) == 0
+    def test_assign_clusters_ignores_unknown_nodes(self, store):
+        assert store.assign_clusters({"nope": 1}) == 0
 
-    def test_get_node_community_returns_none_for_unassigned(self, store):
+    def test_assign_clusters_drops_legacy_community_key(self, store):
+        """A DB stamped by the pre-rename code carries ``community`` on its
+        nodes; re-clustering must not leave that ghost key in the properties
+        dump alongside the new ``cluster`` key."""
+        store.add_node("fn1", "Function", "login", properties={"community": 3, "path": "auth.py"})
+        store.assign_clusters({"fn1": 1})
+        props = store.get_node("fn1")["properties"]
+        assert props["cluster"] == 1
+        assert "community" not in props
+        assert props["path"] == "auth.py"
+
+    def test_get_node_cluster_returns_none_for_unassigned(self, store):
         store.add_node("orphan", "Function", "orphan")
-        assert store.get_node_community("orphan") is None
+        assert store.get_node_cluster("orphan") is None
 
     def test_clustering_adds_no_nodes(self, store):
         """Assignment is metadata: the node census must not move."""
         store.add_node("fn1", "Function", "login")
         before = store.get_stats()["total_nodes"]
-        store.assign_communities({"fn1": 1})
+        store.assign_clusters({"fn1": 1})
         assert store.get_stats()["total_nodes"] == before
 
     def test_list_god_nodes_sorted_by_degree(self, store):
@@ -944,40 +955,40 @@ class TestKnowledgeGraph:
         gods = store.list_god_nodes(limit=10, exclude_types=("Service",))
         assert all(g["type"] != "Service" for g in gods)
 
-    def test_cross_community_bridges(self, store):
-        # Two communities, one bridge edge
+    def test_cross_cluster_bridges(self, store):
+        # Two clusters, one bridge edge
         store.add_node("n1", "Function", "n1")
         store.add_node("n2", "Function", "n2")
-        store.assign_communities({"n1": 1, "n2": 2})
+        store.assign_clusters({"n1": 1, "n2": 2})
         store.add_relationship("r1", "CALLS", "n1", "n2")
-        bridges = store.list_cross_community_bridges()
+        bridges = store.list_cross_cluster_bridges()
         assert len(bridges) == 1
         b = bridges[0]
         assert b["source_id"] == "n1"
         assert b["target_id"] == "n2"
-        assert b["source_community_id"] != b["target_community_id"]
+        assert b["source_cluster_id"] != b["target_cluster_id"]
         assert b["relation"] == "CALLS"
 
-    def test_intra_community_edge_is_not_a_bridge(self, store):
+    def test_intra_cluster_edge_is_not_a_bridge(self, store):
         store.add_node("n1", "Function", "n1")
         store.add_node("n2", "Function", "n2")
-        store.assign_communities({"n1": 1, "n2": 1})
+        store.assign_clusters({"n1": 1, "n2": 1})
         store.add_relationship("r1", "CALLS", "n1", "n2")
-        assert store.list_cross_community_bridges() == []
+        assert store.list_cross_cluster_bridges() == []
 
     def test_unassigned_endpoint_is_not_a_bridge(self, store):
-        """An unassigned node is not evidence of a community boundary."""
+        """An unassigned node is not evidence of a cluster boundary."""
         store.add_node("n1", "Function", "n1")
         store.add_node("n2", "Function", "n2")
-        store.assign_communities({"n1": 1})
+        store.assign_clusters({"n1": 1})
         store.add_relationship("r1", "CALLS", "n1", "n2")
-        assert store.list_cross_community_bridges() == []
+        assert store.list_cross_cluster_bridges() == []
 
-    def test_cross_community_bridges_on_unclustered_graph(self, store):
+    def test_cross_cluster_bridges_on_unclustered_graph(self, store):
         store.add_node("n1", "Function", "n1")
         store.add_node("n2", "Function", "n2")
         store.add_relationship("r1", "CALLS", "n1", "n2")
-        assert store.list_cross_community_bridges() == []
+        assert store.list_cross_cluster_bridges() == []
 
 
 class TestFtsSearchOrdering:

--- a/agent/tests/opentrace_agent/pipeline/test_cluster.py
+++ b/agent/tests/opentrace_agent/pipeline/test_cluster.py
@@ -22,13 +22,13 @@ nx = pytest.importorskip("networkx")
 ladybug = pytest.importorskip("real_ladybug")
 
 from opentrace_agent.pipeline.cluster import (  # noqa: E402
-    Community,
+    Cluster,
     _cohesion,
     build_graph_from_store,
-    detect_communities,
+    detect_clusters,
     run_clustering,
 )
-from opentrace_agent.retrieval.communities import list_communities  # noqa: E402
+from opentrace_agent.retrieval.clusters import list_clusters  # noqa: E402
 from opentrace_agent.store import GraphStore  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -36,9 +36,9 @@ from opentrace_agent.store import GraphStore  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-class TestDetectCommunities:
+class TestDetectClusters:
     def test_empty_graph(self):
-        assert detect_communities(nx.Graph()) == []
+        assert detect_clusters(nx.Graph()) == []
 
     def test_two_disjoint_cliques_split_into_two(self):
         g = nx.Graph()
@@ -50,22 +50,22 @@ class TestDetectCommunities:
         for i in range(5):
             for j in range(i + 1, 5):
                 g.add_edge(f"b{i}", f"b{j}")
-        communities = detect_communities(g)
-        # Expect two communities, each grouping its clique members.
-        assert len(communities) == 2
-        sizes = sorted(len(c.members) for c in communities)
+        clusters = detect_clusters(g)
+        # Expect two clusters, each grouping its clique members.
+        assert len(clusters) == 2
+        sizes = sorted(len(c.members) for c in clusters)
         assert sizes == [5, 5]
-        for c in communities:
-            # Members of each community must share the same prefix.
+        for c in clusters:
+            # Members of each cluster must share the same prefix.
             prefixes = {m[0] for m in c.members}
             assert len(prefixes) == 1
 
     def test_single_clique_has_high_cohesion(self):
         g = nx.complete_graph(6)
-        communities = detect_communities(g)
-        # Single complete graph → one community, cohesion 1.0
-        assert len(communities) == 1
-        assert communities[0].cohesion == pytest.approx(1.0)
+        clusters = detect_clusters(g)
+        # Single complete graph → one cluster, cohesion 1.0
+        assert len(clusters) == 1
+        assert clusters[0].cohesion == pytest.approx(1.0)
 
     def test_god_flag_marks_largest(self):
         g = nx.Graph()
@@ -76,18 +76,18 @@ class TestDetectCommunities:
         for i in range(3):
             for j in range(i + 1, 3):
                 g.add_edge(f"small{i}", f"small{j}")
-        communities = detect_communities(g)
-        gods = [c for c in communities if c.is_god]
-        assert gods, "expected at least one god community"
+        clusters = detect_clusters(g)
+        gods = [c for c in clusters if c.is_god]
+        assert gods, "expected at least one god cluster"
         assert all(len(g.members) >= 3 for g in gods)
 
-    def test_disconnected_singletons_become_own_communities(self):
+    def test_disconnected_singletons_become_own_clusters(self):
         g = nx.Graph()
         for i in range(5):
             g.add_node(f"iso{i}")
-        communities = detect_communities(g)
-        # Each isolated node is its own community.
-        assert sum(len(c.members) for c in communities) == 5
+        clusters = detect_clusters(g)
+        # Each isolated node is its own cluster.
+        assert sum(len(c.members) for c in clusters) == 5
 
 
 class TestCohesion:
@@ -142,24 +142,24 @@ class TestStoreRoundTrip:
         g = build_graph_from_store(store)
         assert g.number_of_nodes() == 8
 
-    def test_run_clustering_writes_communities(self, store):
+    def test_run_clustering_writes_clusters(self, store):
         _seed_two_clusters(store)
         report = run_clustering(store)
         assert report.nodes == 8
-        assert report.communities >= 2
-        communities = list_communities(store)
-        assert len(communities) == report.communities
-        # Verify membership: each non-internal node has a community.
+        assert report.clusters >= 2
+        clusters = list_clusters(store)
+        assert len(clusters) == report.clusters
+        # Verify membership: each non-internal node has a cluster.
         for prefix in ("a", "b"):
             for i in range(4):
-                c = store.get_node_community(f"{prefix}{i}")
-                assert c is not None, f"missing community for {prefix}{i}"
+                c = store.get_node_cluster(f"{prefix}{i}")
+                assert c is not None, f"missing cluster for {prefix}{i}"
 
     def test_clustering_adds_no_nodes_or_edges(self, store):
         """The partition is metadata, so it must not grow the graph.
 
         This is the property the Community-node model could not hold: it added
-        a node per community and an edge per member, which inflated every
+        a node per cluster and an edge per member, which inflated every
         census and degree count taken afterwards.
         """
         _seed_two_clusters(store)
@@ -174,28 +174,28 @@ class TestStoreRoundTrip:
         _seed_two_clusters(store)
         first = run_clustering(store)
         second = run_clustering(store)
-        # Re-running must not accumulate communities or stale assignments.
-        assert first.communities == second.communities
-        communities = list_communities(store)
-        assert len(communities) == second.communities
+        # Re-running must not accumulate clusters or stale assignments.
+        assert first.clusters == second.clusters
+        clusters = list_clusters(store)
+        assert len(clusters) == second.clusters
 
-    def test_clear_communities_removes_assignments(self, store):
+    def test_clear_clusters_removes_assignments(self, store):
         _seed_two_clusters(store)
         run_clustering(store)
-        assert list_communities(store)
-        store.clear_communities()
-        assert list_communities(store) == []
-        assert store.get_node_community("a0") is None
+        assert list_clusters(store)
+        store.clear_clusters()
+        assert list_clusters(store) == []
+        assert store.get_node_cluster("a0") is None
 
-    def test_clear_communities_preserves_the_nodes(self, store):
+    def test_clear_clusters_preserves_the_nodes(self, store):
         """Clearing drops the property, never the member it was stamped on."""
         _seed_two_clusters(store)
         run_clustering(store)
-        store.clear_communities()
+        store.clear_clusters()
         assert store.get_stats()["total_nodes"] == 8
         assert store.get_node("a0") is not None
 
-    def test_disjoint_clusters_assigned_distinct_communities(self, store):
+    def test_disjoint_components_assigned_distinct_clusters(self, store):
         # Two cliques with NO bridge edge between them.
         for i in range(4):
             store.add_node(f"a{i}", "Function", f"a{i}")
@@ -207,15 +207,15 @@ class TestStoreRoundTrip:
                     store.add_relationship(f"r{rel_id}", "CALLS", f"{prefix}{i}", f"{prefix}{j}")
                     rel_id += 1
         run_clustering(store)
-        ca = store.get_node_community("a0")
-        cb = store.get_node_community("b0")
+        ca = store.get_node_cluster("a0")
+        cb = store.get_node_cluster("b0")
         assert ca is not None and cb is not None
         assert ca != cb
 
     def test_empty_graph_returns_zeroes(self, store):
         report = run_clustering(store)
         assert report.nodes == 0
-        assert report.communities == 0
+        assert report.clusters == 0
 
     def test_legacy_community_nodes_are_swept_before_partitioning(self, store):
         """A DB from the old node-based model must not cluster its own output.
@@ -243,11 +243,11 @@ class TestStoreRoundTrip:
 
 
 # ---------------------------------------------------------------------------
-# Smoke: Community dataclass invariants
+# Smoke: Cluster dataclass invariants
 # ---------------------------------------------------------------------------
 
 
-def test_community_is_immutable():
-    c = Community(id=0, members=("a", "b"), cohesion=0.5, is_god=True)
+def test_cluster_is_immutable():
+    c = Cluster(id=0, members=("a", "b"), cohesion=0.5, is_god=True)
     with pytest.raises(Exception):
         c.id = 1  # type: ignore[misc]

--- a/docs/architecture/ontology.md
+++ b/docs/architecture/ontology.md
@@ -13,7 +13,7 @@ The graph organises into two domains:
 
 Doc ingestion is corpus-only: it indexes the documents (labels, epistemic status, doc↔doc links, `File` twins) and keeps their bodies verbatim. A `KnowledgeDoc` carries a title, a one-line summary, and an epistemic `status`; its normalized body sits verbatim in the corpus, readable with `load_source`, enumerable with `list_nodes`, and sweepable with `grep`.
 
-The one auxiliary type, `IndexMetadata`, sits outside the domains and comes from index bookkeeping. Community detection adds no type: it writes a `community` property onto the nodes it partitions.
+The one auxiliary type, `IndexMetadata`, sits outside the domains and comes from index bookkeeping. Clustering adds no type: it writes a `cluster` property onto the nodes it partitions.
 
 ## Node reference
 
@@ -147,16 +147,20 @@ Excluded from default cluster + analysis walks (it's bookkeeping, not data).
 | `MIRRORS` | KnowledgeDoc → File | The ingested doc's twin in the code tree. Emitted during `index --wiki` on a directory for every repo-walked doc; the KnowledgeDoc gets a repo-relative `path` property stamped. When the code walk didn't create the File node (extensions like `.rst`/`.txt`/`.html`/PDFs), it is created at link time so the twin always exists. Docs not from a repo walk (uploads, URLs, attached global vaults) have no edge. Bridges the corpus layer and the code tree — either twin reaches the other in one hop, and provenance chains include the mirrored File id |
 | `DOCUMENTS` | Repository → KnowledgeVault | The vault spawned from this repo. Written only by `index --wiki` runs where the wiki compile executes alongside a repo walk (the vault also gets a `spawned_from` stamp). Attached globals and vaults compiled from dropped files/URLs never get the edge — they live alongside a repo without documenting it. Joins the wiki layer to the code tree at the root |
 
-## Communities are a property, not a type
+## Clusters are a property, not a type
 
-`opentraceai cluster` stamps a `community` integer onto every node it
-partitions. There is no `Community` node and no membership edge, so clustering
+`opentraceai cluster` stamps a `cluster` integer onto every node it
+partitions. There is no cluster node and no membership edge, so clustering
 leaves the node and edge counts untouched and nothing downstream has to exclude
 its output from a census, a degree count, or a traversal.
 
-The per-community summary — label, member count, cohesion, god flag — is
-recomputed from the partition by `retrieval.communities` rather than stored, so
+The per-cluster summary — label, member count, cohesion, god flag — is
+recomputed from the partition by `retrieval.clusters` rather than stored, so
 there is no second copy to drift from the members it describes.
+
+(The UI viewer has an unrelated, ephemeral feature also called "communities" —
+its own on-screen Louvain grouping for colour and layout. It never touches the
+graph. See `ui/CLAUDE.md`.)
 
 ## Confidence on `CALLS`
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -23,7 +23,7 @@ OpenTrace builds a single knowledge graph that holds two layers of information a
 │  │  Pipeline      │  │   Retrieval primitives     │  │
 │  │  scan→process→ │  │   search / overview /      │  │
 │  │   extract→     │  │   find_path / provenance / │  │
-│  │   resolve→save │  │   communities / grep /     │  │
+│  │   resolve→save │  │   clusters / grep /        │  │
 │  │  + autoprune   │  │   cross_domain_bridges     │  │
 │  └────────────────┘  └────────────────────────────┘  │
 │                                                      │
@@ -68,9 +68,9 @@ doc domain      — KnowledgeVault / KnowledgeDoc
 
 `opentraceai analyze` surfaces:
 
-- **Cross-community bridges** — edges spanning detected communities
+- **Cross-cluster bridges** — edges spanning detected clusters
 - **Cross-domain bridges** — edges spanning code ↔ doc (the original "AuthMiddleware appears in 5 code files plus 2 design docs" view)
-- **Cross-cutting communities** — communities whose members span ≥2 domains
+- **Cross-cutting clusters** — clusters whose members span ≥2 domains
 
 `MIRRORS` is the code ↔ doc bridge — a `KnowledgeDoc` and its `File` twin reach each other in one hop.
 
@@ -96,7 +96,7 @@ Python package + CLI (`opentraceai`). Managed with [uv](https://docs.astral.sh/u
 |---|---|
 | `index` | Build/refresh the graph from code, docs, or both. See [Indexing](../getting-started/indexing.md) |
 | `vault` | Ingest a bare doc folder, and manage compiled vaults — ingest, list, show, attach, detach, promote, demote |
-| `cluster` / `analyze` | Community detection + cross-cutting analysis |
+| `cluster` / `analyze` | Graph clustering + cross-cutting analysis |
 | `export-graph` | Deterministic projections — graphml, obsidian, report |
 | `impact` | Blast radius for a changed file |
 | `serve` | REST API for the UI |
@@ -149,7 +149,7 @@ A typical full-stack run (`index ./repo myvault --wiki`):
                documents_deleted and corpus_files_deleted.
 ```
 
-`opentraceai cluster` and `opentraceai analyze` are separate steps that read the assembled graph and either stamp each node's `community` property (cluster) or just print analysis (analyze). Neither adds nodes or edges.
+`opentraceai cluster` and `opentraceai analyze` are separate steps that read the assembled graph and either stamp each node's `cluster` property (cluster) or just print analysis (analyze). Neither adds nodes or edges.
 
 ## Storage layout
 

--- a/docs/getting-started/indexing.md
+++ b/docs/getting-started/indexing.md
@@ -154,6 +154,6 @@ opentraceai index ./repo
 ## What's next
 
 - **Bring your vault into another graph** → [Wiki & Vaults](wiki.md)
-- **Surface gods / bridges / cross-cutting communities** → run `opentraceai cluster` then `opentraceai analyze`
+- **Surface gods / bridges / cross-cutting clusters** → run `opentraceai cluster` then `opentraceai analyze`
 - **Query the graph programmatically** → [Graph Tools](../reference/graph-tools.md)
 - **Configure providers** → [Wiki Providers](../reference/wiki-providers.md)

--- a/docs/getting-started/install-cli.md
+++ b/docs/getting-started/install-cli.md
@@ -54,7 +54,7 @@ Install the `opentraceai` command-line tool to index repositories and run an MCP
 
 ## Optional extras
 
-A plain install already includes everything doc ingestion and community
+A plain install already includes everything doc ingestion and cluster
 detection need — `markitdown[all]` for PDF/DOCX/PPTX/XLSX/HTML/EPUB conversion,
 `networkx` for clustering and the graph exporters, and the provider SDKs. There
 is no `graph` extra to add.
@@ -99,7 +99,7 @@ opentrace index /path/to/repo --wiki                   # also ingest docs into a
 opentrace index /path/docs foo --wiki                  # index docs into a vault named foo
 opentrace vault ingest /path/docs                      # docs-only: no repo required
 opentrace vault list                                   # vaults visible from current project
-opentrace cluster && opentrace analyze                 # community detection + cross-cutting analysis
+opentrace cluster && opentrace analyze                 # graph clustering + cross-cutting analysis
 opentrace mcp                                          # start an MCP server over stdio
 opentrace --help                                       # see all commands
 ```

--- a/docs/getting-started/wiki.md
+++ b/docs/getting-started/wiki.md
@@ -193,7 +193,7 @@ Then surface cross-cutting structure:
 
 ```bash
 opentraceai cluster
-opentraceai analyze            # god nodes + bridges + cross-domain bridges + cross-cutting communities
+opentraceai analyze            # god nodes + bridges + cross-domain bridges + cross-cutting clusters
 ```
 
 ## Where vaults live on disk

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -130,7 +130,7 @@ Errors with a list of visible vaults if `NAME` doesn't exist locally or globally
 
 ## `opentraceai cluster`
 
-Run community detection over the graph.
+Partition the graph into clusters.
 
 ```
 opentraceai cluster [--db PATH] [--json]
@@ -141,11 +141,11 @@ opentraceai cluster [--db PATH] [--json]
 | `--db PATH` | Graph DB |
 | `--json` | Output a structured summary instead of human-readable text |
 
-Stamps each member's `community` property; adds no nodes or edges. Idempotent — every assignment is rewritten on each run. Uses Leiden when `graspologic` is available, Louvain otherwise.
+Stamps each member's `cluster` property; adds no nodes or edges. Idempotent — every assignment is rewritten on each run. Uses Leiden when `graspologic` is available, Louvain otherwise.
 
 ## `opentraceai analyze`
 
-Surface god nodes, bridges, cross-domain bridges, and cross-cutting communities.
+Surface god nodes, bridges, cross-domain bridges, and cross-cutting clusters.
 
 ```
 opentraceai analyze [--db PATH] [--gods N] [--bridges N] [--json]
@@ -155,10 +155,10 @@ opentraceai analyze [--db PATH] [--gods N] [--bridges N] [--json]
 |---|---|
 | `--db PATH` | Graph DB |
 | `--gods N` | Top-N god nodes to surface (default 10) |
-| `--bridges N` | Top-N cross-community bridges to surface (default 10) |
-| `--json` | Output structured JSON with `gods`, `bridges`, `cross_domain_bridges`, `cross_cutting_communities`, `questions` |
+| `--bridges N` | Top-N cross-cluster bridges to surface (default 10) |
+| `--json` | Output structured JSON with `gods`, `bridges`, `cross_domain_bridges`, `cross_cutting_clusters`, `questions` |
 
-Run `cluster` first — bridges + cross-cutting communities depend on community membership.
+Run `cluster` first — bridges + cross-cutting clusters depend on cluster membership.
 
 ## `opentraceai export-graph`
 
@@ -173,8 +173,8 @@ opentraceai export-graph report   -o DIR [--db PATH]
 | Format | Output |
 |---|---|
 | `graphml` | Single `.graphml` file (Gephi, yEd, Cytoscape) |
-| `obsidian` | Markdown vault — one `.md` per node, folders by community, `[[wikilinks]]` for edges |
-| `report` | Folder of linked markdown pages — an `index.md` dashboard (provenance + Mermaid community map), per-community and per-god-node pages, and a `bridges.md` of community- and domain-crossing edges |
+| `obsidian` | Markdown vault — one `.md` per node, folders by cluster, `[[wikilinks]]` for edges |
+| `report` | Folder of linked markdown pages — an `index.md` dashboard (provenance + Mermaid cluster map), per-cluster and per-god-node pages, and a `bridges.md` of cluster- and domain-crossing edges |
 
 ## `opentraceai serve` / `opentraceai mcp`
 

--- a/docs/reference/graph-tools.md
+++ b/docs/reference/graph-tools.md
@@ -14,11 +14,11 @@ The OpenTrace knowledge graph is queryable through three transports: MCP (Model 
 | `count_by` | Global or descendants-of-parent counts | "How many Functions in this Service?" |
 | `provenance` | Trust chain — code (commit_sha + line range) or wiki (the document's own identity + its `MIRRORS` File twin) | "Where did this come from?" |
 | `grep` | Regex match via ripgrep over a Repository, or a Vault's full document corpus — every member doc's normalized body, hits joined to doc id/title/status | "Find this exact string in source" / "prove no document mentions X" / "what does every doc say about X" |
-| `list_communities` | Detected communities with cohesion + member counts, derived from the stored partition | After running `cluster` |
+| `list_clusters` | Detected clusters with cohesion + member counts, derived from the stored partition | After running `cluster` |
 | `god_nodes` | Top-degree nodes (centrality hubs) | "What's connected to everything?" |
-| `cross_community_bridges` | Edges spanning different communities | "Where do two clusters touch?" |
+| `cross_cluster_bridges` | Edges spanning different clusters | "Where do two clusters touch?" |
 | `cross_domain_bridges` | Edges spanning code / doc domains | "What connects code and docs?" |
-| `find_communities_spanning_domains` | Communities whose members span ≥N domains | Cross-cutting topics |
+| `find_clusters_spanning_domains` | Clusters whose members span ≥N domains | Cross-cutting topics |
 
 **"Which documents discuss X" is a `grep` sweep** — exhaustive, verbatim, and pre-labelled with each doc's title and status.
 
@@ -45,10 +45,10 @@ count_by                                # counts, optionally scoped to a parent
 overview                                # session-start orientation
 provenance                              # trust chain for a node
 grep                                    # ripgrep over Repository / Vault scope
-get_communities                         # listed clusters
+get_clusters                            # listed clusters
 get_god_nodes                           # centrality hubs
-get_bridges                             # cross-community edges
-find_cross_cutting_communities          # communities spanning ≥N domains
+get_bridges                             # cross-cluster edges
+find_cross_cutting_clusters             # clusters spanning ≥N domains
 load_source                             # a node's underlying content — code from the
                                         #  repo checkout, KnowledgeDoc bodies verbatim
                                         #  from the corpus (with title/path/status)
@@ -107,9 +107,9 @@ from opentrace_agent.retrieval import (
     provenance,
     grep,
     god_nodes,
-    cross_community_bridges,
+    cross_cluster_bridges,
     cross_domain_bridges,
-    find_communities_spanning_domains,
+    find_clusters_spanning_domains,
 )
 
 with GraphStore(".opentrace/index.db") as store:

--- a/plugins/claude-code/CLAUDE.md
+++ b/plugins/claude-code/CLAUDE.md
@@ -62,11 +62,11 @@ Knowledge-graph pipeline (all native — no external indexer dependency):
 |---|---|
 | `/build [path or url]` | Full pipeline — `opentraceai index` → `cluster` → `analyze` |
 | `/path A B` | Shortest path between two graph nodes, walked hop-by-hop |
-| `/cluster` | Re-run community detection (Leiden / Louvain) on the existing graph |
-| `/analyze` | God nodes, cross-community bridges, starter questions |
+| `/cluster` | Re-run clustering (Leiden / Louvain) on the existing graph |
+| `/analyze` | God nodes, cross-cluster bridges, starter questions |
 | `/export-obsidian` | Obsidian vault (one file per node, wikilinks for edges) |
 | `/export-graphml` | GraphML for Gephi / yEd / Cytoscape |
-| `/export-report` | Folder of linked markdown pages (`index.md`, communities, god nodes, bridges) |
+| `/export-report` | Folder of linked markdown pages (`index.md`, clusters, god nodes, bridges) |
 
 Cross-corpus merge is folded into `opentraceai import`. MCP serving is the
 existing `opentraceai mcp` — no separate `/mcp-server`.
@@ -106,18 +106,18 @@ All agents/skills use these tools from the `opentrace-oss` MCP server:
 | `grep` | Regex sweep over a repo checkout or a vault's whole document corpus — the exhaustive counterpart to ranked `search_graph`. Use it for "which documents discuss X"; there is no doc→topic edge to traverse |
 | `provenance` | Trust chain — a `KnowledgeDoc`'s own identity (sha256, filename, path, ingest time, + MIRRORS File twin when present); code → commit + line range |
 | `get_god_nodes` | Top-degree hubs — "what's connected to everything?". Degree-based, so it works on any indexed graph |
-| `get_communities` | Detected clusters with cohesion + member counts |
-| `get_bridges` | Edges spanning two different communities — where clusters touch |
-| `find_cross_cutting_communities` | Communities whose members span ≥`min_domains` domains (code / doc) |
+| `get_clusters` | Detected clusters with cohesion + member counts |
+| `get_bridges` | Edges spanning two different clusters — where clusters touch |
+| `find_cross_cutting_clusters` | Clusters whose members span ≥`min_domains` domains (code / doc) |
 
 The last three need `opentraceai cluster` to have been run — they return an
 empty list on an unclustered graph rather than erroring, so an empty result
 means "not clustered yet" at least as often as it means "none exist". You
-cannot tell the two apart from `get_stats`: a community is a `community`
+cannot tell the two apart from `get_stats`: a cluster is a `cluster`
 property on the nodes it partitions, not a node type, so clustering leaves the
-type census unchanged. Call `get_communities` — an empty list there is the
+type census unchanged. Call `get_clusters` — an empty list there is the
 "not clustered yet" signal.
-`find_cross_cutting_communities` additionally needs both domains present: on a
+`find_cross_cutting_clusters` additionally needs both domains present: on a
 code-only graph (no vault ingested) nothing can span two domains, so it is
 always empty there.
 

--- a/plugins/claude-code/agents/graph-guide.md
+++ b/plugins/claude-code/agents/graph-guide.md
@@ -25,8 +25,8 @@ answer, and propose the next stop.
 - The OpenTrace MCP — read through `search_graph`, `get_node`, `traverse_graph`,
   `list_nodes`, and `get_stats`. This is your primary lens; the database is
   there but you should rarely need to touch it directly.
-- `/analyze` output — once communities exist, this surfaces god nodes,
-  cross-community bridges, and seed questions.
+- `/analyze` output — once clusters exist, this surfaces god nodes,
+  cross-cluster bridges, and seed questions.
 
 ## Loop
 
@@ -35,7 +35,7 @@ answer, and propose the next stop.
 
 2. **Pick a thread.** Follow the user's explicit question if they have one.
    Otherwise reach for whichever seed question touches the most different
-   communities, or hangs off the highest-degree bridge — those reveal the most
+   clusters, or hangs off the highest-degree bridge — those reveal the most
    structure per hop.
 
 3. **Answer from the graph.** Run `/interrogate`, `/path`, or `/explore` as
@@ -45,7 +45,7 @@ answer, and propose the next stop.
    the store, never from intuition.
 
 4. **Surface the structure**, not just the answer. Name the route:
-   "we crossed from the *Training* community to the *Evaluation* community via
+   "we crossed from the *Training* cluster to the *Evaluation* cluster via
    this bridge node — the only edge between them". That's the value the graph
    adds over plain search.
 

--- a/plugins/claude-code/commands/analyze.md
+++ b/plugins/claude-code/commands/analyze.md
@@ -1,23 +1,23 @@
 ---
 name: analyze
 description: |
-  Surface god nodes, cross-community bridges, and suggested questions.
+  Surface god nodes, cross-cluster bridges, and suggested questions.
   Use when: "/analyze", "what should I look at first?", "surface the highlights".
 allowed-tools: Bash
 ---
 
-Runs `opentraceai analyze`. Run `/cluster` first — bridges depend on community
+Runs `opentraceai analyze`. Run `/cluster` first — bridges depend on cluster
 membership.
 
 ## Arguments
 $ARGUMENTS
 
 - `--gods N` — top-N god nodes (default 10)
-- `--bridges N` — top-N cross-community bridges (default 10)
+- `--bridges N` — top-N cross-cluster bridges (default 10)
 - `--json` — structured JSON output
 
 ## Instructions
 
 1. Run `opentraceai analyze $ARGUMENTS`.
-2. Call out the one bridge whose two communities are otherwise least connected.
+2. Call out the one bridge whose two clusters are otherwise least connected.
 3. Offer the top suggested question for follow-up via `/interrogate` or `/path`.

--- a/plugins/claude-code/commands/build.md
+++ b/plugins/claude-code/commands/build.md
@@ -24,13 +24,13 @@ Recognised forms:
    `opentraceai fetch-and-index <url>`. Otherwise run `opentraceai index <path>`
    (default `.`).
 
-2. **Cluster.** Run `opentraceai cluster` to detect communities (Leiden with
-   Louvain fallback) and stamp each node's `community` property back onto the DB.
+2. **Cluster.** Run `opentraceai cluster` to detect clusters (Leiden with
+   Louvain fallback) and stamp each node's `cluster` property back onto the DB.
 
 3. **Analyze.** Run `opentraceai analyze --json` to get god nodes,
-   cross-community bridges, and suggested questions.
+   cross-cluster bridges, and suggested questions.
 
-4. **Report.** Show the top god nodes (degree-sorted) and any cross-community
+4. **Report.** Show the top god nodes (degree-sorted) and any cross-cluster
    bridges found. Offer the most interesting suggested question for follow-up.
 
 ## Optional follow-ups

--- a/plugins/claude-code/commands/cluster.md
+++ b/plugins/claude-code/commands/cluster.md
@@ -1,12 +1,12 @@
 ---
 name: cluster
 description: |
-  Re-run community detection on the existing index.
-  Use when: "re-cluster the graph", "/cluster", "split communities again after re-indexing".
+  Re-run clustering on the existing index.
+  Use when: "re-cluster the graph", "/cluster", "split clusters again after re-indexing".
 allowed-tools: Bash
 ---
 
-Runs `opentraceai cluster`. Stamps each node's `community` property, so it adds
+Runs `opentraceai cluster`. Stamps each node's `cluster` property, so it adds
 no nodes or edges and the graph's counts are unchanged. Idempotent — every
 assignment is rewritten on each run. Leiden via graspologic with a deterministic
 Louvain fallback on Python ≥3.13.
@@ -20,6 +20,6 @@ $ARGUMENTS
 ## Instructions
 
 1. Run `opentraceai cluster $ARGUMENTS`.
-2. Show the resulting community count, god-community count, largest community,
+2. Show the resulting cluster count, god-cluster count, largest cluster,
    and mean cohesion.
 3. Suggest `/analyze` to surface the highlights.

--- a/plugins/claude-code/commands/export-graphml.md
+++ b/plugins/claude-code/commands/export-graphml.md
@@ -7,7 +7,7 @@ allowed-tools: Bash
 ---
 
 Runs `opentraceai export-graph graphml -o <output>`. Carries each node's
-community id as a GraphML attribute (so Gephi can colour by it)
+cluster id as a GraphML attribute (so Gephi can colour by it)
 so downstream tools can render cluster structure alongside the source graph.
 
 ## Arguments

--- a/plugins/claude-code/commands/export-obsidian.md
+++ b/plugins/claude-code/commands/export-obsidian.md
@@ -1,7 +1,7 @@
 ---
 name: export-obsidian
 description: |
-  Export an Obsidian-compatible vault — one .md per node, folder per community.
+  Export an Obsidian-compatible vault — one .md per node, folder per cluster.
   Use when: "/export-obsidian", "open this graph in Obsidian".
 allowed-tools: Bash
 ---

--- a/plugins/claude-code/commands/export-report.md
+++ b/plugins/claude-code/commands/export-report.md
@@ -1,7 +1,7 @@
 ---
 name: export-report
 description: |
-  Export a folder of linked markdown pages — an index dashboard (provenance header, Mermaid community map), per-community and per-god-node pages, and a bridges page.
+  Export a folder of linked markdown pages — an index dashboard (provenance header, Mermaid cluster map), per-cluster and per-god-node pages, and a bridges page.
   Use when: "/export-report", "generate docs from the graph".
 allowed-tools: Bash
 ---
@@ -9,8 +9,8 @@ allowed-tools: Bash
 Runs `opentraceai export-graph report -o <dir>`. Deterministic projection over
 the stored graph — no LLM calls at export time.
 
-Run `/cluster` first: community and god-node pages are projected from stored
-`Community` nodes, so without them the export is only `index.md` and
+Run `/cluster` first: cluster and god-node pages are projected from the stored
+cluster assignments, so without them the export is only `index.md` and
 `bridges.md`.
 
 ## Arguments

--- a/plugins/claude-code/skills/graph/SKILL.md
+++ b/plugins/claude-code/skills/graph/SKILL.md
@@ -2,17 +2,17 @@
 name: graph
 description: |
   Run the full OpenTrace knowledge-graph pipeline over a folder or repo — index,
-  community detection, highlight surfacing, and the markdown / graphml / Obsidian
+  clustering, highlight surfacing, and the markdown / graphml / Obsidian
   exporters. Use this skill when the user wants more than the bare structural
-  index: when they ask for communities, highlights, or a navigable artifact to
+  index: when they ask for clusters, highlights, or a navigable artifact to
   hand to another tool.
 
   Triggers on:
   - "build the knowledge graph", "make a graph of this folder", "graph this"
   - "what is this codebase about", "give me a map of this project", "what's connected
     to what"
-  - "find the communities", "cluster the graph", "what are the architectural hubs?"
-  - any time a user mentions community detection, god nodes, or bridges
+  - "find the clusters", "cluster the graph", "what are the architectural hubs?"
+  - any time a user mentions clustering, god nodes, or bridges
   - when `.opentrace/index.db` is already present in the working directory,
     an indexed graph exists — prefer answering from it over re-deriving
     answers from raw files
@@ -34,7 +34,7 @@ Match the user's intent to one of the commands below. When in doubt, default to
 |---|---|
 | Build the graph from scratch on a folder or GitHub URL | `/build [path or url]` |
 | Index only (no clustering / analysis) | `/index [path]` |
-| Re-run community detection | `/cluster` |
+| Re-run clustering | `/cluster` |
 | Surface god nodes, bridges, suggested questions | `/analyze` |
 | Quick exploration of a named component | `/explore <name>` |
 | Read-only Q&A over the graph | `/interrogate "<question>"` |

--- a/plugins/opencode/src/graph-client.ts
+++ b/plugins/opencode/src/graph-client.ts
@@ -803,7 +803,7 @@ export class GraphClient {
   }
 
   /**
-   * Run community detection. Uses the INDEX timeout, not the default one:
+   * Run clustering. Uses the INDEX timeout, not the default one:
    * Leiden/Louvain over a large graph runs for minutes, and the default
    * `run()` budget is 10s — a build tool that shells out through `run()` gets
    * its subprocess killed and returns partial stderr on any real repo.

--- a/plugins/opencode/src/tools/graph-analyze.ts
+++ b/plugins/opencode/src/tools/graph-analyze.ts
@@ -18,12 +18,12 @@ import { tool } from "@opencode-ai/plugin"
 import type { GraphClient } from "../graph-client.js"
 
 /**
- * Graph hotspots — god nodes and cross-community bridges. Wraps
+ * Graph hotspots — god nodes and cross-cluster bridges. Wraps
  * `opentraceai analyze --json`.
  */
 export function createGraphAnalyzeTool(client: GraphClient) {
   return tool({
-    description: `Summarise the hotspots of the indexed knowledge graph: god nodes (the highest-degree hubs) and edges that cross community boundaries, plus starter questions for exploring them. A good first call on an unfamiliar graph. Run opentrace_graph_build first so community data exists.`,
+    description: `Summarise the hotspots of the indexed knowledge graph: god nodes (the highest-degree hubs) and edges that cross cluster boundaries, plus starter questions for exploring them. A good first call on an unfamiliar graph. Run opentrace_graph_build first so cluster data exists.`,
     args: {
       top: tool.schema.number().optional().describe("Items per category (default 10)."),
     },

--- a/plugins/opencode/src/tools/graph-build.ts
+++ b/plugins/opencode/src/tools/graph-build.ts
@@ -18,7 +18,7 @@ import { tool } from "@opencode-ai/plugin"
 import type { GraphClient } from "../graph-client.js"
 
 /**
- * Index a folder and run community detection over the result. Wraps
+ * Index a folder and run clustering over the result. Wraps
  * `opentraceai index` followed by `opentraceai cluster`.
  *
  * Both run on the INDEX timeout, not the default 10s command budget — see
@@ -26,7 +26,7 @@ import type { GraphClient } from "../graph-client.js"
  */
 export function createGraphBuildTool(client: GraphClient) {
   return tool({
-    description: `Index a folder into the OpenTrace knowledge graph and run community detection on the result, so analyze/report tooling has cluster data to work with. Use when the user says things like "index this repo", "build the graph", or "map this codebase".`,
+    description: `Index a folder into the OpenTrace knowledge graph and run clustering on the result, so analyze/report tooling has cluster data to work with. Use when the user says things like "index this repo", "build the graph", or "map this codebase".`,
     args: {
       path: tool.schema.string().optional().describe("Folder to index. Default '.'."),
     },

--- a/proto/opentrace/v1/code_graph.proto
+++ b/proto/opentrace/v1/code_graph.proto
@@ -184,17 +184,17 @@ message KnowledgeDocNode {
   string status           = 12;
 }
 
-// Community detection deliberately declares NO node or relationship type here.
-// `opentraceai cluster` derives communities from an already-indexed graph, so
+// Clustering deliberately declares NO node or relationship type here.
+// `opentraceai cluster` derives clusters from an already-indexed graph, so
 // its output is metadata about nodes rather than nodes in their own right: each
-// member carries its community id in the `community` property, and the
-// per-community summary (label, cohesion, god flag) is recomputed on read.
+// member carries its cluster id in the `cluster` property, and the
+// per-cluster summary (label, cohesion, god flag) is recomputed on read.
 //
 // A CommunityNode + MemberOfCommunityRel pair lived here briefly and was removed
 // before any release shipped them. Storing derived data as graph data meant every
-// consumer had to remember to exclude it: `stats` counted communities as indexed
+// consumer had to remember to exclude it: `stats` counted clusters as indexed
 // content, the viewer rendered them as ordinary nodes, and the degree ranking
-// scored a community as a top hub because it has one edge per member. Don't
+// scored a cluster as a top hub because it has one edge per member. Don't
 // reintroduce them — an attribute cannot be miscounted as a node.
 
 // IndexMetadataNode stores a single record of index provenance per database.

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -72,17 +72,18 @@ Heavy computation runs off the main thread:
 
 Workers use transferable objects (Float64Array) for zero-copy position handoff. **Copy the buffer before React state updates** — ownership transfers on `postMessage`.
 
-### Two things are called "communities" — this is the viewer's own
+### "Communities" here ≠ the agent's "clusters"
 
 `communityWorker` / `useCommunities` compute a Louvain partition **in the
 browser, over whatever nodes are currently loaded**, for node colour and layout
 grouping. It is view state: never persisted, recomputed (debounced) whenever the
 node set changes, and scoped to what is on screen rather than to the whole graph.
+This feature owns the name "communities" — keep it.
 
-The agent has a separate, unrelated partition: `opentraceai cluster` runs Leiden
-over the *entire indexed graph* and stores the result as a `community` property
-on each node, feeding `analyze`, the exporters, and the MCP tools. See
-`agent/src/opentrace_agent/store/CLAUDE.md`.
+The agent has a separate, unrelated partition with its own name: `opentraceai
+cluster` runs Leiden over the *entire indexed graph* and stores the result as a
+`cluster` property on each node, feeding `analyze`, the exporters, and the MCP
+tools. See `agent/src/opentrace_agent/store/CLAUDE.md`.
 
 Nothing connects the two. The viewer does **not** read the stored property, so
 its colours and the groupings `analyze` reports can disagree about the same
@@ -90,6 +91,8 @@ graph. Both are the same shape (node id → integer group id) and node
 `properties` already reach the viewer, so preferring the stored partition when
 present — with this worker as the fallback for browser-indexed and
 not-yet-clustered graphs — is a small change if that divergence ever matters.
+Beware the sampling caveat before doing it: the viewer loads a capped slice, so
+a whole-graph partition can fragment into many tiny on-screen groups.
 
 ## Key Interfaces
 


### PR DESCRIPTION
## Rename "communities" to "clusters" throughout agent
♻️ **Refactor** · 📝 **Docs** · 🔧 **Chore**

Renames the graph partitioning concept from "communities" to "clusters" across the entire agent stack — Python source, MCP tools, CLI output, JSON keys, export paths, docs, and plugin guidance. The UI's own ephemeral "communities" viewer feature (a separate, unrelated Louvain grouping) keeps its name and is now explicitly disambiguated in comments and docs.

Also adds a **legacy DB migration**: `clear_clusters()` now sweeps both `"cluster"` (new) and `"community"` (old) property keys, so a database written before this rename is cleaned up automatically on the next `opentraceai cluster` run.

### Complexity
🟢 Low · `43 files changed, 578 insertions(+), 545 deletions(-)`

Mechanically uniform across 42 files — identifier and string replacement throughout, one file rename (`communities.py` → `clusters.py`), and one small logic addition (the legacy key sweep). A reviewer familiar with the codebase can verify it by scanning for any missed old names rather than reasoning about behaviour.

### Tests
🧪 All affected tests updated in lockstep; one new test (`test_assign_clusters_drops_legacy_community_key`) covers the legacy DB migration path specifically.

### Note
⚠️ The MCP tool renames (`get_communities` → `get_clusters`, `find_cross_cutting_communities` → `find_cross_cutting_clusters`) are breaking changes for any agent or integration already calling those tools by name. Worth confirming whether any shipped integrations depend on the old names before merging.

### Review focus
Pay particular attention to the following areas:

- **Breaking external API surface** — the `--json` output of `opentraceai analyze` renames `cross_cutting_communities` → `cross_cutting_clusters`; MCP tools `get_communities` and `find_cross_cutting_communities` are renamed; bridge response fields (`source_community_id/name`, `target_community_id/name`) are renamed; the GraphML node attribute `community` → `cluster`; and the report output directory `communities/` → `clusters/`. Any external consumer of these will break silently.
- **Pre-rename databases** — until `opentraceai cluster` is re-run, `iter_analysis_graph()` reads `CLUSTER_PROPERTY = "cluster"` and finds nothing on nodes that carry the old `"community"` key, so `analyze`, `export`, and MCP tools return empty cluster data. This is not currently documented in user-facing upgrade notes.
<!-- opentrace:jid=01KZRPR2MDJ1NCR4TW2FVDDWMX|sha=fecfc897199d7e67a013e5470764d4a9863f40f8 -->